### PR TITLE
add input mapper

### DIFF
--- a/src/DataGrid/src/GridFactory.php
+++ b/src/DataGrid/src/GridFactory.php
@@ -52,8 +52,12 @@ class GridFactory implements GridFactoryInterface
      * @param GridInterface|null        $view
      * @param InputMapperInterface|null $mapper
      */
-    public function __construct(Compiler $compiler, InputInterface $input = null, GridInterface $view = null, InputMapperInterface $mapper = null)
-    {
+    public function __construct(
+        Compiler $compiler,
+        InputInterface $input = null,
+        GridInterface $view = null,
+        InputMapperInterface $mapper = null
+    ) {
         $mapper = $mapper ?? new NullMapper();
 
         $this->compiler = $compiler;
@@ -61,6 +65,14 @@ class GridFactory implements GridFactoryInterface
         $this->defaults = new NullInput();
         $this->view = $view ?? new Grid();
         $this->mapper = $mapper->withInput($input);
+    }
+
+    public function withMapper(InputMapperInterface $mapper): GridFactoryInterface
+    {
+        $generator = clone $this;
+        $generator->mapper = $mapper->withInput($generator->input);
+
+        return $generator;
     }
 
     /**

--- a/src/DataGrid/src/GridFactory.php
+++ b/src/DataGrid/src/GridFactory.php
@@ -64,7 +64,7 @@ class GridFactory implements GridFactoryInterface
         $this->input = $input ?? new NullInput();
         $this->defaults = new NullInput();
         $this->view = $view ?? new Grid();
-        $this->mapper = $mapper->withInput($input);
+        $this->mapper = $mapper->withInput($this->input);
     }
 
     public function withMapper(InputMapperInterface $mapper): GridFactoryInterface

--- a/src/DataGrid/src/GridFactory.php
+++ b/src/DataGrid/src/GridFactory.php
@@ -42,17 +42,24 @@ class GridFactory implements GridFactoryInterface
     /** @var GridInterface */
     private $view;
 
+    /** @var InputMapperInterface */
+    private $mapper;
+
     /**
-     * @param Compiler            $compiler
-     * @param InputInterface|null $input
-     * @param GridInterface|null  $view
+     * @param Compiler                  $compiler
+     * @param InputInterface|null       $input
+     * @param GridInterface|null        $view
+     * @param InputMapperInterface|null $mapper
      */
-    public function __construct(Compiler $compiler, InputInterface $input = null, GridInterface $view = null)
+    public function __construct(Compiler $compiler, InputInterface $input = null, GridInterface $view = null, InputMapperInterface $mapper = null)
     {
+        $mapper = $mapper ?? new NullMapper();
+
         $this->compiler = $compiler;
         $this->input = $input ?? new NullInput();
         $this->defaults = new NullInput();
         $this->view = $view ?? new Grid();
+        $this->mapper = $mapper->withInput($input);
     }
 
     /**
@@ -65,6 +72,7 @@ class GridFactory implements GridFactoryInterface
     {
         $generator = clone $this;
         $generator->input = $input;
+        $generator->mapper = $generator->mapper->withInput($input);
 
         return $generator;
     }
@@ -173,8 +181,8 @@ class GridFactory implements GridFactoryInterface
      */
     private function getOption(string $option)
     {
-        if ($this->input->hasValue($option)) {
-            return $this->input->getValue($option);
+        if ($this->mapper->hasOption($option)) {
+            return $this->mapper->getOption($option);
         }
 
         return $this->defaults->getValue($option);

--- a/src/DataGrid/src/InputMapper.php
+++ b/src/DataGrid/src/InputMapper.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid;
+
+class InputMapper implements InputMapperInterface
+{
+    /** @var InputInterface */
+    private $input;
+
+    /** @var array */
+    private $mapping;
+
+    /** @var array */
+    private $mapped = [];
+
+    public function __construct(array $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    public function withInput(InputInterface $input): InputMapperInterface
+    {
+        $mapper = clone $this;
+        $mapper->input = $input;
+        $mapper->mapped = [];
+
+        return $mapper;
+    }
+
+    public function hasOption(string $option): bool
+    {
+        $mapped = $this->map($option);
+        if (!isset($mapped[$option])) {
+            return $this->input->hasValue($option);
+        }
+
+        $paths = (array)$mapped[$option][0];
+
+        $firstPath = array_shift($paths);
+        if (!$this->input->hasValue($firstPath)) {
+            return false;
+        }
+
+        if (empty($paths)) {
+            return true;
+        }
+
+        $data = $this->input->getValue($firstPath);
+        foreach ($paths as $path) {
+            if (!is_array($data)) {
+                return false;
+            }
+
+            if (!isset($data[$path])) {
+                return false;
+            }
+
+            $data = $data[$path];
+        }
+
+        return true;
+    }
+
+    public function getOption(string $option)
+    {
+        $mappedOptions = $this->map($option);
+
+        if (!isset($mappedOptions)) {
+            return $this->input->getValue($option);
+        }
+
+        $output = [];
+        foreach ($mappedOptions as $mappedOption) {
+            $paths = (array)$mappedOption[0];
+
+            $firstPath = array_shift($paths);
+            if (!$this->input->getValue($firstPath)) {
+                return false;
+            }
+
+            $data = $this->input->getValue($firstPath);
+            $unmappedData = $data;
+            if (!empty($paths) && is_array($unmappedData)) {
+                dump(compact('unmappedData','paths'));
+                unset($unmappedData[$paths[0]]);
+                dump(compact('unmappedData'));
+            }
+
+            foreach ($paths as $path) {
+                $data = $data[$path];
+            }
+
+            $result = $data;
+            foreach ((array)$mappedOption[1] as $path) {
+                $result = [$path => $result];
+            }
+            $output[] = $result;
+            if (is_array($unmappedData)) {
+                $output[] = $unmappedData;
+            }
+        }
+
+        return !empty($output) ? array_merge(...$output) : [];
+    }
+
+    protected function map(string $option): array
+    {
+        if (isset($this->mapped[$option])) {
+            return $this->mapped[$option];
+        }
+
+        $result = [];
+        foreach ($this->mapping as $from => $to) {
+            $to = explode('.', $to);
+            if (isset($to[0]) && $to[0] === $option) {
+                array_shift($to);
+                $result[] = [explode('.', $from), array_reverse($to)];
+            }
+        }
+
+        $this->mapped[$option] = $result;
+        return $result;
+    }
+}

--- a/src/DataGrid/src/InputMapper.php
+++ b/src/DataGrid/src/InputMapper.php
@@ -25,7 +25,7 @@ class InputMapper implements InputMapperInterface
         $mapper = clone $this;
         $mapper->input = $input;
         $mapper->mapped = [];
-        $mapper->mapAll();
+        $mapper->map();
 
         return $mapper;
     }
@@ -90,7 +90,7 @@ class InputMapper implements InputMapperInterface
         return !empty($output) ? array_merge(...$output) : [];
     }
 
-    protected function mapAll(): void
+    protected function map(): void
     {
         foreach ($this->mapping as $from => $to) {
             $to = explode('.', $to);

--- a/src/DataGrid/src/InputMapper.php
+++ b/src/DataGrid/src/InputMapper.php
@@ -48,14 +48,10 @@ class InputMapper implements InputMapperInterface
         return false;
     }
 
-    /**
-     * @param string $option
-     * @return array|mixed
-     */
-    public function getOption(string $option)
+    public function getOption(string $option, $default = null)
     {
         if (!isset($this->mapped[$option])) {
-            return $this->input->getValue($option);
+            return $this->input->getValue($option, $default);
         }
 
         $mappedOptions = $this->mapped[$option];

--- a/src/DataGrid/src/InputMapperInterface.php
+++ b/src/DataGrid/src/InputMapperInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid;
+
+interface InputMapperInterface
+{
+    public function withInput(InputInterface $input): InputMapperInterface;
+
+    public function hasOption(string $option): bool;
+
+    public function getOption(string $option);
+}

--- a/src/DataGrid/src/InputMapperInterface.php
+++ b/src/DataGrid/src/InputMapperInterface.php
@@ -10,5 +10,5 @@ interface InputMapperInterface
 
     public function hasOption(string $option): bool;
 
-    public function getOption(string $option);
+    public function getOption(string $option, $default = null);
 }

--- a/src/DataGrid/src/NullMapper.php
+++ b/src/DataGrid/src/NullMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid;
+
+class NullMapper implements InputMapperInterface
+{
+    /** @var InputInterface */
+    private $input;
+
+    public function withInput(InputInterface $input): InputMapperInterface
+    {
+        $mapper = clone $this;
+        $mapper->input = $input;
+
+        return $mapper;
+    }
+
+    public function hasOption(string $option): bool
+    {
+        return $this->input->hasValue($option);
+    }
+
+    public function getOption(string $option)
+    {
+        return $this->input->getValue($option);
+    }
+}

--- a/src/DataGrid/src/NullMapper.php
+++ b/src/DataGrid/src/NullMapper.php
@@ -22,8 +22,8 @@ class NullMapper implements InputMapperInterface
         return $this->input->hasValue($option);
     }
 
-    public function getOption(string $option)
+    public function getOption(string $option, $default = null)
     {
-        return $this->input->getValue($option);
+        return $this->input->getValue($option, $default);
     }
 }

--- a/src/DataGrid/tests/MapperTest.php
+++ b/src/DataGrid/tests/MapperTest.php
@@ -15,22 +15,18 @@ class MapperTest extends TestCase
         $mapper = new InputMapper(
             [
                 'sortByNewest'         => 'sort.newest',
-                'sortMissed'           => 'sort.missed',
                 'sort.as.super.nested' => 'sort.as.nested',
                 'sort.byOldestSort'    => 'sort.by.oldest',
+                'sortMissed'           => 'sort.missed.value', //not in the input, should be ignored
             ]
         );
         $mapper = $mapper->withInput(
             new ArrayInput(
                 [
-                    'sortByNewest' => true,
+                    'sortByNewest' => 'true',
                     'sort'         => [
-                        'as'           => [
-                            'super' => [
-                                'nested' => 'desc'
-                            ]
-                        ],
-                        'byOldestSort' => false,
+                        'as'           => ['super' => ['nested' => 'desc']],
+                        'byOldestSort' => 'false',
                     ]
                 ]
             )
@@ -40,9 +36,9 @@ class MapperTest extends TestCase
         $this->assertFalse($mapper->hasOption('filter'));
         $this->assertSame(
             [
-                'newest' => true,
+                'newest' => 'true',
                 'as'     => ['nested' => 'desc'],
-                'by'     => ['oldest' => false],
+                'by'     => ['oldest' => 'false'],
             ],
             $mapper->getOption('sort')
         );
@@ -59,17 +55,15 @@ class MapperTest extends TestCase
         $mapper = $mapper->withInput(
             new ArrayInput(
                 [
-                    'sortByNewest' => true,
+                    'sortByNewest' => 'true',
                     'sort'         => [
-                        'as'           => [
-                            'super' => [
-                                'nested' => 'desc'
-                            ]
-                        ],
+                        'as'           => ['super' => ['nested' => 'desc']],
+                        //not in the mapping, should be ignored because sort section is partially mapped
                         'byOldestSort' => false,
                     ],
                     'filter'       => [
-                        'byOldestSort' => false
+                        //not in the mapping, should be added because filter section is not mapped at all
+                        'byOldestFilter' => false,
                     ]
                 ]
             )
@@ -79,21 +73,18 @@ class MapperTest extends TestCase
         $this->assertTrue($mapper->hasOption('filter'));
         $this->assertSame(
             [
-                'newest'       => true,
-                'as'           => ['nested' => 'desc'],
-                'byOldestSort' => false,
+                'newest' => 'true',
+                'as'     => ['nested' => 'desc'],
             ],
             $mapper->getOption('sort')
         );
         $this->assertSame(
-            [
-                'byOldestSort' => false,
-            ],
+            ['byOldestFilter' => false,],
             $mapper->getOption('filter')
         );
     }
 
-    public function testMapperWithExtraValues(): void
+    public function testMapperCrossOptions(): void
     {
         $mapper = new InputMapper(
             [
@@ -107,11 +98,7 @@ class MapperTest extends TestCase
                 [
                     'sortByNewest' => true,
                     'sort'         => [
-                        'as'           => [
-                            'super' => [
-                                'nested' => 'desc'
-                            ]
-                        ],
+                        'as'           => ['super' => ['nested' => 'desc']],
                         'byOldestSort' => false,
                     ],
                     'filter'       => [
@@ -126,14 +113,12 @@ class MapperTest extends TestCase
         $this->assertSame(
             [
                 'newest' => true,
-                'as'     => ['nested' => 'desc']
+                'as'     => ['nested' => 'desc'],
             ],
             $mapper->getOption('sort')
         );
         $this->assertSame(
-            [
-                'by' => ['oldest' => false]
-            ],
+            ['by' => ['oldest' => false],],
             $mapper->getOption('filter')
         );
     }

--- a/src/DataGrid/tests/MapperTest.php
+++ b/src/DataGrid/tests/MapperTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\DataGrid;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\DataGrid\Input\ArrayInput;
+use Spiral\DataGrid\InputMapper;
+
+class MapperTest extends TestCase
+{
+    public function testMapper(): void
+    {
+        $mapper = new InputMapper(
+            [
+                'sortByNewest'         => 'sort.newest',
+                'sortMissed'           => 'sort.missed',
+                'sort.as.super.nested' => 'sort.as.nested',
+                'sort.byOldestSort'    => 'sort.by.oldest',
+            ]
+        );
+        $mapper = $mapper->withInput(
+            new ArrayInput(
+                [
+                    'sortByNewest' => true,
+                    'sort'         => [
+                        'as'           => [
+                            'super' => [
+                                'nested' => 'desc'
+                            ]
+                        ],
+                        'byOldestSort' => false,
+                    ]
+                ]
+            )
+        );
+
+        $this->assertTrue($mapper->hasOption('sort'));
+        $this->assertFalse($mapper->hasOption('filter'));
+        $this->assertSame(
+            [
+                'newest' => true,
+                'as'     => ['nested' => 'desc'],
+                'by'     => ['oldest' => false],
+            ],
+            $mapper->getOption('sort')
+        );
+    }
+
+    public function testWithoutMapping(): void
+    {
+        $mapper = new InputMapper(
+            [
+                'sortByNewest'         => 'sort.newest',
+                'sort.as.super.nested' => 'sort.as.nested',
+            ]
+        );
+        $mapper = $mapper->withInput(
+            new ArrayInput(
+                [
+                    'sortByNewest' => true,
+                    'sort'         => [
+                        'as'           => [
+                            'super' => [
+                                'nested' => 'desc'
+                            ]
+                        ],
+                        'byOldestSort' => false,
+                    ],
+                    'filter'       => [
+                        'byOldestSort' => false
+                    ]
+                ]
+            )
+        );
+
+        $this->assertTrue($mapper->hasOption('sort'));
+        $this->assertTrue($mapper->hasOption('filter'));
+        $this->assertSame(
+            [
+                'newest'       => true,
+                'as'           => ['nested' => 'desc'],
+                'byOldestSort' => false,
+            ],
+            $mapper->getOption('sort')
+        );
+        $this->assertSame(
+            [
+                'byOldestSort' => false,
+            ],
+            $mapper->getOption('filter')
+        );
+    }
+
+    public function testMapperWithExtraValues(): void
+    {
+        $mapper = new InputMapper(
+            [
+                'sortByNewest'         => 'sort.newest',
+                'sort.as.super.nested' => 'sort.as.nested',
+                'sort.byOldestSort'    => 'filter.by.oldest',
+            ]
+        );
+        $mapper = $mapper->withInput(
+            new ArrayInput(
+                [
+                    'sortByNewest' => true,
+                    'sort'         => [
+                        'as'           => [
+                            'super' => [
+                                'nested' => 'desc'
+                            ]
+                        ],
+                        'byOldestSort' => false,
+                    ],
+                    'filter'       => [
+                        'byOldestSort' => false
+                    ]
+                ]
+            )
+        );
+
+        $this->assertTrue($mapper->hasOption('sort'));
+        $this->assertTrue($mapper->hasOption('filter'));
+        $this->assertSame(
+            [
+                'newest' => true,
+                'as'     => ['nested' => 'desc']
+            ],
+            $mapper->getOption('sort')
+        );
+        $this->assertSame(
+            [
+                'by' => ['oldest' => false]
+            ],
+            $mapper->getOption('filter')
+        );
+    }
+}

--- a/src/DataGridBridge/src/Annotation/DataGrid.php
+++ b/src/DataGridBridge/src/Annotation/DataGrid.php
@@ -58,4 +58,20 @@ class DataGrid
      * @var string
      */
     public $factory;
+
+    /**
+     * Custom input mapper
+     *
+     * @Attribute(name="mapper", type="string")
+     * @var string
+     */
+    public $mapper;
+
+    /**
+     * Custom input mapping, default to GridSchema->getMapping() if such method exists.
+     *
+     * @Attribute(name="mapping", type="array")
+     * @var array
+     */
+    public $mapping = [];
 }


### PR DESCRIPTION
Now custom input can be mapped into a traditional structure using `InputMapperInterface`. Provided a `InputMapper` that can to mapping from the box.
- if at least one section param is mapped, no original values will be taken, you need to map all of them explicitly even if the mapping is 1-1
- if no mapping for the section is provided, it mapper will use the original values

see tests for working examples

- [ ] add integration test for mapper (+using an interceptor)
