### PR TITLE
Adds bootloader registration step.

### DIFF
--- a/src/Boot/src/BootloadManager.php
+++ b/src/Boot/src/BootloadManager.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Boot;
 
+use Closure;
 use Spiral\Boot\Bootloader\BootloaderInterface;
 use Spiral\Boot\Bootloader\DependedInterface;
 use Spiral\Core\Container;
@@ -23,7 +24,7 @@ final class BootloadManager implements Container\SingletonInterface
     /* @var Container @internal */
     protected $container;
 
-    /** @var array */
+    /** @var array<string> */
     private $classes = [];
 
     public function __construct(Container $container)
@@ -48,16 +49,17 @@ final class BootloadManager implements Container\SingletonInterface
      *    CustomizedBootloader::class => ["option" => "value"]
      * ]
      *
-     * @param array $classes
-     *
+     * @param array<int,string>|array<string,array<string,mixed>> $classes
+     * @param array<Closure> $bootingCallbacks
+     * @param array<Closure> $bootedCallbacks
      * @throws \Throwable
      */
-    public function bootload(array $classes): void
+    public function bootload(array $classes, array $bootingCallbacks = [], array $bootedCallbacks = []): void
     {
         $this->container->runScope(
             [self::class => $this],
-            function () use ($classes): void {
-                $this->boot($classes);
+            function () use ($classes, $bootingCallbacks, $bootedCallbacks): void {
+                $this->boot($classes, $bootingCallbacks, $bootedCallbacks);
             }
         );
     }
@@ -65,61 +67,69 @@ final class BootloadManager implements Container\SingletonInterface
     /**
      * Bootloader all given classes.
      *
-     *
      * @throws \Throwable
      */
-    protected function boot(array $classes): void
+    protected function boot(array $classes, array $bootingCallbacks, array $bootedCallbacks): void
     {
+        $bootloaders = [];
+
         foreach ($classes as $class => $options) {
             // default bootload syntax as simple array
-            if (is_string($options)) {
+            if (\is_string($options)) {
                 $class = $options;
                 $options = [];
             }
 
-            if (in_array($class, $this->classes)) {
+            if (\in_array($class, $this->classes, true)) {
                 continue;
             }
 
             $this->classes[] = $class;
             $bootloader = $this->container->get($class);
 
-            if (!$bootloader instanceof BootloaderInterface) {
+            if (! $bootloader instanceof BootloaderInterface) {
                 continue;
             }
 
-            $this->initBootloader($bootloader, $options);
+            $this->initBootloader($bootloader, $bootingCallbacks, $bootedCallbacks);
+            $bootloaders[] = compact('bootloader', 'options');
+
+            $this->invokeBootloader($bootloader, 'register', $options);
         }
+
+        $this->fireCallbacks($bootingCallbacks);
+        foreach ($bootloaders as $data) {
+            $bootloader = $data['bootloader'];
+            $options = $data['options'];
+            $this->invokeBootloader($bootloader, 'boot', $options);
+        }
+        $this->fireCallbacks($bootedCallbacks);
+
+        unset($bootloaders);
     }
 
     /**
-     *
      * @throws \Throwable
      */
-    protected function initBootloader(BootloaderInterface $bootloader, array $options = []): void
-    {
+    protected function initBootloader(
+        BootloaderInterface $bootloader,
+        array $bootingCallbacks,
+        array $bootedCallbacks
+    ): void {
         if ($bootloader instanceof DependedInterface) {
-            $this->boot($bootloader->defineDependencies());
+            $this->boot($bootloader->defineDependencies(), $bootingCallbacks, $bootedCallbacks);
         }
 
-        $this->initBindings($bootloader->defineBindings(), $bootloader->defineSingletons());
-
-        if ((new \ReflectionClass($bootloader))->hasMethod('boot')) {
-            $boot = new \ReflectionMethod($bootloader, 'boot');
-
-            $args = $this->container->resolveArguments($boot, $options);
-            if (!isset($args['boot'])) {
-                $args['boot'] = $options;
-            }
-
-            $boot->invokeArgs($bootloader, \array_values($args));
-        }
+        $this->initBindings(
+            $bootloader->defineBindings(),
+            $bootloader->defineSingletons()
+        );
     }
 
     /**
      * Bind declared bindings.
      */
-    protected function initBindings(array $bindings, array $singletons): void
+    private function initBindings(array $bindings, array $singletons): void
     {
         foreach ($bindings as $aliases => $resolver) {
             $this->container->bind($aliases, $resolver);
@@ -127,6 +137,30 @@ final class BootloadManager implements Container\SingletonInterface
 
         foreach ($singletons as $aliases => $resolver) {
             $this->container->bindSingleton($aliases, $resolver);
+        }
+    }
+
+    private function invokeBootloader(BootloaderInterface $bootloader, string $method, array $options): void
+    {
+        $refl = new \ReflectionClass($bootloader);
+        if (! $refl->hasMethod($method)) {
+            return;
+        }
+
+        $boot = new \ReflectionMethod($bootloader, $method);
+
+        $args = $this->container->resolveArguments($boot);
+        if (! isset($args['boot'])) {
+            $args['boot'] = $options;
+        }
+
+        $boot->invokeArgs($bootloader, \array_values($args));
+    }
+
+    private function fireCallbacks(array $bootingCallbacks): void
+    {
+        foreach ($bootingCallbacks as $callback) {
+            $callback($this->container);
         }
     }
 }

--- a/src/Boot/tests/BootloadersTest.php
+++ b/src/Boot/tests/BootloadersTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Spiral\Boot\BootloadManager;
 use Spiral\Core\Exception\Container\NotFoundException;
 use Spiral\Tests\Boot\Fixtures\SampleBoot;
+use Spiral\Tests\Boot\Fixtures\SampleBootWithRegister;
 use Spiral\Tests\Boot\Fixtures\SampleClass;
 use Spiral\Core\Container;
 
@@ -25,13 +26,30 @@ class BootloadersTest extends TestCase
         $container = new Container();
 
         $bootloader = new BootloadManager($container);
-        $bootloader->bootload([SampleClass::class, SampleBoot::class]);
+        $bootloader->bootload($classes = [
+            SampleClass::class,
+            SampleBoot::class,
+            SampleBootWithRegister::class
+        ], [
+            static function(Container $container) {
+                $container->bind('efg', new SampleBoot());
+            }
+        ], [
+            static function(Container $container) {
+                $container->bind('ghi', new SampleBoot());
+            }
+        ]);
 
         $this->assertTrue($container->has('abc'));
         $this->assertTrue($container->hasInstance('cde'));
+        $this->assertTrue($container->hasInstance('def'));
+        $this->assertTrue($container->hasInstance('efg'));
         $this->assertTrue($container->has('single'));
+        $this->assertTrue($container->has('ghi'));
+        $this->assertNotInstanceOf(SampleBoot::class, $container->get('efg'));
+        $this->assertInstanceOf(SampleBoot::class, $container->get('ghi'));
 
-        $this->assertSame([SampleClass::class, SampleBoot::class], $bootloader->getClasses());
+        $this->assertSame($classes, $bootloader->getClasses());
     }
 
     public function testException(): void

--- a/src/Boot/tests/Fixtures/ConfigBootloader.php
+++ b/src/Boot/tests/Fixtures/ConfigBootloader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Boot\Fixtures;
 
+use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\Bootloader\ConfigurationBootloader;
 use Spiral\Boot\Bootloader\CoreBootloader;
@@ -15,8 +16,42 @@ class ConfigBootloader extends Bootloader
         CoreBootloader::class,
     ];
 
-    public function boot(ConfigurationBootloader $configuration, Container $container): void
+    public function register(Container $container, AbstractKernel $kernel): void
     {
+        $kernel->booting(function (AbstractKernel $kernel) use ($container) {
+            $container->bind('hij', 'foo');
+
+            $kernel->booting(function () use ($container) {
+                $container->bind('ijk', 'foo');
+            });
+        });
+
+        $kernel->booted(function (AbstractKernel $kernel) use ($container) {
+            $container->bind('jkl', 'foo');
+
+            $kernel->booting(function () use ($container) {
+                $container->bind('klm', 'foo');
+            });
+
+            $kernel->booted(function () use ($container) {
+                $container->bind('lmn', 'foo');
+            });
+        });
+
+        $container->bind('efg', 'foo');
+    }
+
+    public function boot(ConfigurationBootloader $configuration, AbstractKernel $kernel, Container $container): void
+    {
+        // won't be executed
+        $kernel->booting(function (AbstractKernel $kernel) use ($container) {
+            $container->bind('ghi', 'foo');
+        });
+
+        $kernel->booted(function (AbstractKernel $kernel) use ($container) {
+            $container->bind('mno', 'foo');
+        });
+
         $configuration->addLoader('yaml', $container->get(TestLoader::class));
     }
 }

--- a/src/Boot/tests/Fixtures/SampleBootWithRegister.php
+++ b/src/Boot/tests/Fixtures/SampleBootWithRegister.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\BinderInterface;
+
+class SampleBootWithRegister extends Bootloader
+{
+    public const BOOT = true;
+
+    public const BINDINGS   = ['abc' => self::class];
+    public const SINGLETONS = ['single' => self::class];
+
+    public function register(BinderInterface $binder): void
+    {
+        $binder->bind('def', new SampleBoot());
+    }
+
+    public function boot(BinderInterface $binder): void
+    {
+        $binder->bind('efg', new SampleClass());
+        $binder->bind('ghi', 'foo');
+    }
+}

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -21,7 +21,6 @@ use Throwable;
 class KernelTest extends TestCase
 {
     /**
-     *
      * @throws Throwable
      */
     public function testKernelException(): void
@@ -103,5 +102,44 @@ class KernelTest extends TestCase
             'VALUE',
             $kernel->getContainer()->get(EnvironmentInterface::class)->get('INTERNAL')
         );
+    }
+
+    public function testBootingCallbacks()
+    {
+        $kernel = TestCore::create([
+            'root' => __DIR__,
+        ]);
+
+        $kernel->booting(static function (TestCore $core) {
+            $core->getContainer()->bind('abc', 'foo');
+        });
+
+        $kernel->booting(static function (TestCore $core) {
+            $core->getContainer()->bind('bcd', 'foo');
+        });
+
+        $kernel->booted( static function (TestCore $core) {
+            $core->getContainer()->bind('cde', 'foo');
+        });
+
+        $kernel->booted( static function (TestCore $core) {
+            $core->getContainer()->bind('def', 'foo');
+        });
+
+        $kernel->run();
+
+        $this->assertTrue($kernel->getContainer()->has('abc'));
+        $this->assertTrue($kernel->getContainer()->has('bcd'));
+        $this->assertTrue($kernel->getContainer()->has('cde'));
+        $this->assertTrue($kernel->getContainer()->has('def'));
+        $this->assertTrue($kernel->getContainer()->has('efg'));
+        $this->assertFalse($kernel->getContainer()->has('fgh'));
+        $this->assertFalse($kernel->getContainer()->has('ghi'));
+        $this->assertTrue($kernel->getContainer()->has('hij'));
+        $this->assertTrue($kernel->getContainer()->has('ijk'));
+        $this->assertTrue($kernel->getContainer()->has('jkl'));
+        $this->assertFalse($kernel->getContainer()->has('klm'));
+        $this->assertTrue($kernel->getContainer()->has('lmn'));
+        $this->assertTrue($kernel->getContainer()->has('mno'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

A bootloader used to have only boot method, but now it has two methods: register and boot.

Within the register method, you should only bind things into the container.

The boot method is called after all other bootloaders have been registered (register method fired for all bootloaders)


Added an ability to create a kernel in two steps:

```php
$app = App::create([
    'root' => dirname(__DIR__),
    //...
]);

// ...

$app->run(new Environment([
     'APP_ENV' => 'production'
]));
```