### PR TITLE
PlainRenderer fix for multiply `Accept` header

### DIFF
--- a/src/Framework/Http/ErrorHandler/PlainRenderer.php
+++ b/src/Framework/Http/ErrorHandler/PlainRenderer.php
@@ -14,6 +14,7 @@ namespace Spiral\Http\ErrorHandler;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Spiral\Http\Header\AcceptHeader;
 
 /**
  * Does not render any page body.
@@ -39,8 +40,10 @@ final class PlainRenderer implements RendererInterface
      */
     public function renderException(Request $request, int $code, string $message): Response
     {
+        $acceptItems = AcceptHeader::fromString($request->getHeaderLine('Accept'))->getAll();
+
         $response = $this->responseFactory->createResponse($code);
-        if ($request->getHeaderLine('Accept') == 'application/json') {
+        if ($acceptItems && $acceptItems[0]->getValue() === 'application/json') {
             $response = $response->withHeader('Content-Type', 'application/json; charset=UTF-8');
             $response->getBody()->write(json_encode(['status' => $code, 'error' => $message]));
         } else {

--- a/tests/Framework/Http/ErrorHandler/PlainRendererTest.php
+++ b/tests/Framework/Http/ErrorHandler/PlainRendererTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Spiral\Tests\Framework\Http\ErrorHandler;
 
 use GuzzleHttp\Psr7\Response;
+use Laminas\Diactoros\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Spiral\Http\ErrorHandler\PlainRenderer;
 
 /**
@@ -17,22 +17,10 @@ class PlainRendererTest extends TestCase
 {
     public function testContentTypeApplicationJson(): void
     {
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory
-            ->expects(self::once())
-            ->method('createResponse')
-            ->willReturnCallback(static function () {
-                return new Response();
-            });
-
-        $renderer = new PlainRenderer($responseFactory);
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->expects(self::once())
-            ->method('getHeaderLine')
-            ->willReturnMap([
-                ['Accept', 'application/json'],
-            ]);
+        $renderer = new PlainRenderer($this->mockResponseFactory());
+        $request = new ServerRequest([], [], null, null, 'php://input', [
+            'Accept' => 'application/json',
+        ]);
 
         $response = $renderer->renderException($request, 400, 'message');
         self::assertTrue($response->hasHeader('Content-Type'));
@@ -41,5 +29,108 @@ class PlainRendererTest extends TestCase
         $stream = $response->getBody();
         $stream->rewind();
         self::assertJsonStringEqualsJsonString('{"status": 400, "error": "message"}', $stream->getContents());
+    }
+
+    public function testNoAcceptHeader(): void
+    {
+        $renderer = new PlainRenderer($this->mockResponseFactory());
+        $request = new ServerRequest([], [], null, null, 'php://input');
+
+        $response = $renderer->renderException($request, 400, 'message');
+        $stream = $response->getBody();
+        $stream->rewind();
+        self::assertEquals('Error code: 400', $stream->getContents());
+    }
+
+    /**
+     * @dataProvider dataResponseIsJson
+     */
+    public function testResponseIsJson(): void
+    {
+        $renderer = new PlainRenderer($this->mockResponseFactory());
+        $request = new ServerRequest([], [], null, null, 'php://input', [
+            'Accept' => [
+                'application/json',
+                'application/json',
+            ],
+        ]);
+
+        $response = $renderer->renderException($request, 400, 'message');
+        self::assertTrue($response->hasHeader('Content-Type'));
+        self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
+
+        $stream = $response->getBody();
+        $stream->rewind();
+        self::assertJsonStringEqualsJsonString('{"status": 400, "error": "message"}', $stream->getContents());
+    }
+
+    public function dataResponseIsJson(): iterable
+    {
+        yield [
+            'application/json',
+        ];
+
+        //Client and Server set `Accept` header each
+        yield [
+            ['application/json', 'application/json'],
+        ];
+
+        yield [
+            'application/json, text/html;q=0.9, */*;q=0.8',
+        ];
+
+        yield [
+            [
+                'application/json',
+                'text/html, application/json;q=0.9, */*;q=0.8',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataResponseIsPlain
+     */
+    public function testResponseIsPlain($acceptHeader): void
+    {
+        $renderer = new PlainRenderer($this->mockResponseFactory());
+        $request = new ServerRequest([], [], null, null, 'php://input', [
+            'Accept' => $acceptHeader,
+        ]);
+
+        $response = $renderer->renderException($request, 400, 'message');
+        $stream = $response->getBody();
+        $stream->rewind();
+        self::assertEquals('Error code: 400', $stream->getContents());
+    }
+
+    public function dataResponseIsPlain(): iterable
+    {
+        //Accept header contains several mime types with `q` values. JSON is not prioritized
+        yield [
+            'text/html, application/json;q=0.9, */*;q=0.8',
+        ];
+
+        yield [
+            [
+                'text/html, application/json;q=0.9, */*;q=0.8',
+                'application/json',
+            ],
+        ];
+
+        yield [
+            'text/html, application/json, */*;q=0.9',
+        ];
+    }
+
+    private function mockResponseFactory(): ResponseFactoryInterface
+    {
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory
+            ->expects(self::once())
+            ->method('createResponse')
+            ->willReturnCallback(static function () {
+                return new Response();
+            });
+        return $responseFactory;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->

Client send `Accept` header.

I have this lines in my Roadrunner config.
```yaml
headers:
    request:
        "Accept": "application/json"
```

If an error occurs `PlainRenderer` could not read the header correctly and sends response not in JSON format