### PR TITLE
Add content type to json payload middleware

### DIFF
--- a/src/Bootloader/Http/JsonPayloadsBootloader.php
+++ b/src/Bootloader/Http/JsonPayloadsBootloader.php
@@ -25,7 +25,7 @@ final class JsonPayloadsBootloader extends Bootloader
     ];
 
     /** @var ConfiguratorInterface */
-    protected $config;
+    private $config;
 
     /**
      * JsonPayloadsBootloader constructor.

--- a/src/Bootloader/Http/JsonPayloadsBootloader.php
+++ b/src/Bootloader/Http/JsonPayloadsBootloader.php
@@ -12,19 +12,54 @@ declare(strict_types=1);
 namespace Spiral\Bootloader\Http;
 
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\JsonPayloadConfig;
+use Spiral\Config\Patch\Append;
 use Spiral\Http\Middleware\JsonPayloadMiddleware;
 
 final class JsonPayloadsBootloader extends Bootloader
 {
+    /** @var array */
     protected const DEPENDENCIES = [
         HttpBootloader::class
     ];
+
+    /** @var ConfiguratorInterface */
+    protected $config;
+
+    /**
+     * JsonPayloadsBootloader constructor.
+     * @param ConfiguratorInterface $config
+     */
+    public function __construct(ConfiguratorInterface $config)
+    {
+        $this->config = $config;
+    }
 
     /**
      * @param HttpBootloader $http
      */
     public function boot(HttpBootloader $http): void
     {
+        $this->config->setDefaults(
+            JsonPayloadConfig::CONFIG,
+            [
+                'contentTypes' => [
+                    'application/json'
+                ]
+            ]
+        );
+
         $http->addMiddleware(JsonPayloadMiddleware::class);
+    }
+
+    /**
+     * Add custom MIME type to be parsed as JSON.
+     *
+     * @param string $contentType
+     */
+    public function addContentType(string $contentType): void
+    {
+        $this->config->modify(JsonPayloadConfig::CONFIG, new Append('contentTypes', null, $contentType));
     }
 }

--- a/src/Config/JsonPayloadConfig.php
+++ b/src/Config/JsonPayloadConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Pavel Z
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Config;
+
+use Spiral\Core\InjectableConfig;
+
+class JsonPayloadConfig extends InjectableConfig
+{
+    public const CONFIG = 'json-payload';
+
+    /** @var array */
+    protected $config = [
+        'contentTypes' => [
+            'application/json'
+        ]
+    ];
+
+    /**
+     * @return mixed
+     */
+    public function getContentTypes()
+    {
+        return $this->config['contentTypes'];
+    }
+}

--- a/src/Config/JsonPayloadConfig.php
+++ b/src/Config/JsonPayloadConfig.php
@@ -27,7 +27,7 @@ class JsonPayloadConfig extends InjectableConfig
     /**
      * @return mixed
      */
-    public function getContentTypes()
+    public function getContentTypes(): array
     {
         return $this->config['contentTypes'];
     }

--- a/src/Http/Middleware/JsonPayloadMiddleware.php
+++ b/src/Http/Middleware/JsonPayloadMiddleware.php
@@ -24,7 +24,7 @@ use Spiral\Http\Exception\ClientException;
 final class JsonPayloadMiddleware implements MiddlewareInterface
 {
     /** @var JsonPayloadConfig */
-    protected $config;
+    private $config;
 
     /**
      * JsonPayloadMiddleware constructor.

--- a/src/Http/Middleware/JsonPayloadMiddleware.php
+++ b/src/Http/Middleware/JsonPayloadMiddleware.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Config\JsonPayloadConfig;
 use Spiral\Http\Exception\ClientException;
 
 /**
@@ -22,6 +23,19 @@ use Spiral\Http\Exception\ClientException;
  */
 final class JsonPayloadMiddleware implements MiddlewareInterface
 {
+    /** @var JsonPayloadConfig */
+    protected $config;
+
+    /**
+     * JsonPayloadMiddleware constructor.
+     *
+     * @param JsonPayloadConfig $config
+     */
+    public function __construct(JsonPayloadConfig $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param ServerRequestInterface  $request
      * @param RequestHandlerInterface $handler
@@ -47,6 +61,12 @@ final class JsonPayloadMiddleware implements MiddlewareInterface
     {
         $contentType = $request->getHeaderLine('Content-Type');
 
-        return stripos($contentType, 'application/json') === 0;
+        foreach ($this->config->getContentTypes() as $allowedType) {
+            if (stripos($contentType, $allowedType) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Framework/Http/ControllerTest.php
+++ b/tests/Framework/Http/ControllerTest.php
@@ -43,6 +43,17 @@ class ControllerTest extends HttpTest
         $this->assertSame('{"a":"b"}', (string)$response->getBody());
     }
 
+    public function testPayloadWithCustomJsonHeader(): void
+    {
+        $factory = new StreamFactory();
+
+        $response = $this->http->handle($this->request('/payload', 'POST', [], [
+            'Content-Type' => 'application/vnd.api+json;charset=UTF-8;'
+        ], [])->withBody($factory->createStream('{"a":"b"}')));
+
+        $this->assertSame('{"a":"b"}', (string)$response->getBody());
+    }
+
     public function testPayloadActionBad(): void
     {
         $factory = new StreamFactory();

--- a/tests/app/src/Bootloader/AppBootloader.php
+++ b/tests/app/src/Bootloader/AppBootloader.php
@@ -18,6 +18,7 @@ use Spiral\App\Controller\TestController;
 use Spiral\App\User\UserRepository;
 use Spiral\App\ViewEngine\TestEngine;
 use Spiral\Bootloader\DomainBootloader;
+use Spiral\Bootloader\Http\JsonPayloadsBootloader;
 use Spiral\Bootloader\Security\ValidationBootloader;
 use Spiral\Bootloader\Views\ViewsBootloader;
 use Spiral\Core\CoreInterface;
@@ -46,7 +47,8 @@ class AppBootloader extends DomainBootloader
         RouterInterface $router,
         PermissionsInterface $rbac,
         ViewsBootloader $views,
-        ValidationBootloader $validation
+        ValidationBootloader $validation,
+        JsonPayloadsBootloader $json
     ): void {
         $authBootloader->addActorProvider(UserRepository::class);
 
@@ -74,5 +76,7 @@ class AppBootloader extends DomainBootloader
         $validation->addAlias('aliased', 'notEmpty');
         $validation->addChecker('my', MyChecker::class);
         $validation->addCondition('cond', MyCondition::class);
+
+        $json->addContentType('application/vnd.api+json');
     }
 }


### PR DESCRIPTION
Created new configurations for json payload middleware.

For example if someone wants to use text/json as a MIME types for JSON payloads, he can extend config to allow such "content-type" to be parsed as JSON.

Inspired by willing to implement JSON:API with Spiral framework, but have some doubts about need of JsonPayloadMiddleware be a part of the framework code, as there is different libraries solving it already.

Example:
https://github.com/middlewares/payload#jsonpayload 