### PR TITLE
Allow adding custom config loaders

### DIFF
--- a/src/Boot/src/Bootloader/ConfigurationBootloader.php
+++ b/src/Boot/src/Bootloader/ConfigurationBootloader.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Bootloader;
+
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Config\ConfigManager;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Loader\DirectoryLoader;
+use Spiral\Config\Loader\FileLoaderInterface;
+use Spiral\Config\Loader\JsonLoader;
+use Spiral\Config\Loader\PhpLoader;
+use Spiral\Core\ConfigsInterface;
+use Spiral\Core\Container;
+
+/**
+ * Bootloads core services.
+ */
+final class ConfigurationBootloader extends Bootloader
+{
+    protected const SINGLETONS = [
+        // configuration
+        ConfigsInterface::class      => ConfiguratorInterface::class,
+        ConfiguratorInterface::class => ConfigManager::class,
+        ConfigManager::class         => [self::class, 'configManager'],
+    ];
+
+    /** @var ConfiguratorInterface */
+    private $configurator;
+
+    /** @var FileLoaderInterface[] */
+    private $loaders;
+
+    /** @var DirectoriesInterface */
+    private $directories;
+
+    /** @var Container */
+    private $container;
+
+    public function __construct(DirectoriesInterface $directories, Container $container)
+    {
+        $this->loaders = [
+            'php' => $container->get(PhpLoader::class),
+            'json' => $container->get(JsonLoader::class),
+        ];
+
+        $this->directories = $directories;
+        $this->container = $container;
+        $this->configurator = $this->createConfigManager();
+    }
+
+    public function addLoader(string $ext, FileLoaderInterface $loader): void
+    {
+        if (!isset($this->loaders[$ext]) || get_class($this->loaders[$ext]) !== get_class($loader)) {
+            $this->loaders[$ext] = $loader;
+            $this->container->bindSingleton(ConfigManager::class, $this->createConfigManager());
+        }
+    }
+
+    private function createConfigManager(): ConfiguratorInterface
+    {
+        return new ConfigManager(
+            new DirectoryLoader($this->directories->get('config'), $this->loaders),
+            true
+        );
+    }
+
+    /**
+     * @return ConfiguratorInterface
+     */
+    private function configManager(): ConfiguratorInterface
+    {
+        return $this->configurator;
+    }
+}

--- a/src/Boot/src/Bootloader/CoreBootloader.php
+++ b/src/Boot/src/Bootloader/CoreBootloader.php
@@ -14,11 +14,6 @@ namespace Spiral\Boot\Bootloader;
 use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\Memory;
 use Spiral\Boot\MemoryInterface;
-use Spiral\Config\ConfigManager;
-use Spiral\Config\ConfiguratorInterface;
-use Spiral\Config\Loader\DirectoryLoader;
-use Spiral\Core\ConfigsInterface;
-use Spiral\Core\FactoryInterface;
 use Spiral\Debug\Dumper;
 use Spiral\Files\Files;
 use Spiral\Files\FilesInterface;
@@ -29,6 +24,10 @@ use Spiral\Logger;
  */
 final class CoreBootloader extends Bootloader
 {
+    protected const DEPENDENCIES = [
+        ConfigurationBootloader::class,
+    ];
+
     protected const SINGLETONS = [
         // core services and helpers
         FilesInterface::class                   => Files::class,
@@ -38,24 +37,7 @@ final class CoreBootloader extends Bootloader
         Dumper::class                           => Dumper::class,
         Logger\ListenerRegistryInterface::class => Logger\ListenerRegistry::class,
         Logger\LogsInterface::class             => Logger\LogFactory::class,
-
-        // configuration
-        ConfigsInterface::class                 => ConfiguratorInterface::class,
-        ConfiguratorInterface::class            => ConfigManager::class,
-        ConfigManager::class                    => [self::class, 'configManager'],
     ];
-
-    /**
-     * @param DirectoriesInterface $directories
-     * @param FactoryInterface     $factory
-     * @return ConfiguratorInterface
-     */
-    private function configManager(
-        DirectoriesInterface $directories,
-        FactoryInterface $factory
-    ): ConfiguratorInterface {
-        return new ConfigManager(new DirectoryLoader($directories->get('config'), $factory), true);
-    }
 
     /**
      * @param DirectoriesInterface $directories

--- a/src/Boot/tests/ConfigsTest.php
+++ b/src/Boot/tests/ConfigsTest.php
@@ -32,7 +32,7 @@ class ConfigsTest extends TestCase
         $this->assertSame(['key' => 'value'], $config->toArray());
     }
 
-    public function testDep(): void
+    public function testCustomConfigLoader(): void
     {
         $core = TestCore::init([
             'root'   => __DIR__,

--- a/src/Boot/tests/ConfigsTest.php
+++ b/src/Boot/tests/ConfigsTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Config\ConfiguratorInterface;
 use Spiral\Tests\Boot\Fixtures\TestConfig;
+use Spiral\Tests\Boot\Fixtures\TestConfigurationCore;
 use Spiral\Tests\Boot\Fixtures\TestCore;
 
 class ConfigsTest extends TestCase
@@ -28,5 +30,18 @@ class ConfigsTest extends TestCase
         $config = $core->getContainer()->get(TestConfig::class);
 
         $this->assertSame(['key' => 'value'], $config->toArray());
+    }
+
+    public function testDep(): void
+    {
+        $core = TestCore::init([
+            'root'   => __DIR__,
+            'config' => __DIR__ . '/config',
+        ]);
+
+        /** @var ConfiguratorInterface $config */
+        $configurator = $core->getContainer()->get(ConfiguratorInterface::class);
+
+        $this->assertSame(['test-key' => 'test value'], $configurator->getConfig('yaml'));
     }
 }

