### PR TITLE
Allow json requests with empty body

### DIFF
--- a/src/Http/Middleware/JsonPayloadMiddleware.php
+++ b/src/Http/Middleware/JsonPayloadMiddleware.php
@@ -44,9 +44,12 @@ final class JsonPayloadMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->isJsonPayload($request)) {
-            $request = $request->withParsedBody(json_decode((string)$request->getBody(), true));
-            if (json_last_error() !== 0) {
-                throw new ClientException(400, 'invalid json payload');
+            $body = (string)$request->getBody();
+            if ($body !== '') {
+                $request = $request->withParsedBody(json_decode($body, true));
+                if (json_last_error() !== 0) {
+                    throw new ClientException(400, 'invalid json payload');
+                }
             }
         }
 


### PR DESCRIPTION
This will loosen the restriction on sending requests with empty body.
The thinking behind this is that `Content-Type` header usually set codebase-wide and being rigorous in this regard doesn't seem to give any benefits.