### PR TITLE
Fix @var declaration of nullable Spiral\Console\Command properties

### DIFF
--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -41,7 +41,7 @@ abstract class Command extends SymfonyCommand
     // getArguments() method.
     protected const ARGUMENTS = [];
 
-    /** @var Container */
+    /** @var Container|null */
     protected $container;
 
     /**

--- a/src/Console/src/Traits/HelpersTrait.php
+++ b/src/Console/src/Traits/HelpersTrait.php
@@ -24,7 +24,7 @@ trait HelpersTrait
      * OutputInterface is the interface implemented by all Output classes. Only exists when command
      * are being executed.
      *
-     * @var OutputInterface
+     * @var OutputInterface|null
      */
     protected $output;
 
@@ -32,7 +32,7 @@ trait HelpersTrait
      * InputInterface is the interface implemented by all input classes. Only exists when command
      * are being executed.
      *
-     * @var InputInterface
+     * @var InputInterface|null
      */
     protected $input;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ❌

None of these properties are set in __construct, so they are potentially nullable