### PR TITLE
Generate annotated routes name when it is not specified explicitly

### DIFF
--- a/src/AnnotatedRoutes/src/Annotation/Route.php
+++ b/src/AnnotatedRoutes/src/Annotation/Route.php
@@ -28,10 +28,10 @@ final class Route
     public $route;
 
     /**
-     * @Attribute(name="name", type="string", required=true)
+     * @Attribute(name="name", type="string")
      * @var string
      */
-    public $name;
+    public $name = null;
 
     /**
      * @Attribute(name="verbs", type="mixed", required=true)

--- a/src/AnnotatedRoutes/src/RouteLocator.php
+++ b/src/AnnotatedRoutes/src/RouteLocator.php
@@ -42,8 +42,9 @@ final class RouteLocator
         foreach ($routes as $match) {
             /** @var RouteAnnotation $route */
             $route = $match->getAnnotation();
+            $routeName = $route->name ?? $this->generateName($route);
 
-            $result[$route->name] = [
+            $result[$routeName] = [
                 'pattern'    => $route->route,
                 'controller' => $match->getClass()->getName(),
                 'action'     => $match->getMethod()->getName(),
@@ -55,5 +56,20 @@ final class RouteLocator
         }
 
         return $result;
+    }
+
+    /**
+     * Generates route name based on declared methods and route.
+     *
+     * @param RouteAnnotation $route
+     * @return string
+     */
+    private function generateName(RouteAnnotation $route): string
+    {
+        $methods = is_array($route->methods)
+            ? implode(',', $route->methods)
+            : $route->methods;
+
+        return mb_strtolower(sprintf('%s:%s', $methods, $route->route));
     }
 }

--- a/src/AnnotatedRoutes/tests/App/Controller/NamelessRoutesController.php
+++ b/src/AnnotatedRoutes/tests/App/Controller/NamelessRoutesController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Vladislav Gorenkin (vladgorenkin)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\App\Controller;
+
+use Spiral\Router\Annotation\Route;
+
+class NamelessRoutesController
+{
+    /**
+     * @Route(route="/nameless",  methods="GET")
+     */
+    public function index()
+    {
+        return 'index';
+    }
+
+    /**
+     * @Route(route="/nameless", methods="POST")
+     */
+    public function method()
+    {
+        return 'method';
+    }
+
+    /**
+     * @Route(route="/nameless/route", methods={"GET", "POST"})
+     */
+    public function route()
+    {
+        return 'route';
+    }
+}

--- a/src/AnnotatedRoutes/tests/IntegrationTest.php
+++ b/src/AnnotatedRoutes/tests/IntegrationTest.php
@@ -50,6 +50,18 @@ class IntegrationTest extends TestCase
         $this->assertSame('about', $r->getBody()->__toString());
     }
 
+    public function testRoutesWithoutNames(): void
+    {
+        $r = $this->get('/nameless');
+        $this->assertSame('index', $r->getBody()->__toString());
+
+        $r = $this->post('/nameless');
+        $this->assertSame('method', $r->getBody()->__toString());
+
+        $r = $this->get('/nameless/route');
+        $this->assertSame('route', $r->getBody()->__toString());
+    }
+
     public function get(
         $uri,
         array $query = [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

This feature implementation is more of a dialog starter than a request for a change.

Speaking from my experience on a project with 250+ API-methods -- I never needed to reference a route name once. I understand  route names are useful for generating URLs and etc, but at the same time they can be an unnecessary burden. You have to make sure that names are unique (which I offen forget to check after copying controller actions). You also need to have sane naming convention and refactor route names with actions and etc.

Instead we could make specifying route names optional (at least for annotations) and when not specified generate them from route methods and pattern. In the current implementation route name is generated as follows:

```php
/** @Route('/api/news', methods={"POST", "PATCH"}) */ -> 'post,patch:/api/news'
```

What do you think of this idea? Does it make sense to you?