### PR TITLE
Fixes problem with invoking `start` method where bootloader has dependencies

### DIFF
--- a/src/Boot/src/BootloadManager.php
+++ b/src/Boot/src/BootloadManager.php
@@ -123,7 +123,7 @@ final class BootloadManager implements Container\SingletonInterface
             yield from $this->initBootloader($bootloader);
             $this->invokeBootloader($bootloader, 'boot', $options);
 
-            yield \compact('bootloader', 'options');
+            yield $class => \compact('bootloader', 'options');
         }
     }
 

--- a/src/Boot/tests/BootloadersTest.php
+++ b/src/Boot/tests/BootloadersTest.php
@@ -13,6 +13,8 @@ namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Boot\BootloadManager;
+use Spiral\Tests\Boot\Fixtures\BootloaderA;
+use Spiral\Tests\Boot\Fixtures\BootloaderB;
 use Spiral\Tests\Boot\Fixtures\SampleBoot;
 use Spiral\Tests\Boot\Fixtures\SampleBootWithStarted;
 use Spiral\Tests\Boot\Fixtures\SampleClass;
@@ -27,8 +29,8 @@ class BootloadersTest extends TestCase
         $bootloader = new BootloadManager($container);
         $bootloader->bootload($classes = [
             SampleClass::class,
-            SampleBoot::class,
-            SampleBootWithStarted::class
+            SampleBootWithStarted::class,
+            SampleBoot::class
         ], [
             static function(Container $container) {
                 $container->bind('efg', new SampleBoot());
@@ -48,7 +50,10 @@ class BootloadersTest extends TestCase
         $this->assertNotInstanceOf(SampleBoot::class, $container->get('efg'));
         $this->assertInstanceOf(SampleBoot::class, $container->get('ghi'));
 
-        $this->assertSame($classes, $bootloader->getClasses());
+        $this->assertSame(array_merge($classes, [
+            BootloaderA::class,
+            BootloaderB::class,
+        ]), $bootloader->getClasses());
     }
 
     public function testException(): void

--- a/src/Boot/tests/Fixtures/SampleBoot.php
+++ b/src/Boot/tests/Fixtures/SampleBoot.php
@@ -20,6 +20,10 @@ class SampleBoot extends Bootloader
 
     public const BINDINGS   = ['abc' => self::class];
     public const SINGLETONS = ['single' => self::class];
+    public const DEPENDENCIES = [
+        BootloaderA::class,
+        BootloaderB::class,
+    ];
 
     public function boot(BinderInterface $binder): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | #535