### PR TITLE
Fixes problem with `Class "Composer\InstalledVersions" not found`

### DIFF
--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -81,7 +81,7 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
             $kernel->addDispatcher($factory->make(SapiDispatcher::class));
         });
 
-        if (! InstalledVersions::isInstalled('spiral/roadrunner-bridge')) {
+        if (! class_exists('Spiral\RoadRunnerBridge\Http\Dispatcher')) {
             if (class_exists(PSR7Client::class)) {
                 $kernel->addDispatcher($factory->make(LegacyRrDispatcher::class));
             }


### PR DESCRIPTION
Replaces `InstalledVersions::isInstalled('spiral/roadrunner-bridge')` with `class_exists('Spiral\RoadRunnerBridge\Http\Dispatcher')`

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