### PR TITLE
Adds ability to use mailer without queueing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@
     'number::higher' rules were changed to reflect that these checks are in
     fact 'lower or equal' and 'higher or equal'. You may need to adjust
     translations file accordingly.
+  - [spiral/sendit] Added ability to use `sync` driver for mail queue (#398)
 - **Other Features**
-  - [spiral/validation] Add array::count, array::range, array::shorter and array::longer rules (#435)
-  - [spiral/queue] New component with common interfaces (RR2.0 support)
+  - [spiral/validation] Add array::count, array::range, array::shorter and array::longer
+  - [spiral/queue] New component with common interfaces (RR2.0 support) rules (#435)
+  - [spiral/cache] New component with common interfaces (RR2.0 support)
   - [spiral/views] [Allow custom loader in ViewManager](https://github.com/spiral/framework/issues/488)
 
 ## v2.8.0 - 2021-06-03

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -74,7 +74,7 @@ final class MailerBootloader extends Bootloader
             $registry->setSerializer(MailQueue::JOB_NAME, MessageSerializer::class);
             $container->bindSingleton(
                 MailerInterface::class,
-                static function (MailerConfig $config) use($container) {
+                static function (MailerConfig $config) use ($container) {
                     if ($config->getQueueConnection() === 'sync') {
                         $queue = $container->get(ShortCircuit::class);
                     } else {

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -84,12 +84,7 @@ final class MailerBootloader extends Bootloader
                     return new MailQueue($config, $queue);
                 }
             );
-        }
-
-        if ($container->has(HandlerRegistryInterface::class)) {
-            $registry = $container->get(HandlerRegistryInterface::class);
-            $registry->setHandler(MailQueue::JOB_NAME, MailJob::class);
-
+        } else {
             $container->bindSingleton(
                 MailerInterface::class,
                 static function (MailerConfig $config, QueueConnectionProviderInterface $provider) {
@@ -99,6 +94,11 @@ final class MailerBootloader extends Bootloader
                     );
                 }
             );
+        }
+
+        if ($container->has(HandlerRegistryInterface::class)) {
+            $registry = $container->get(HandlerRegistryInterface::class);
+            $registry->setHandler(MailQueue::JOB_NAME, MailJob::class);
         }
     }
 

--- a/src/SendIt/src/Config/MailerConfig.php
+++ b/src/SendIt/src/Config/MailerConfig.php
@@ -19,9 +19,10 @@ final class MailerConfig extends InjectableConfig
 
     /** @var array */
     protected $config = [
-        'dsn'      => '',
-        'from'     => '',
+        'dsn' => '',
+        'from' => '',
         'pipeline' => '',
+        'queueConnection' => null,
     ];
 
     public function getDSN(): string
@@ -37,5 +38,10 @@ final class MailerConfig extends InjectableConfig
     public function getQueuePipeline(): string
     {
         return $this->config['pipeline'];
+    }
+
+    public function getQueueConnection(): ?string
+    {
+        return $this->config['queueConnection'] ?? null;
     }
 }

--- a/src/SendIt/tests/ConfigTest.php
+++ b/src/SendIt/tests/ConfigTest.php
@@ -19,13 +19,21 @@ class ConfigTest extends TestCase
     public function testConfig(): void
     {
         $cfg = new MailerConfig([
-            'dsn'      => 'mailer-dsn',
-            'from'     => 'admin@spiral.dev',
-            'pipeline' => 'emails'
+            'dsn' => 'mailer-dsn',
+            'from' => 'admin@spiral.dev',
+            'pipeline' => 'emails',
+            'queueConnection' => 'foo',
         ]);
 
         $this->assertSame('mailer-dsn', $cfg->getDSN());
         $this->assertSame('admin@spiral.dev', $cfg->getFromAddress());
         $this->assertSame('emails', $cfg->getQueuePipeline());
+        $this->assertSame('foo', $cfg->getQueueConnection());
+    }
+
+    public function testGetsQueueConnectionWithoutKey(): void
+    {
+        $cfg = new MailerConfig();
+        $this->assertNull($cfg->getQueueConnection());
     }
 }

--- a/src/SendIt/tests/JobsQueueTest.php
+++ b/src/SendIt/tests/JobsQueueTest.php
@@ -6,14 +6,14 @@ namespace Spiral\Tests\SendIt;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Spiral\Jobs\Options;
+use Spiral\Jobs\QueueInterface;
 use Spiral\Mailer\Message;
-use Spiral\Queue\Options;
-use Spiral\Queue\QueueInterface;
 use Spiral\SendIt\Config\MailerConfig;
 use Spiral\SendIt\MailQueue;
 use Spiral\SendIt\MessageSerializer;
 
-class QueueTest extends TestCase
+class JobsQueueTest extends TestCase
 {
     public function testQueue(): void
     {
@@ -36,7 +36,7 @@ class QueueTest extends TestCase
             function ($job, $data, Options $options) use ($mail) {
                 $this->assertSame(MailQueue::JOB_NAME, $job);
                 $this->assertSame($data, MessageSerializer::pack($mail));
-                $this->assertSame('mailer', $options->getQueue());
+                $this->assertSame('mailer', $options->getPipeline());
 
                 return true;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #398

```php
// config mailer.php

return [
    'dsn' => '...',
    'from' => '...',
    'pipeline' => '...', // won't be used for sync queue
    'queueConnection' => 'sync', // use sync queue
];
```