### PR TITLE
More verbose config-related error messages

### DIFF
--- a/src/Config/src/Loader/DirectoryLoader.php
+++ b/src/Config/src/Loader/DirectoryLoader.php
@@ -61,11 +61,11 @@ final class DirectoryLoader implements LoaderInterface
             try {
                 return $this->getLoader($extension)->loadFile($section, $filename);
             } catch (LoaderException $e) {
-                throw new LoaderException("Unable to load config `{$section}`.", $e->getCode(), $e);
+                throw new LoaderException("Unable to load config `{$section}`: {$e->getMessage()}", $e->getCode(), $e);
             }
         }
 
-        throw new LoaderException("Unable to load config `{$section}`.");
+        throw new LoaderException("Unable to load config `{$section}`: no suitable loader found.");
     }
 
     private function loaderExtensions(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

Currently only "Unable to load config `foobar`" is displayed without information on why it is unable to load it