### PR TITLE
Kernel bootloaders

### DIFF
--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -230,13 +230,23 @@ abstract class AbstractKernel implements KernelInterface
     abstract protected function mapDirectories(array $directories): array;
 
     /**
+     * Get list of defined kernel bootloaders
+     *
+     * @return array<int, class-string>|array<class-string, array<non-empty-string, mixed>>
+     */
+    protected function defineBootloaders(): array
+    {
+        return static::LOAD;
+    }
+
+    /**
      * Bootload all registered classes using BootloadManager.
      */
     private function bootload(): void
     {
         $self = $this;
         $this->bootloader->bootload(
-            static::LOAD,
+            $this->defineBootloaders(),
             [
                 static function () use ($self): void {
                     $self->fireCallbacks($self->startingCallbacks);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

Adds a new `AbstractKernel` method `defineBootloaders` with list of bootloaders to load.

This PR allows to dynamically extend list of bootloaders, that should be bootloaded 
