### PR TITLE
Fix uuid segment regex in UriHandler

### DIFF
--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -30,7 +30,7 @@ final class UriHandler
     private const SEGMENT_TYPES    = [
         'int'     => '\d+',
         'integer' => '\d+',
-        'uuid'    => '0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}',
+        'uuid'    => '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}',
     ];
     private const URI_FIXERS       = [
         '[]'  => '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ✔️, if someone uses literal `uuid` in segment part of route parameter
| New feature?  | ❌