### PR TITLE
Fix http bootloader

### DIFF
--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Bootloader\Http;
 
+use Composer\InstalledVersions;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -25,8 +26,8 @@ use Spiral\Http\Config\HttpConfig;
 use Spiral\Http\Emitter\SapiEmitter;
 use Spiral\Http\EmitterInterface;
 use Spiral\Http\Http;
-use Spiral\Http\Pipeline;
 use Spiral\Http\LegacyRrDispatcher;
+use Spiral\Http\Pipeline;
 use Spiral\Http\RrDispatcher;
 use Spiral\Http\SapiDispatcher;
 use Spiral\RoadRunner\Http\PSR7Worker;
@@ -64,7 +65,7 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
     public function boot(KernelInterface $kernel, FactoryInterface $factory): void
     {
         $this->config->setDefaults(
-            'http',
+            HttpConfig::class,
             [
                 'basePath'   => '/',
                 'headers'    => [
@@ -76,12 +77,14 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
 
         $kernel->addDispatcher($factory->make(SapiDispatcher::class));
 
-        if (class_exists(PSR7Client::class)) {
-            $kernel->addDispatcher($factory->make(LegacyRrDispatcher::class));
-        }
+        if (! InstalledVersions::isInstalled('spiral/roadrunner-bridge')) {
+            if (class_exists(PSR7Client::class)) {
+                $kernel->addDispatcher($factory->make(LegacyRrDispatcher::class));
+            }
 
-        if (class_exists(PSR7Worker::class)) {
-            $kernel->addDispatcher($factory->make(RrDispatcher::class));
+            if (class_exists(PSR7Worker::class)) {
+                $kernel->addDispatcher($factory->make(RrDispatcher::class));
+            }
         }
     }
 

--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -65,7 +65,7 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
     public function boot(KernelInterface $kernel, FactoryInterface $factory): void
     {
         $this->config->setDefaults(
-            HttpConfig::class,
+            HttpConfig::CONFIG,
             [
                 'basePath'   => '/',
                 'headers'    => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

Don't register old http roadrunner dispatchers when roadrunner bridge installed.