### PR TITLE
Switch dumper from error_log to direct writing into php://stderr

### DIFF
--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -38,6 +38,8 @@ if (!function_exists('dumprr')) {
      */
     function dumprr($value): void
     {
-        dump($value, Dumper::ERROR_LOG);
+        $result = dump($value, Dumper::RETURN);
+
+        file_put_contents('php://stderr', $result);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌ 

Fixes the work of the `dumprr` helper in the case when the `error_log` is not configured to write to the `php://stderr`.

P.S. Psalm CI errors has been fixed in https://github.com/spiral/framework/pull/388