### PR TITLE
Allows using custom loaders in ViewManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - [spiral/validation] Add array::count, array::range, array::shorter and array::longer rules (#435)
   - [spiral/cache] New component with common interfaces (RR2.0 support)
   - [spiral/queue] New component with common interfaces (RR2.0 support)
+  - [spiral/views] [Allow custom loader in ViewManager](https://github.com/spiral/framework/issues/488)
 
 ## v2.8.0 - 2021-06-03
 

--- a/src/Framework/Bootloader/Views/ViewsBootloader.php
+++ b/src/Framework/Bootloader/Views/ViewsBootloader.php
@@ -18,6 +18,8 @@ use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Views\Engine\Native\NativeEngine;
+use Spiral\Views\LoaderInterface;
+use Spiral\Views\ViewLoader;
 use Spiral\Views\ViewManager;
 use Spiral\Views\ViewsInterface;
 
@@ -25,6 +27,7 @@ final class ViewsBootloader extends Bootloader implements SingletonInterface
 {
     protected const SINGLETONS = [
         ViewsInterface::class => ViewManager::class,
+        LoaderInterface::class => ViewLoader::class,
     ];
 
     /** @var ConfiguratorInterface */

--- a/src/Views/src/ViewLoader.php
+++ b/src/Views/src/ViewLoader.php
@@ -29,10 +29,10 @@ final class ViewLoader implements LoaderInterface
     private $parser;
 
     /** @var array */
-    private $namespaces = [];
+    private $namespaces;
 
     /** @var string */
-    private $defaultNamespace = self::DEFAULT_NAMESPACE;
+    private $defaultNamespace;
 
     public function __construct(
         array $namespaces,

--- a/src/Views/src/ViewManager.php
+++ b/src/Views/src/ViewManager.php
@@ -20,7 +20,7 @@ final class ViewManager implements ViewsInterface
     /** @var ViewsConfig */
     private $config;
 
-    /** @var ViewContext */
+    /** @var ContextInterface */
     private $context;
 
     /** @var LoaderInterface */
@@ -32,11 +32,11 @@ final class ViewManager implements ViewsInterface
     /** @var EngineInterface[] */
     private $engines;
 
-    public function __construct(ViewsConfig $config, FactoryInterface $factory)
+    public function __construct(ViewsConfig $config, FactoryInterface $factory, ?ContextInterface $context = null)
     {
         $this->config = $config;
-        $this->context = new ViewContext();
-        $this->loader = $factory->make(ViewLoader::class, [
+        $this->context = $context ?? new ViewContext();
+        $this->loader = $factory->make(LoaderInterface::class, [
             'namespaces' => $config->getNamespaces(),
         ]);
 

--- a/src/Views/tests/ManagerTest.php
+++ b/src/Views/tests/ManagerTest.php
@@ -17,7 +17,9 @@ use Spiral\Views\Config\ViewsConfig;
 use Spiral\Views\Context\ValueDependency;
 use Spiral\Views\Engine\Native\NativeEngine;
 use Spiral\Views\Exception\ViewException;
+use Spiral\Views\LoaderInterface;
 use Spiral\Views\ViewCache;
+use Spiral\Views\ViewLoader;
 use Spiral\Views\ViewManager;
 
 class ManagerTest extends TestCase
@@ -27,6 +29,7 @@ class ManagerTest extends TestCase
     public function setUp(): void
     {
         $this->container = new Container();
+        $this->container->bindSingleton(LoaderInterface::class, ViewLoader::class);
     }
 
     public function testMultipleEngines(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #488


This PR allows replace view loader with custom realization in ViewManager.


```php
use Spiral\Core\Container\SingletonInterface;
use Spiral\Views\LoaderInterface;

final class ViewsBootloader extends Bootloader implements SingletonInterface
{
    protected const SINGLETONS = [
        LoaderInterface::class => [self::class, 'initDatabaseViewLoader'],
    ];

    public function initDatabaseViewLoader(): LoaderInterface
    {
         return new DatabaseViewLoader(....);
    }
}
```


