### PR TITLE
Adds session factory interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,18 @@
 ## v2.10.0 - Unreleased
 - **High Impact Changes**
 - **Medium Impact Changes**
-  - Console commands `Spiral\Scaffolder\Command\MigrationCommand`, `Spiral\Scaffolder\Command\Database\RepositoryCommand`, 
+  - [spiral/session] Added `Spiral\Session\SessionFactoryInterface`. Now you can use custom implementation of sessions.
+  - [spiral/scaffolder] Console commands `Spiral\Scaffolder\Command\MigrationCommand`, `Spiral\Scaffolder\Command\Database\RepositoryCommand`, 
     `Spiral\Scaffolder\Command\Database\EntityCommand` is deprecated. Will be moved to `spiral/cycle-bridge` and removed in v3.0
-  - Scaffolder `Spiral\Scaffolder\Declaration\MigrationDeclaration` is deprecated. Will be moved to `spiral/cycle-bridge`
+  - [spiral/scaffolder] Scaffolder `Spiral\Scaffolder\Declaration\MigrationDeclaration` is deprecated. Will be moved to `spiral/cycle-bridge`
     and removed in v3.0
+  - [spiral/attributes] Class annotations will be discovered from class traits.
   - A minimal version of `PHP` increased to `^7.4`
 - **Other Features**
+  - [spiral/prototype] Added `queue` and `cache` properties
   - [spiral/mailer] Added ability to set delay for messages
   - [spiral/queue] Added NullDriver
-  - Class `Spiral\Mailer\Message` is no longer final and is available for extension
+  - [spiral/mailer] Class `Spiral\Mailer\Message` is no longer final and is available for extension
 
 ## v2.9.1 - 2022-02-11
 - **High Impact Changes**

--- a/src/Framework/Bootloader/Http/SessionBootloader.php
+++ b/src/Framework/Bootloader/Http/SessionBootloader.php
@@ -62,7 +62,7 @@ final class SessionBootloader extends Bootloader
                 'handler' => new Autowire(
                     FileHandler::class,
                     [
-                        'directory' => $directories->get('runtime').'session',
+                        'directory' => $directories->get('runtime') . 'session',
                         'lifetime' => 86400,
                     ]
                 ),

--- a/src/Framework/Bootloader/Http/SessionBootloader.php
+++ b/src/Framework/Bootloader/Http/SessionBootloader.php
@@ -17,14 +17,18 @@ use Spiral\Config\ConfiguratorInterface;
 use Spiral\Core\Container\Autowire;
 use Spiral\Session\Handler\FileHandler;
 use Spiral\Session\Middleware\SessionMiddleware;
-
-//use Spiral\Session\SectionInterface;
+use Spiral\Session\SessionFactory;
+use Spiral\Session\SessionFactoryInterface;
 
 final class SessionBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         HttpBootloader::class,
         CookiesBootloader::class,
+    ];
+
+    protected const SINGLETONS = [
+        SessionFactoryInterface::class => SessionFactory::class,
     ];
 
     /** @var ConfiguratorInterface */
