### PR TITLE
Fix GRPC Generate Path Argument

### DIFF
--- a/src/Command/GRPC/GenerateCommand.php
+++ b/src/Command/GRPC/GenerateCommand.php
@@ -80,7 +80,7 @@ final class GenerateCommand extends Command
      */
     protected function getPath(KernelInterface $kernel): string
     {
-        $path = $this->argument('namespace');
+        $path = $this->argument('path');
         if ($path !== 'auto') {
             return $path;
         }


### PR DESCRIPTION
Currently the GRPC Generate command doesn't actually use it's Path argument