### PR TITLE
Upping min version of Cycle ORM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "aws/aws-sdk-php": "^3.0",
         "cycle/annotated": "^2.0.6",
         "cycle/migrations": "^1.0.1",
-        "cycle/orm": "^1.2.6",
+        "cycle/orm": "^1.8.1",
         "cycle/proxy-factory": "^1.2",
         "cycle/schema-builder": "^1.1",
         "guzzlehttp/psr7": "^1.7",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌

These changes fix tests on PHP 7.4 with --prefer-lowest composer flag