### PR TITLE
Adds support PHP8.1 for Dotenv bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/polyfill-php73": "^1.22",
         "symfony/polyfill-php80": "^1.22",
         "symfony/translation": "^5.1",
-        "vlucas/phpdotenv": "^3.6"
+        "vlucas/phpdotenv": "^5.4"
     },
     "autoload": {
         "files": [
@@ -127,7 +127,6 @@
         "guzzlehttp/psr7": "^1.7",
         "jetbrains/phpstorm-attributes": "^1.0",
         "laminas/laminas-diactoros": "^2.3",
-        "laminas/laminas-hydrator": "^3.0",
         "league/flysystem-async-aws-s3": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "mikey179/vfsstream": "^1.6",

--- a/src/Bridge/Dotenv/composer.json
+++ b/src/Bridge/Dotenv/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.2",
         "spiral/boot": "^2.8",
-        "vlucas/phpdotenv": "^3.6"
+        "vlucas/phpdotenv": "^5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"

--- a/src/Bridge/Dotenv/src/Bootloader/DotenvBootloader.php
+++ b/src/Bridge/Dotenv/src/Bootloader/DotenvBootloader.php
@@ -33,7 +33,7 @@ final class DotenvBootloader extends Bootloader
         $path = dirname($dotenvPath);
         $file = basename($dotenvPath);
 
-        foreach (Dotenv::create($path, $file)->load() as $key => $value) {
+        foreach (Dotenv::createImmutable($path, $file)->load() as $key => $value) {
             $env->set($key, $value);
         }
     }

--- a/src/Bridge/Dotenv/tests/LoadTest.php
+++ b/src/Bridge/Dotenv/tests/LoadTest.php
@@ -29,7 +29,10 @@ class LoadTest extends TestCase
 
     public function testFound()
     {
-        $e = new Environment();
+        $e = new Environment([
+            'KEY' => 'value'
+        ]);
+
         $d = new Directories(['root' => __DIR__]);
 
         $b = new DotenvBootloader();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | https://github.com/spiral/app/issues/46

Dotenv 3.6 doesn't support PHP8.1. This PR increases dotenv version up to  5.4 and adds PHP8.1 support