### PR TITLE
Fix installer downloader url

### DIFF
--- a/bin/spiral
+++ b/bin/spiral
@@ -127,7 +127,7 @@ class RRHelper
             $ext = '.tar.gz';
         }
 
-        return 'https://github.com/spiral/framework/releases/download/v'
+        return 'https://github.com/spiral/framework/releases/download/'
             . static::getVersion() . '/' . self::getSignature()
             . $ext;
     }


### PR DESCRIPTION
Currently github has urls like `*download/2.9.0/*` Instead of  `*download/v2.9.0/*` (v prefix for version not required).
This was causing installation failure when running 
composer create-project spiral/app spiral-test

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->
