### PR TITLE
[bugfix]: issue-425 - fix request validator require to not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - **High Impact Changes**
     - Added `league/flysystem: ^2.0` dependency.
 
+- **Medium Impact Changes**
+    - Modified `required` alias field validation from `notEmpty` to `notNull`
+
 - **Other Features**
     - Added basic RoadRunner 2.0 support (only HTTP)
     - [data-grid] Implement fragment/expression injections for DataGrid sorters (#400)

--- a/src/Framework/Bootloader/Security/ValidationBootloader.php
+++ b/src/Framework/Bootloader/Security/ValidationBootloader.php
@@ -87,7 +87,7 @@ final class ValidationBootloader extends Bootloader implements SingletonInterfac
                 'aliases'    => [
                     'notEmpty'   => 'type::notEmpty',
                     'notNull'    => 'type::notNull',
-                    'required'   => 'type::notEmpty',
+                    'required'   => 'type::notNull',
                     'datetime'   => 'type::datetime',
                     'timezone'   => 'type::timezone',
                     'bool'       => 'type::boolean',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ✔️
| New feature?  | ❌ 
| Issues        | #425

Required field can be empty but not null

This change can brokes validation if value will be empty but not null