--- a/src/Boot/tests/Fixtures/ConfigBootloader.php
+++ b/src/Boot/tests/Fixtures/ConfigBootloader.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\Bootloader\ConfigurationBootloader;
+use Spiral\Boot\Bootloader\CoreBootloader;
+use Spiral\Core\Container;
+
+class ConfigBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        CoreBootloader::class,
+    ];
+
+    public function boot(ConfigurationBootloader $configuration, Container $container): void
+    {
+        $configuration->addLoader('yaml', $container->get(TestLoader::class));
+    }
+}

--- a/src/Boot/tests/Fixtures/TestCore.php
+++ b/src/Boot/tests/Fixtures/TestCore.php
@@ -17,6 +17,10 @@ use Spiral\Boot\Exception\BootException;
 
 class TestCore extends AbstractKernel
 {
+    protected const LOAD = [
+        ConfigBootloader::class,
+    ];
+
     public function getContainer()
     {
         return $this->container;

--- a/src/Boot/tests/Fixtures/TestLoader.php
+++ b/src/Boot/tests/Fixtures/TestLoader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Config\Loader\FileLoaderInterface;
+
+class TestLoader implements FileLoaderInterface
+{
+    public function loadFile(string $section, string $filename): array
+    {
+        return [
+            'test-key' => 'test value',
+        ];
+    }
+}

--- a/src/Boot/tests/config/yaml.yaml
+++ b/src/Boot/tests/config/yaml.yaml
@@ -1,0 +1,1 @@
+#content doesn't matter - we have no yaml loader yet

--- a/src/Bridge/Stempler/tests/BaseTest.php
+++ b/src/Bridge/Stempler/tests/BaseTest.php
@@ -20,6 +20,8 @@ use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Loader\DirectoryLoader;
+use Spiral\Config\Loader\JsonLoader;
+use Spiral\Config\Loader\PhpLoader;
 use Spiral\Core\ConfigsInterface;
 use Spiral\Core\Container;
 use Spiral\Stempler\Bootloader\PrettyPrintBootloader;
@@ -59,7 +61,10 @@ abstract class BaseTest extends TestCase
         $this->container->bind(
             ConfiguratorInterface::class,
             new ConfigManager(
-                new DirectoryLoader(__DIR__ . '/config/', $this->container),
+                new DirectoryLoader(__DIR__ . '/config/', [
+                    'php'  => $this->container->get(PhpLoader::class),
+                    'json' => $this->container->get(JsonLoader::class),
+                ]),
                 true
             )
         );

--- a/src/Config/tests/BaseTest.php
+++ b/src/Config/tests/BaseTest.php
@@ -14,6 +14,8 @@ namespace Spiral\Tests\Config;
 use PHPUnit\Framework\TestCase;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\Loader\DirectoryLoader;
+use Spiral\Config\Loader\JsonLoader;
+use Spiral\Config\Loader\PhpLoader;
 use Spiral\Core\Container;
 
 abstract class BaseTest extends TestCase
@@ -34,6 +36,12 @@ abstract class BaseTest extends TestCase
             $directory = __DIR__ . '/fixtures';
         }
 
-        return new ConfigManager(new DirectoryLoader($directory, $this->container), $strict);
+        return new ConfigManager(
+            new DirectoryLoader($directory, [
+                'php'  => $this->container->get(PhpLoader::class),
+                'json' => $this->container->get(JsonLoader::class),
+            ]),
+            $strict
+        );
     }
 }


### PR DESCRIPTION
https://github.com/spiral/framework/issues/364
https://github.com/spiral/framework/issues/381
```php
class YamlBootloader extends Bootloader
{
    public function boot(ConfigurationBootloader $bootloader)
    {
        $bootloader->addLoader('yaml', YamlLoader::class);
    }
}
```