### PR TITLE
Implement fragment/expression injections for DataGrid sorters

### DIFF
--- a/src/Bridge/DataGrid/src/Specification/Sorter/ExpressionInjectionSorter.php
+++ b/src/Bridge/DataGrid/src/Specification/Sorter/ExpressionInjectionSorter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid\Specification\Sorter;
+
+use Spiral\Database\Injection\Expression;
+use Spiral\Database\Injection\Fragment;
+
+final class ExpressionInjectionSorter extends InjectionSorter
+{
+    protected const INJECTION = Expression::class;
+}

--- a/src/Bridge/DataGrid/src/Specification/Sorter/FragmentInjectionSorter.php
+++ b/src/Bridge/DataGrid/src/Specification/Sorter/FragmentInjectionSorter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid\Specification\Sorter;
+
+use Spiral\Database\Injection\Fragment;
+
+final class FragmentInjectionSorter extends InjectionSorter
+{
+    protected const INJECTION = Fragment::class;
+}

--- a/src/Bridge/DataGrid/src/Specification/Sorter/InjectionSorter.php
+++ b/src/Bridge/DataGrid/src/Specification/Sorter/InjectionSorter.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DataGrid\Specification\Sorter;
+
+use Spiral\Database\Injection\FragmentInterface;
+use Spiral\DataGrid\Specification\Sorter\AbstractSorter;
+use Spiral\DataGrid\SpecificationInterface;
+
+abstract class InjectionSorter extends AbstractSorter
+{
+    protected const INJECTION = '';
+
+    /**
+     * @var AbstractSorter
+     */
+    private $expression;
+
+    public function __construct(SpecificationInterface $expression)
+    {
+        if (!$expression instanceof AbstractSorter) {
+            throw new \LogicException('Only sorters allowed');
+        }
+
+        $this->expression = $expression;
+    }
+
+    /**
+     * @return FragmentInterface[]
+     */
+    public function getInjections(): array
+    {
+        $injector = static::INJECTION;
+
+        if (!class_exists($injector)) {
+            throw new \LogicException(
+                sprintf('Class "%s" does not exist', $injector)
+            );
+        }
+
+        if (!is_subclass_of($injector, FragmentInterface::class)) {
+            throw new \LogicException(
+                'INJECTION class does not implement FragmentInterface'
+            );
+        }
+
+        return array_map(
+            function (string $expression) use ($injector): FragmentInterface {
+                return new $injector($expression);
+            },
+            $this->expression->getExpressions()
+        );
+    }
+
+    public function getSorter(): AbstractSorter
+    {
+        return $this->expression;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue(): string
+    {
+        return $this->expression->getValue();
+    }
+}

--- a/src/Bridge/DataGrid/src/Writer/QueryWriter.php
+++ b/src/Bridge/DataGrid/src/Writer/QueryWriter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Spiral\DataGrid\Writer;
 
 use Cycle\ORM\Select;
+use Spiral\DataGrid\Specification\Sorter\InjectionSorter;
 use Spiral\Database\Injection\Parameter;
 use Spiral\Database\Query\SelectQuery;
 use Spiral\DataGrid\Compiler;
@@ -178,6 +179,15 @@ class QueryWriter implements WriterInterface
             $direction = static::SORTER_DIRECTIONS[get_class($sorter)];
             foreach ($sorter->getExpressions() as $expression) {
                 $source = $source->orderBy($expression, $direction);
+            }
+
+            return $source;
+        }
+
+        if ($sorter instanceof InjectionSorter) {
+            $direction = static::SORTER_DIRECTIONS[get_class($sorter)] ?? 'ASC';
+            foreach ($sorter->getInjections() as $injection) {
+                $source = $source->orderBy($injection, $direction);
             }
 
             return $source;

--- a/src/Bridge/DataGrid/tests/QueryWriter/WriteSorterTest.php
+++ b/src/Bridge/DataGrid/tests/QueryWriter/WriteSorterTest.php
@@ -195,6 +195,32 @@ class WriteSorterTest extends BaseTest
         }
     }
 
+    public function testFragmentInjection(): void
+    {
+        $select = $this->compile(
+            $this->initQuery(),
+            new Sorter\FragmentInjectionSorter(new Sorter\AscSorter("json_field->>'date'"))
+        );
+
+        $this->assertEqualSQL(
+            "SELECT * FROM \"users\" ORDER BY json_field->>'date' ASC",
+            $select
+        );
+    }
+
+    public function testExpressionInjection(): void
+    {
+        $select = $this->compile(
+            $this->initQuery(),
+            new Sorter\ExpressionInjectionSorter(new Sorter\AscSorter('date(created)'))
+        );
+
+        $this->assertEqualSQL(
+            'SELECT * FROM "users" ORDER BY date("created") ASC',
+            $select
+        );
+    }
+
     public function binarySortProvider(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #393

Allows to use Fragment/Expression in DataGrid sorters as such:
```
new Sorter\FragmentInjectionSorter(new Sorter\AscSorter("json_field->>'some_data'")))
```