### PR TITLE
Fix execution of EnvironmentCollector::populate outside of DispatcherInterface context

### DIFF
--- a/src/Framework/Debug/StateCollector/EnvironmentCollector.php
+++ b/src/Framework/Debug/StateCollector/EnvironmentCollector.php
@@ -43,7 +43,7 @@ final class EnvironmentCollector implements StateCollectorInterface
     {
         $state->setTag('php', phpversion());
 
-        if ($this->container->get(DispatcherInterface::class)) {
+        if ($this->container->has(DispatcherInterface::class)) {
             switch (get_class($this->container->get(DispatcherInterface::class))) {
                 case RrDispatcher::class:
                     $state->setTag('dispatcher', 'roadrunner');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

Executing `EnvironmentCollector::populate` outside of `DispatchInterface` context will result in exception on `if ($this->container->has(DispatcherInterface::class)) {` line.

Currently this exception is caught in `ErrorHandlerMiddleware::getOptional`.

AFAIK `container::get()` can not return non-object result which renders this `if` statement useless.