### PR TITLE
Add S3 and Cloudfront prefixes support

### DIFF
--- a/src/Distribution/src/Resolver/CloudFrontResolver.php
+++ b/src/Distribution/src/Resolver/CloudFrontResolver.php
@@ -40,15 +40,22 @@ class CloudFrontResolver extends ExpirationAwareResolver
     private $factory;
 
     /**
+     * @var string|null
+     */
+    private $prefix;
+
+    /**
      * @param string $keyPairId
      * @param string $privateKey
      * @param string $domain
+     * @param string|null $prefix
      */
-    public function __construct(string $keyPairId, string $privateKey, string $domain)
+    public function __construct(string $keyPairId, string $privateKey, string $domain, string $prefix = null)
     {
         $this->assertCloudFrontAvailable();
 
         $this->domain = $domain;
+        $this->prefix = $prefix;
         $this->factory = new AmazonUriFactory();
         $this->signer = new UrlSigner($keyPairId, $privateKey);
 
@@ -91,6 +98,6 @@ class CloudFrontResolver extends ExpirationAwareResolver
      */
     private function createUrl(string $file): string
     {
-        return \sprintf('rtmp://%s/%s', $this->domain, \trim($file, '/'));
+        return \sprintf('https://%s/%s', $this->domain, $this->concat($file, $this->prefix));
     }
 }

--- a/src/Distribution/src/Resolver/S3SignedResolver.php
+++ b/src/Distribution/src/Resolver/S3SignedResolver.php
@@ -33,13 +33,20 @@ class S3SignedResolver extends ExpirationAwareResolver
     private $bucket;
 
     /**
+     * @var string|null
+     */
+    private $prefix;
+
+    /**
      * @param S3ClientInterface $client
      * @param string $bucket
+     * @param string|null $prefix
      */
-    public function __construct(S3ClientInterface $client, string $bucket)
+    public function __construct(S3ClientInterface $client, string $bucket, string $prefix = null)
     {
         $this->client = $client;
         $this->bucket = $bucket;
+        $this->prefix = $prefix;
 
         parent::__construct();
     }
@@ -52,7 +59,7 @@ class S3SignedResolver extends ExpirationAwareResolver
      */
     public function resolve(string $file, $expiration = null): UriInterface
     {
-        $command = $this->createCommand($file);
+        $command = $this->createCommand($this->concat($file, $this->prefix));
 
         $request = $this->client->createPresignedRequest(
             $command,

--- a/src/Distribution/src/Resolver/UriResolver.php
+++ b/src/Distribution/src/Resolver/UriResolver.php
@@ -15,4 +15,17 @@ use Spiral\Distribution\UriResolverInterface;
 
 abstract class UriResolver implements UriResolverInterface
 {
+    /**
+     * @param string $file
+     * @param string|null $prefix
+     * @return string
+     */
+    protected function concat(string $file, ?string $prefix): string
+    {
+        if ($prefix === null) {
+            return $file;
+        }
+
+        return \trim($prefix, '/') . '/' . \trim($file, '/');
+    }
 }

--- a/src/Framework/Bootloader/Distribution/DistributionConfig.php
+++ b/src/Framework/Bootloader/Distribution/DistributionConfig.php
@@ -191,6 +191,10 @@ class DistributionConfig
         }
 
         // Optional config options
+        if (!\is_string($config['prefix'] ?? '')) {
+            throw $this->invalidConfigKey($name, 'prefix', 'string or null');
+        }
+
         if (!\is_string($config['version'] ?? '')) {
             throw $this->invalidConfigKey($name, 'version', 'string or null');
         }
@@ -219,7 +223,7 @@ class DistributionConfig
 
         $client = new S3Client($s3Options);
 
-        return new S3SignedResolver($client, $config['bucket']);
+        return new S3SignedResolver($client, $config['bucket'], $config['prefix'] ?? null);
     }
 
     /**
@@ -241,10 +245,15 @@ class DistributionConfig
             throw $this->invalidConfigKey($name, 'domain', 'string');
         }
 
+        if (!\is_string($config['prefix'] ?? '')) {
+            throw $this->invalidConfigKey($name, 'prefix', 'string or null');
+        }
+
         return new CloudFrontResolver(
             $config['key'],
             $config['private'],
-            $config['domain']
+            $config['domain'],
+            $config['prefix'] ?? null
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️/❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #434
| Documentation | https://github.com/spiral/docs/pull/201

This PR will add prefixes to the S3 and CloudFront URL generators.
