### PR TITLE
Removed "not empty" constraint from arrayOf checker

### DIFF
--- a/src/Validation/src/Checker/ArrayChecker.php
+++ b/src/Validation/src/Checker/ArrayChecker.php
@@ -19,7 +19,7 @@ class ArrayChecker extends AbstractChecker
 
     public function of($value, $checker): bool
     {
-        if (!is_array($value) || empty($value)) {
+        if (!is_array($value)) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | Not sure
| New feature?  | ❌

Empty array doesn't violate arrayOf rule. It should be used together with notEmpty rule in case you need to disallow usage of empty arrays.