### PR TITLE
Sort annotated routes by priority

### DIFF
--- a/src/AnnotatedRoutes/src/Annotation/Route.php
+++ b/src/AnnotatedRoutes/src/Annotation/Route.php
@@ -62,4 +62,10 @@ final class Route
      * @var array
      */
     public $middleware = [];
+
+    /**
+     * @Attribute(name="priority", type="int")
+     * @var int
+     */
+    public $priority = 0;
 }

--- a/src/AnnotatedRoutes/src/RouteLocator.php
+++ b/src/AnnotatedRoutes/src/RouteLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Router;
 
+use Spiral\Annotations\AnnotatedMethod;
 use Spiral\Annotations\AnnotationLocator;
 use Spiral\Router\Annotation\Route as RouteAnnotation;
 
@@ -32,8 +33,13 @@ final class RouteLocator
      */
     public function findDeclarations(): array
     {
+        $routes = iterator_to_array($this->locator->findMethods(RouteAnnotation::class));
+        uasort($routes, static function (AnnotatedMethod $route1, AnnotatedMethod $route2) {
+            return $route1->getAnnotation()->priority <=> $route2->getAnnotation()->priority;
+        });
+
         $result = [];
-        foreach ($this->locator->findMethods(RouteAnnotation::class) as $match) {
+        foreach ($routes as $match) {
             /** @var RouteAnnotation $route */
             $route = $match->getAnnotation();
 

--- a/src/AnnotatedRoutes/tests/App/Controller/PageController.php
+++ b/src/AnnotatedRoutes/tests/App/Controller/PageController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\App\Controller;
+
+use Spiral\Router\Annotation\Route;
+
+final class PageController
+{
+    /**
+     * @Route("/page/<page>", name="page_get", methods="GET")
+     */
+    public function get($page)
+    {
+        return 'page-'.$page;
+    }
+
+    /**
+     * @Route("/page/about", name="page_about", methods="GET", priority=-1)
+     */
+    public function about()
+    {
+        return 'about';
+    }
+}

--- a/src/AnnotatedRoutes/tests/IntegrationTest.php
+++ b/src/AnnotatedRoutes/tests/IntegrationTest.php
@@ -36,6 +36,20 @@ class IntegrationTest extends TestCase
         $this->assertStringContainsString('method', $r->getBody()->__toString());
     }
 
+    public function testRoute3(): void
+    {
+        $r = $this->get('/page/test');
+
+        $this->assertSame('page-test', $r->getBody()->__toString());
+    }
+
+    public function testRoute4(): void
+    {
+        $r = $this->get('/page/about');
+
+        $this->assertSame('about', $r->getBody()->__toString());
+    }
+
     public function get(
         $uri,
         array $query = [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #...

## Description

Бывает ситуация, когда два маршрута конфликтуют и нужно изменить их порядок.

## Example

Два маршрута `/page/<page>` и `/page/about`. 
Если `/page/<page>` будет первым в списке маршрутов, то `/page/about` ни когда не запуститься.
Если поменять их порядок, то все маршруты будут работать.

