### PR TITLE
Respect `error_reporting` setting in ExceptionHandler::handleError

### DIFF
--- a/src/Boot/src/ExceptionHandler.php
+++ b/src/Boot/src/ExceptionHandler.php
@@ -75,6 +75,10 @@ final class ExceptionHandler
      */
     public static function handleError($code, $message, $filename = '', $line = 0): void
     {
+        if (!(error_reporting() & $code)) {
+            return;
+        }
+
         throw new \ErrorException($message, $code, 0, $filename, $line);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ I guess
| New feature?  | ❌
| Issues        | #377

For description see related issue #377. This change should not break anything, no new exceptions will be thrown after merge.