### PR TITLE
Json payload allow custom content type

### DIFF
--- a/src/Bootloader/Http/HttpBootloader.php
+++ b/src/Bootloader/Http/HttpBootloader.php
@@ -69,6 +69,11 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
                     'Content-Type' => 'text/html; charset=UTF-8'
                 ],
                 'middleware' => [],
+                'json'       => [
+                    'contentType' => [
+                        'application/json'
+                    ]
+                ]
             ]
         );
 
@@ -87,6 +92,16 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
     public function addMiddleware($middleware): void
     {
         $this->config->modify('http', new Append('middleware', null, $middleware));
+    }
+
+    /**
+     * Add new JSON content type.
+     *
+     * @param string $contentType
+     */
+    public function addJsonContentType(string $contentType): void
+    {
+        $this->config->modify('http', new Append('json.contentType', null, $contentType));
     }
 
     /**

--- a/src/Http/Middleware/JsonPayloadMiddleware.php
+++ b/src/Http/Middleware/JsonPayloadMiddleware.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Http\Config\HttpConfig;
 use Spiral\Http\Exception\ClientException;
 
 /**
@@ -22,6 +23,17 @@ use Spiral\Http\Exception\ClientException;
  */
 final class JsonPayloadMiddleware implements MiddlewareInterface
 {
+    /** @var HttpConfig HttpConfig */
+    protected $httpConfig;
+
+    /**
+     * @param HttpConfig $httpConfig
+     */
+    public function __construct(HttpConfig $httpConfig)
+    {
+        $this->httpConfig = $httpConfig;
+    }
+
     /**
      * @param ServerRequestInterface  $request
      * @param RequestHandlerInterface $handler
@@ -47,6 +59,12 @@ final class JsonPayloadMiddleware implements MiddlewareInterface
     {
         $contentType = $request->getHeaderLine('Content-Type');
 
-        return stripos($contentType, 'application/json') === 0;
+        foreach ($this->httpConfig->getJsonContentType() as $allowedType) {
+            if (stripos($contentType, $allowedType) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Framework/Http/ControllerTest.php
+++ b/tests/Framework/Http/ControllerTest.php
@@ -43,6 +43,17 @@ class ControllerTest extends HttpTest
         $this->assertSame('{"a":"b"}', (string)$response->getBody());
     }
 
+    public function testPayloadWithCustomJsonHeader(): void
+    {
+        $factory = new StreamFactory();
+
+        $response = $this->http->handle($this->request('/payload', 'POST', [], [
+            'Content-Type' => 'application/vnd.api+json;charset=UTF-8;'
+        ], [])->withBody($factory->createStream('{"a":"b"}')));
+
+        $this->assertSame('{"a":"b"}', (string)$response->getBody());
+    }
+
     public function testPayloadActionBad(): void
     {
         $factory = new StreamFactory();

--- a/tests/app/src/Bootloader/AppBootloader.php
+++ b/tests/app/src/Bootloader/AppBootloader.php
@@ -13,8 +13,6 @@ namespace Spiral\App\Bootloader;
 
 use Spiral\App\Checker\MyChecker;
 use Spiral\App\Condition\MyCondition;
-use Spiral\App\Controller\AuthController;
-use Spiral\App\Controller\TestController;
 use Spiral\App\User\UserRepository;
 use Spiral\App\ViewEngine\TestEngine;
 use Spiral\Bootloader\DomainBootloader;
@@ -24,9 +22,6 @@ use Spiral\Core\CoreInterface;
 use Spiral\Domain\CycleInterceptor;
 use Spiral\Domain\FilterInterceptor;
 use Spiral\Domain\GuardInterceptor;
-use Spiral\Router\Route;
-use Spiral\Router\RouterInterface;
-use Spiral\Router\Target\Controller;
 use Spiral\Security\PermissionsInterface;
 
 class AppBootloader extends DomainBootloader
@@ -43,7 +38,6 @@ class AppBootloader extends DomainBootloader
 
     public function boot(
         \Spiral\Bootloader\Auth\AuthBootloader $authBootloader,
-        RouterInterface $router,
         PermissionsInterface $rbac,
         ViewsBootloader $views,
         ValidationBootloader $validation
@@ -55,18 +49,6 @@ class AppBootloader extends DomainBootloader
 
         $rbac->addRole('demo');
         $rbac->associate('demo', 'demo.*');
-
-        $route = new Route(
-            '/<action>[/<name>]',
-            new Controller(TestController::class)
-        );
-
-        $router->setDefault($route->withDefaults(['name' => 'Dave']));
-
-        $router->setRoute(
-            'auth',
-            new Route('/auth/<action>', new Controller(AuthController::class))
-        );
 
         $views->addDirectory('custom', __DIR__ . '/../../views/custom/');
         $views->addEngine(TestEngine::class);

--- a/tests/app/src/Bootloader/AppBootloader.php
+++ b/tests/app/src/Bootloader/AppBootloader.php
@@ -16,6 +16,7 @@ use Spiral\App\Condition\MyCondition;
 use Spiral\App\User\UserRepository;
 use Spiral\App\ViewEngine\TestEngine;
 use Spiral\Bootloader\DomainBootloader;
+use Spiral\Bootloader\Http\HttpBootloader;
 use Spiral\Bootloader\Security\ValidationBootloader;
 use Spiral\Bootloader\Views\ViewsBootloader;
 use Spiral\Core\CoreInterface;
@@ -40,7 +41,8 @@ class AppBootloader extends DomainBootloader
         \Spiral\Bootloader\Auth\AuthBootloader $authBootloader,
         PermissionsInterface $rbac,
         ViewsBootloader $views,
-        ValidationBootloader $validation
+        ValidationBootloader $validation,
+        HttpBootloader $http
     ): void {
         $authBootloader->addActorProvider(UserRepository::class);
 
@@ -56,5 +58,7 @@ class AppBootloader extends DomainBootloader
         $validation->addAlias('aliased', 'notEmpty');
         $validation->addChecker('my', MyChecker::class);
         $validation->addCondition('cond', MyCondition::class);
+
+        $http->addJsonContentType('application/vnd.api+json');
     }
 }

--- a/tests/app/src/Bootloader/RoutesBootloader.php
+++ b/tests/app/src/Bootloader/RoutesBootloader.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\App\Bootloader;
+
+use Spiral\App\Controller\AuthController;
+use Spiral\App\Controller\TestController;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Router\Route;
+use Spiral\Router\RouterInterface;
+use Spiral\Router\Target\Controller;
+
+class RoutesBootloader extends Bootloader
+{
+    public function boot(RouterInterface $router)
+    {
+        $route = new Route(
+            '/<action>[/<name>]',
+            new Controller(TestController::class)
+        );
+
+        $router->setDefault($route->withDefaults(['name' => 'Dave']));
+
+        $router->setRoute(
+            'auth',
+            new Route('/auth/<action>', new Controller(AuthController::class))
+        );
+    }
+}

--- a/tests/app/src/TestApp.php
+++ b/tests/app/src/TestApp.php
@@ -14,6 +14,7 @@ namespace Spiral\App;
 use Psr\Container\ContainerInterface;
 use Spiral\App\Bootloader\AppBootloader;
 use Spiral\App\Bootloader\AuthBootloader;
+use Spiral\App\Bootloader\RoutesBootloader;
 use Spiral\App\Bootloader\WSBootloader;
 use Spiral\Boot\BootloadManager;
 use Spiral\Boot\DirectoriesInterface;
@@ -83,6 +84,7 @@ class TestApp extends Kernel
 
     public const APP = [
         AppBootloader::class,
+        RoutesBootloader::class,
         WSBootloader::class
     ];
 


### PR DESCRIPTION
Add new configuration in http config, that will allow custom MIME types for JSON payloads.

For example if someone wants to use `text/json` as a MIME types for JSON payloads, he can simply extend HTTP config to allow such "content-type" to be parsed as JSON.

Inspired by willing to implement JSON:API with Spiral framework, but have some doubts about need of JsonPayloadMiddleware be a part of the framework code, as there is different libraries solving it already. Example:
https://github.com/middlewares/payload#jsonpayload

