### PR TITLE
Fix validation of extra fields for case insensitive EntityChecker::unique

### DIFF
--- a/tests/Framework/Validation/EntityCheckerTest.php
+++ b/tests/Framework/Validation/EntityCheckerTest.php
@@ -91,7 +91,9 @@ class EntityCheckerTest extends BaseTest
         $transaction->run();
 
         $this->assertFalse($this->isUnique('vaLeNtIN', 'name', [], null, [], true));
+        $this->assertFalse($this->isUnique('1', 'id', ['name' => 'valEntIn'], null, ['name'], true));
         $this->assertTrue($this->isUnique('vaLeNtIN', 'name'));
+        $this->assertTrue($this->isUnique('1', 'id', ['name' => 'valEntIn'], null, ['name']));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

Current implementation of case insensitive `unique` does not take into account `$withFields` variable. This PR fixes it