### PR TITLE
Prevent dumprr from outputing html-wrapped results

### DIFF
--- a/src/Dumper/src/Dumper.php
+++ b/src/Dumper/src/Dumper.php
@@ -35,6 +35,7 @@ class Dumper implements LoggerAwareInterface
     public const ERROR_LOG         = 3;
     public const OUTPUT_CLI        = 4;
     public const OUTPUT_CLI_COLORS = 5;
+    public const ROADRUNNER        = 6;
 
     /** @var int */
     private $maxLevel = 12;
@@ -51,6 +52,7 @@ class Dumper implements LoggerAwareInterface
         self::RETURN            => HtmlRenderer::class,
         self::LOGGER            => PlainRenderer::class,
         self::ERROR_LOG         => PlainRenderer::class,
+        self::ROADRUNNER        => PlainRenderer::class,
     ];
 
     /**
@@ -91,6 +93,7 @@ class Dumper implements LoggerAwareInterface
                 echo $dump;
                 break;
 
+            case self::ROADRUNNER:
             case self::RETURN:
                 return $dump;
 

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -38,7 +38,7 @@ if (!function_exists('dumprr')) {
      */
     function dumprr($value): void
     {
-        $result = dump($value, Dumper::RETURN);
+        $result = dump($value, Dumper::ROADRUNNER);
 
         file_put_contents('php://stderr', $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

Currently `dumprr` uses HtmlRenderer to render results which does not make much sense when outputing to stderr. This patch fixes it.

Related discussion: https://github.com/spiral/framework/commit/0e5a4bc38eeaa65a1f6250490ea6c1853564096d#r47916628