### PR TITLE
Allow injectors to inject interfaces

### DIFF
--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -68,13 +68,6 @@ final class Container implements
     private $injectors = [];
 
     /**
-     * Contains names of all classes which were checked for the available injectors.
-     *
-     * @var array
-     */
-    private $injectorsCache = [];
-
-    /**
      * Container constructor.
      */
     public function __construct()
@@ -362,7 +355,6 @@ final class Container implements
     public function bindInjector(string $class, string $injector): Container
     {
         $this->injectors[$class] = $injector;
-        $this->injectorsCache = [];
 
         return $this;
     }
@@ -373,7 +365,6 @@ final class Container implements
     public function removeInjector(string $class): void
     {
         unset($this->injectors[$class]);
-        $this->injectorsCache = [];
     }
 
     /**
@@ -571,28 +562,24 @@ final class Container implements
             return true;
         }
 
-        if (!isset($this->injectorsCache[$class])) {
-            $this->injectorsCache[$class] = null;
+        // check interfaces
+        foreach ($this->injectors as $target => $injector) {
+            if (
+                \class_exists($target, true)
+                && $reflection->isSubclassOf($target)
+            ) {
+                $this->injectors[$class] = $injector;
 
-            // check interfaces
-            foreach ($this->injectors as $target => $injector) {
-                if (
-                    \class_exists($target, true)
-                    && $reflection->isSubclassOf($target)
-                ) {
-                    $this->injectors[$class] = $injector;
+                return true;
+            }
 
-                    return true;
-                }
+            if (
+                \interface_exists($target, true)
+                && $reflection->implementsInterface($target)
+            ) {
+                $this->injectors[$class] = $injector;
 
-                if (
-                    \interface_exists($target, true)
-                    && $reflection->implementsInterface($target)
-                ) {
-                    $this->injectors[$class] = $injector;
-
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -401,7 +401,7 @@ final class Container implements
      */
     protected function autowire(string $class, array $parameters, string $context = null)
     {
-        if (!\class_exists($class)) {
+        if (!\class_exists($class) && !isset($this->injectors[$class])) {
             throw new NotFoundException(\sprintf("Undefined class or binding '%s'", $class));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

This PR allows to use injectors to inject with interface:

```php
//
// Bootloader
//
private pools = [
    'pool' => new ArrayAdapter(),
];
function boot(Container $container) { 
    $container->bindInjector(CacheItemPoolInterface::class, self::class)
}

function createInjection(\ReflectionClass $class, string $context = null) {
    return $this->pools[$context];
}
//...
// Code
//
public withClass(ArrayAdapter $pool) { // ArrayAdapter implements CachePoolItemInterface, injection works
}

public withInterface(CacheItemPoolInterface $pool) { // Currently container throws 'Undefined class or binding '%s'', because class_exists() returns false for CacheItemPoolInterface
}
```