@@ -41,11 +45,6 @@ final class SessionBootloader extends Bootloader
     /**
      * Automatically registers session starter middleware and excludes session cookie from
      * cookie protection.
-     *
-     * @param ConfiguratorInterface $config
-     * @param CookiesBootloader     $cookies
-     * @param HttpBootloader        $http
-     * @param DirectoriesInterface  $directories
      */
     public function boot(
         ConfiguratorInterface $config,
@@ -57,14 +56,14 @@ final class SessionBootloader extends Bootloader
             'session',
             [
                 'lifetime' => 86400,
-                'cookie'   => 'sid',
-                'secure'   => true,
+                'cookie' => 'sid',
+                'secure' => true,
                 'sameSite' => null,
-                'handler'  => new Autowire(
+                'handler' => new Autowire(
                     FileHandler::class,
                     [
-                        'directory' => $directories->get('runtime') . 'session',
-                        'lifetime'  => 86400,
+                        'directory' => $directories->get('runtime').'session',
+                        'lifetime' => 86400,
                     ]
                 ),
             ]

--- a/src/Framework/Session/Middleware/SessionMiddleware.php
+++ b/src/Framework/Session/Middleware/SessionMiddleware.php
@@ -22,6 +22,7 @@ use Spiral\Core\ScopeInterface;
 use Spiral\Http\Config\HttpConfig;
 use Spiral\Session\Config\SessionConfig;
 use Spiral\Session\SessionFactory;
+use Spiral\Session\SessionFactoryInterface;
 use Spiral\Session\SessionInterface;
 
 final class SessionMiddleware implements MiddlewareInterface
@@ -47,18 +48,11 @@ final class SessionMiddleware implements MiddlewareInterface
     /** @var ScopeInterface */
     private $scope;
 
-    /**
-     * @param SessionConfig  $config
-     * @param HttpConfig     $httpConfig
-     * @param CookiesConfig  $cookiesConfig
-     * @param SessionFactory $factory
-     * @param ScopeInterface $scope
-     */
     public function __construct(
         SessionConfig $config,
         HttpConfig $httpConfig,
         CookiesConfig $cookiesConfig,
-        SessionFactory $factory,
+        SessionFactoryInterface $factory,
         ScopeInterface $scope
     ) {
         $this->config = $config;
@@ -144,12 +138,10 @@ final class SessionMiddleware implements MiddlewareInterface
      */
     protected function withCookie(Request $request, Response $response, string $id = null): Response
     {
-        $response = $response->withAddedHeader(
+        return $response->withAddedHeader(
             'Set-Cookie',
             $this->sessionCookie($request->getUri(), $id)->createHeader()
         );
-
-        return $response;
     }
 
     /**

--- a/src/Session/src/SessionFactory.php
+++ b/src/Session/src/SessionFactory.php
@@ -21,7 +21,7 @@ use Spiral\Session\Exception\SessionException;
 /**
  * Initiates session instance and configures session handlers.
  */
-final class SessionFactory implements SingletonInterface
+final class SessionFactory implements SessionFactoryInterface, SingletonInterface
 {
     /** @var SessionConfig */
     private $config;
@@ -35,19 +35,13 @@ final class SessionFactory implements SingletonInterface
         $this->factory = $factory;
     }
 
-    /**
-     * @param string      $clientSignature User specific token, does not provide full security but
-     *                                     hardens session transfer.
-     * @param string|null $id              When null - expect php to create session automatically.
-     *
-     */
     public function initSession(string $clientSignature, string $id = null): SessionInterface
     {
         if (session_status() === PHP_SESSION_ACTIVE) {
             throw new MultipleSessionException('Unable to initiate session, session already started');
         }
 
-        //Initiating proper session handler
+        // Initiating proper session handler
         if ($this->config->getHandler() !== null) {
             try {
                 $handler = $this->config->getHandler()->resolve($this->factory);
@@ -60,8 +54,8 @@ final class SessionFactory implements SingletonInterface
 
         return $this->factory->make(Session::class, [
             'clientSignature' => $clientSignature,
-            'lifetime'        => $this->config->getLifetime(),
-            'id'              => $id,
+            'lifetime' => $this->config->getLifetime(),
+            'id' => $id,
         ]);
     }
 }

--- a/src/Session/src/SessionFactoryInterface.php
+++ b/src/Session/src/SessionFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Session;
+
+interface SessionFactoryInterface
+{
+    /**
+     * @param string $clientSignature User specific token, does not provide full security but
+     *                                     hardens session transfer.
+     * @param string|null $id When null - expect php to create session automatically.
+     */
+    public function initSession(string $clientSignature, string $id = null): SessionInterface;
+}


### PR DESCRIPTION
fixes #580

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️ 
| Issues        | #580 

This PR adds an ability to replace current SessionFactory via SessionFactoryInterface with custom realization


```php
$container->bindSingleton(\Spiral\Session\SessionFactoryInterface::class, CustomSessionFactory::class);
```