### PR TITLE
fix(distribution): always prefix file uri with slash

### DIFF
--- a/src/Distribution/src/Resolver/StaticResolver.php
+++ b/src/Distribution/src/Resolver/StaticResolver.php
@@ -72,11 +72,9 @@ class StaticResolver extends UriResolver
      */
     private function suffix(string $file): string
     {
-        $prefix = $this->host->getPath();
+        $prefix = \trim($this->host->getPath(), self::URI_PATH_DELIMITER);
+        $file = \trim($file, self::URI_PATH_DELIMITER);
 
-        return \implode(self::URI_PATH_DELIMITER, [
-            \trim($prefix, self::URI_PATH_DELIMITER),
-            \trim($file, self::URI_PATH_DELIMITER),
-        ]);
+        return self::URI_PATH_DELIMITER . ('' === $prefix ? '' : $prefix . self::URI_PATH_DELIMITER) . $file;
     }
 }

--- a/src/Distribution/tests/Resolver/StaticResolverTest.php
+++ b/src/Distribution/tests/Resolver/StaticResolverTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Distribution\Resolver;
+
+use Spiral\Distribution\Resolver\StaticResolver;
+use Spiral\Tests\Distribution\TestCase;
+
+class StaticResolverTest extends TestCase
+{
+    public function testGuzzleResolve(): void
+    {
+        $resolver = StaticResolver::create('http://localhost');
+
+        $uri = $resolver->resolve('file.jpg');
+
+        self::assertSame('http://localhost/file.jpg', (string)$uri);
+        self::assertNull(error_get_last());
+    }
+
+    public function testGuzzleResolveWithPrefix(): void
+    {
+        $resolver = StaticResolver::create('http://localhost/upload/');
+
+        $uri = $resolver->resolve('file.jpg');
+
+        self::assertSame('http://localhost/upload/file.jpg', (string)$uri);
+        self::assertNull(error_get_last());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        |
| Docs PR       | 

always prefix file uri with slash, to prevent guzzle uri trigger an error, when resolving file from subdirectory