### PR TITLE
[Exceptions] Add missing space in PlainHandler render before "in"

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,7 +7,6 @@
     errorLevel="8"
     hoistConstants="true"
     resolveFromConfigFile="true"
-    allowPhpStormGenerics="true"
     findUnusedPsalmSuppress="true"
     findUnusedVariablesAndParams="true"
     ensureArrayStringOffsetsExist="true"

--- a/src/Exceptions/src/PlainHandler.php
+++ b/src/Exceptions/src/PlainHandler.php
@@ -31,7 +31,7 @@ final class PlainHandler extends AbstractHandler
             $result .= '[' . get_class($e) . "]\n" . $e->getMessage();
         }
 
-        $result .= sprintf("in %s:%s\n", $e->getFile(), $e->getLine());
+        $result .= sprintf(" in %s:%s\n", $e->getFile(), $e->getLine());
 
         if ($verbosity >= self::VERBOSITY_DEBUG) {
             $result .= $this->renderTrace($e, new Highlighter(new PlainStyle()));

--- a/src/Exceptions/tests/PlainHandlerTest.php
+++ b/src/Exceptions/tests/PlainHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Exceptions;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Spiral\Exceptions\PlainHandler;
+
+class PlainHandlerTest extends TestCase
+{
+    public function testRenderException(): void
+    {
+        $plainHandler = new PlainHandler();
+        $result = $plainHandler->renderException(new Exception('Undefined variable $undefined'));
+
+        $this->assertStringContainsString(
+            sprintf('Undefined variable $undefined in %s:24', __FILE__),
+            $result
+        );
+    }
+}

--- a/src/Exceptions/tests/PlainHandlerTest.php
+++ b/src/Exceptions/tests/PlainHandlerTest.php
@@ -23,7 +23,7 @@ class PlainHandlerTest extends TestCase
         $result = $plainHandler->renderException(new Exception('Undefined variable $undefined'));
 
         $this->assertStringContainsString(
-            sprintf('Undefined variable $undefined in %s:24', __FILE__),
+            sprintf('Undefined variable $undefined in %s', __FILE__),
             $result
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

Before and after, it wrote into snapshot like the following diff:

```diff
-Undefined variable $undefinedin /Users/samsonasik/www/spiral-app/app/src/Controller/HomeController.php:36
+Undefined variable $undefined in /Users/samsonasik/www/spiral-app/app/src/Controller/HomeController.php:36
```

**Before**

![Screen Shot 2021-11-01 at 00 51 59](https://user-images.githubusercontent.com/459648/139595779-210c24c7-2f2d-43fc-a8a6-4e4cf0bf7a7e.png)

**After**

![Screen Shot 2021-11-01 at 00 52 06](https://user-images.githubusercontent.com/459648/139595782-d8ed380d-a0df-459f-9f97-6d59610f23a7.png)


so the `$undefined` needs space between message and the append description "in /path/to/file/path.php"