### PR TITLE
Escape Annotation

### DIFF
--- a/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
@@ -25,9 +25,9 @@ use Spiral\Stempler\Lexer\Token;
 
 /**
  * Similar to Laravel blade, this grammar defines the ability to echo PHP variables using {{ $var }} statements
- * Grammar also support various component support using @directive(options) pattern.
+ * Grammar also support various component support using [@directive(options)] pattern.
  *
- * Attention, the syntaxt will treat all @sequnce() as directive unless DirectiveRendererInterface is provided.
+ * Attention, the syntaxt will treat all [@sequnce()] as directive unless DirectiveRendererInterface is provided.
  */
 final class DynamicGrammar implements GrammarInterface
 {


### PR DESCRIPTION
vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:39

[Semantical Error] The annotation "@directive" in class Spiral\Stempler\Lexer\Grammar\DynamicGrammar was never imported. Did you maybe forget to add a "use" statement for this annotation?
[Semantical Error] The annotation "@sequnce" in class Spiral\Stempler\Lexer\Grammar\DynamicGrammar was never imported. Did you maybe forget to add a "use" statement for this annotation?

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC? |   ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature? | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        |  <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       |  <!-- prefix each issue number with "spiral/docs#", required only for new features -->
