### PR TITLE
Json response status hotfix

### DIFF
--- a/src/Http/src/Traits/JsonTrait.php
+++ b/src/Http/src/Traits/JsonTrait.php
@@ -33,7 +33,7 @@ trait JsonTrait
             $payload = $payload->jsonSerialize();
         }
 
-        if (is_array($payload) && isset($payload['status'])) {
+        if (is_array($payload) && isset($payload['status']) && is_int($payload['status'])) {
             $code = $payload['status'];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | #412

Although the problem is being solved, however, the use of JSON fields (that converted from php array) for status codes is not a very good idea. 

Requires a break BC and removal of this functionality in future releases.