### PR TITLE
[Rector] Start Add Rector for QA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         run: composer require --dev roave/security-advisories:dev-latest
 
   static-analysis:
-    name: Psalm
+    name: Psalm and Rector
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -100,7 +100,9 @@ jobs:
 
       # Execution
       - name: Static Analysis
-        run: vendor/bin/psalm --no-cache
+        run: |
+          vendor/bin/psalm --no-cache
+          vendor/bin/rector --dry-run
 
 
   coding-standards:

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.5|^9.0",
         "ramsey/uuid": "^3.9",
-        "rector/rector": "0.12.2",
+        "rector/rector": "0.12.3",
         "spiral/broadcast": "^2.0",
         "spiral/broadcast-ws": "^1.0",
         "spiral/code-style": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.5|^9.0",
         "ramsey/uuid": "^3.9",
-        "rector/rector": "0.12.1",
+        "rector/rector": "0.12.2",
         "spiral/broadcast": "^2.0",
         "spiral/broadcast-ws": "^1.0",
         "spiral/code-style": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,7 @@
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.5|^9.0",
         "ramsey/uuid": "^3.9",
+        "rector/rector": "0.12.1",
         "spiral/broadcast": "^2.0",
         "spiral/broadcast-ws": "^1.0",
         "spiral/code-style": "^1.0",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Php71\Rector\FuncCall\CountOnNullRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src/*/src',
+    ]);
+
+    $parameters->set(Option::SKIP, [
+        CountOnNullRector::class,
+    ]);
+
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
+};

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -70,7 +70,7 @@ abstract class Command extends SymfonyCommand
         $resolver = $this->container->get(ResolverInterface::class);
 
         try {
-            list($this->input, $this->output) = [$input, $output];
+            [$this->input, $this->output] = [$input, $output];
 
             //Executing perform method with method injection
             return (int)$reflection->invokeArgs($this, $resolver->resolveArguments(

--- a/src/Csrf/src/Middleware/CsrfMiddleware.php
+++ b/src/Csrf/src/Middleware/CsrfMiddleware.php
@@ -46,6 +46,7 @@ final class CsrfMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, RequestHandlerInterface $handler): Response
     {
+        $cookie = null;
         if (isset($request->getCookieParams()[$this->config->getCookie()])) {
             $token = $request->getCookieParams()[$this->config->getCookie()];
         } else {

--- a/src/Stempler/src/Lexer/Grammar/Dynamic/DeclareGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/Dynamic/DeclareGrammar.php
@@ -40,6 +40,7 @@ final class DeclareGrammar implements GrammarInterface
      */
     public function parse(Buffer $src): \Generator
     {
+        $quoted = [];
         while ($n = $src->next()) {
             switch ($n->char) {
                 case '"':

--- a/src/Streams/src/StreamWrapper.php
+++ b/src/Streams/src/StreamWrapper.php
@@ -173,7 +173,7 @@ final class StreamWrapper
             return;
         }
 
-        stream_wrapper_register('spiral', __CLASS__);
+        stream_wrapper_register('spiral', self::class);
 
         self::$registered = true;
     }

--- a/src/Tokenizer/src/Reflection/ReflectionFile.php
+++ b/src/Tokenizer/src/Reflection/ReflectionFile.php
@@ -255,7 +255,7 @@ final class ReflectionFile
      */
     protected function importSchema(array $cache)
     {
-        list($this->hasIncludes, $this->declarations, $this->functions, $this->namespaces) = $cache;
+        [$this->hasIncludes, $this->declarations, $this->functions, $this->namespaces] = $cache;
     }
 
     /**
@@ -599,7 +599,7 @@ final class ReflectionFile
         //Nested invocations
         $this->locateInvocations($arguments, $invocationLevel + 1);
 
-        list($class, $operator, $name) = $this->fetchContext($invocationID, $argumentsID);
+        [$class, $operator, $name] = $this->fetchContext($invocationID, $argumentsID);
 
         if (!empty($operator) && empty($class)) {
             //Non detectable
@@ -639,7 +639,7 @@ final class ReflectionFile
         }
 
         if (!empty($operator)) {
-            list($class, $name) = explode($operator, $name);
+            [$class, $name] = explode($operator, $name);
 
             //We now have to clarify class name
             if (in_array($class, ['self', 'static', '$this'])) {

--- a/src/Views/src/Loader/PathParser.php
+++ b/src/Views/src/Loader/PathParser.php
@@ -83,7 +83,7 @@ final class PathParser
         }
 
         if (strpos($filename, LoaderInterface::NS_SEPARATOR) !== false) {
-            list($namespace, $filename) = explode(LoaderInterface::NS_SEPARATOR, $filename);
+            [$namespace, $filename] = explode(LoaderInterface::NS_SEPARATOR, $filename);
         }
 
         //Twig like namespaces


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

This PR apply Rector as part of QA check, start with:

- `LevelSetList::UP_TO_PHP_72` to apply syntax support until php 7.2 per-composer.json
- Only apply to `src/*/src` only (for now)
- Use pinned version `0.12.3` on purpose as it need to sync phpstan and nikic/php-parser, ensure only run when working ok.
- Skip `CountOnNullRector` on purpose as it got too detailed on some cases.
- Using `--dry-run` to show the diff output if there is expected change by rector, to proces, we can run:

```bash
vendor/bin/rector
```