### PR TITLE
Change subject encoding to base64_encode

### DIFF
--- a/src/SendIt/src/Renderer/ViewRenderer.php
+++ b/src/SendIt/src/Renderer/ViewRenderer.php
@@ -72,7 +72,7 @@ final class ViewRenderer implements RendererInterface
     }
 
     /**
-     * Copy-pasted form https://stackoverflow.com/a/54688095
+     * Copy-pasted form https://stackoverflow.com/a/20806227
      * Make sure the subject is ASCII-clean
      *
      * @param string $subject Subject to encode
@@ -86,8 +86,8 @@ final class ViewRenderer implements RendererInterface
         }
 
         // Subject is non-ascii, needs encoding
-        $encoded = quoted_printable_encode($subject);
-        $prefix = '=?UTF-8?q?';
+        $encoded = base64_encode($subject);
+        $prefix = '=?UTF-8?B?';
         $suffix = '?=';
 
         return $prefix . str_replace("=\r\n", $suffix . "\r\n  " . $prefix, $encoded) . $suffix;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

With current encoding subject text displays as `=?UTF-8?q?=D0=9F=D0=BE=D0=B4=D0=B0=D0=BD=D0=B0 =D0=B7=D0=B0=D1=8F=D0=B2=D0=BA=D0?= на покупку'`
Expected result `Подана заявка на покупку`.

Changing encoding to ```base64_encode``` fixes the bug.

Tested in mail.ru
![image](https://user-images.githubusercontent.com/31503975/111118465-070e5a80-8593-11eb-8b19-aa1e9c7f6b97.png)

and gmail.com
![image](https://user-images.githubusercontent.com/31503975/111118511-17263a00-8593-11eb-92ed-952936538702.png)

