### PR TITLE
Datagrid/fix inarray accessor edge case

### DIFF
--- a/src/DataGrid/src/Specification/Filter/InArray.php
+++ b/src/DataGrid/src/Specification/Filter/InArray.php
@@ -15,13 +15,16 @@ namespace Spiral\DataGrid\Specification\Filter;
 use Spiral\DataGrid\Specification\Value\ArrayValue;
 use Spiral\DataGrid\Specification\ValueInterface;
 
-final class InArray extends Expression
+class InArray extends Expression
 {
     /**
      * @inheritDoc
      */
-    public function __construct(string $expression, $value)
+    public function __construct(string $expression, $value, bool $wrapInArray = true)
     {
-        parent::__construct($expression, $value instanceof ValueInterface ? new ArrayValue($value) : $value);
+        parent::__construct(
+            $expression,
+            $value instanceof ValueInterface && $wrapInArray ? new ArrayValue($value) : $value
+        );
     }
 }

--- a/src/DataGrid/src/Specification/Filter/NotInArray.php
+++ b/src/DataGrid/src/Specification/Filter/NotInArray.php
@@ -15,13 +15,16 @@ namespace Spiral\DataGrid\Specification\Filter;
 use Spiral\DataGrid\Specification\Value\ArrayValue;
 use Spiral\DataGrid\Specification\ValueInterface;
 
-final class NotInArray extends Expression
+class NotInArray extends Expression
 {
     /**
      * @inheritDoc
      */
-    public function __construct(string $expression, $value)
+    public function __construct(string $expression, $value, bool $wrapInArray = true)
     {
-        parent::__construct($expression, $value instanceof ValueInterface ? new ArrayValue($value) : $value);
+        parent::__construct(
+            $expression,
+            $value instanceof ValueInterface && $wrapInArray ? new ArrayValue($value) : $value
+        );
     }
 }

--- a/src/DataGrid/src/Specification/Value/Accessor/Split.php
+++ b/src/DataGrid/src/Specification/Value/Accessor/Split.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid\Specification\Value\Accessor;
+
+use Spiral\DataGrid\Specification\ValueInterface;
+
+class Split extends Accessor
+{
+    /** @var string */
+    private $char;
+
+    public function __construct(ValueInterface $next, string $char = ',')
+    {
+        parent::__construct($next);
+        $this->char = $char;
+    }
+
+    protected function acceptsCurrent($value): bool
+    {
+        return is_string($value);
+    }
+
+    protected function convertCurrent($value)
+    {
+        return explode($this->char, $value);
+    }
+}

--- a/src/DataGrid/tests/Specification/InArrayTest.php
+++ b/src/DataGrid/tests/Specification/InArrayTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\DataGrid\Specification;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\DataGrid\Specification\Filter\InArray;
+use Spiral\DataGrid\Specification\Filter\NotInArray;
 use Spiral\DataGrid\Specification\Value\Accessor\Split;
 use Spiral\DataGrid\Specification\Value\ArrayValue;
 use Spiral\DataGrid\Specification\Value\IntValue;
@@ -21,11 +22,62 @@ class InArrayTest extends TestCase
         $this->assertTrue($split->accepts($str));
         $this->assertSame([1, 2, 3], $split->convert($str));
 
+        //failure
         $inArray = new InArray('field', $split);
         $this->assertNotInstanceOf(SpecificationInterface::class, $inArray->withValue($str));
 
+        $notInArray = new NotInArray('field', $split);
+        $this->assertNotInstanceOf(SpecificationInterface::class, $notInArray->withValue($str));
+
+        //success
         $inArray = new InArray('field', $split, false);
         $this->assertInstanceOf(SpecificationInterface::class, $inArray->withValue($str));
         $this->assertSame([1, 2, 3], $inArray->withValue($str)->getValue());
+
+        $notInArray = new NotInArray('field', $split, false);
+        $this->assertInstanceOf(SpecificationInterface::class, $notInArray->withValue($str));
+        $this->assertSame([1, 2, 3], $notInArray->withValue($str)->getValue());
+    }
+
+    public function testWithoutSplit(): void
+    {
+        $arr = ['1', 2];
+        $value = new IntValue();
+
+        $inArray = new InArray('field', $value);
+        $this->assertInstanceOf(SpecificationInterface::class, $inArray->withValue($arr));
+        $this->assertSame([1, 2], $inArray->withValue($arr)->getValue());
+
+        $notInArray = new NotInArray('field', $value);
+        $this->assertInstanceOf(SpecificationInterface::class, $notInArray->withValue($arr));
+        $this->assertSame([1, 2], $notInArray->withValue($arr)->getValue());
+
+        $inArray = new InArray('field', $value, false);
+        $this->assertNotInstanceOf(SpecificationInterface::class, $inArray->withValue($arr));
+
+        $notInArray = new NotInArray('field', $value, false);
+        $this->assertNotInstanceOf(SpecificationInterface::class, $notInArray->withValue($arr));
+    }
+
+    public function testWithOwnWrapping(): void
+    {
+        $arr = ['1', 2];
+        $value = new ArrayValue(new IntValue());
+
+        $inArray = new InArray('field', $value);
+        $this->assertInstanceOf(SpecificationInterface::class, $inArray->withValue($arr));
+        $this->assertSame([1, 2], $inArray->withValue($arr)->getValue());
+
+        $notInArray = new NotInArray('field', $value);
+        $this->assertInstanceOf(SpecificationInterface::class, $notInArray->withValue($arr));
+        $this->assertSame([1, 2], $notInArray->withValue($arr)->getValue());
+
+        $inArray = new InArray('field', $value, false);
+        $this->assertInstanceOf(SpecificationInterface::class, $inArray->withValue($arr));
+        $this->assertSame([1, 2], $inArray->withValue($arr)->getValue());
+
+        $notInArray = new NotInArray('field', $value, false);
+        $this->assertInstanceOf(SpecificationInterface::class, $notInArray->withValue($arr));
+        $this->assertSame([1, 2], $notInArray->withValue($arr)->getValue());
     }
 }

--- a/src/DataGrid/tests/Specification/InArrayTest.php
+++ b/src/DataGrid/tests/Specification/InArrayTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\DataGrid\Specification;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\DataGrid\Specification\Filter\InArray;
+use Spiral\DataGrid\Specification\Value\Accessor\Split;
+use Spiral\DataGrid\Specification\Value\ArrayValue;
+use Spiral\DataGrid\Specification\Value\IntValue;
+use Spiral\DataGrid\SpecificationInterface;
+
+class InArrayTest extends TestCase
+{
+    public function testWithSplit(): void
+    {
+        $str = '1|2|3';
+
+        $split = new Split(new ArrayValue(new IntValue()), '|');
+        $this->assertTrue($split->accepts($str));
+        $this->assertSame([1, 2, 3], $split->convert($str));
+
+        $inArray = new InArray('field', $split);
+        $this->assertNotInstanceOf(SpecificationInterface::class, $inArray->withValue($str));
+
+        $inArray = new InArray('field', $split, false);
+        $this->assertInstanceOf(SpecificationInterface::class, $inArray->withValue($str));
+        $this->assertSame([1, 2, 3], $inArray->withValue($str)->getValue());
+    }
+}


### PR DESCRIPTION
Fix edge cases for inArray filters: allow removing autowrapping into `ArrayValue` when the base value is already wrapped with an accessor