### PR TITLE
Add Symfony 6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - [spiral/sendit] Method `getQueuePipeline` of `Spiral\SendIt\Config\MailerConfig` class is deprecated.
     Use method `getQueue` instead. Added environment variables `MAILER_QUEUE` and `MAILER_QUEUE_CONNECTION`
 - **Other Features**
+  - Added Symfony 6 support
 
 ## v2.9.0 - 2022-02-03
 

--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,12 @@
         "psr/log": "^1.0",
         "psr/simple-cache": "1 - 2",
         "spiral/composer-publish-plugin": "^1.0",
-        "symfony/console": "^5.3",
-        "symfony/finder": "^5.1",
-        "symfony/mailer": "^5.1",
+        "symfony/console": "^5.3|^6.0",
+        "symfony/finder": "^5.1|^6.0",
+        "symfony/mailer": "^5.1|^6.0",
         "symfony/polyfill-php73": "^1.22",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/translation": "^5.1",
+        "symfony/translation": "^5.1|^6.0",
         "vlucas/phpdotenv": "^5.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,7 @@
         "spiral/migrations": "^2.3",
         "spiral/php-grpc": "^1.4",
         "spiral/roadrunner": "^1.9.2",
-        "symfony/var-dumper": "^5.2",
+        "symfony/var-dumper": "^5.2|^6.0",
         "symplify/monorepo-builder": "^8.3",
         "vimeo/psalm": "^4.3"
     },

--- a/src/Attributes/composer.json
+++ b/src/Attributes/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.12",
         "jetbrains/phpstorm-attributes": "^1.0",
-        "symfony/var-dumper": "^5.2",
+        "symfony/var-dumper": "^5.2|^6.0",
         "phpunit/phpunit": "^8.5|^9.5"
     },
     "autoload": {

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.2",
         "spiral/core": "^2.9",
-        "symfony/console": "^5.3"
+        "symfony/console": "^5.3|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5",

--- a/src/Distribution/composer.json
+++ b/src/Distribution/composer.json
@@ -28,7 +28,7 @@
         "aws/aws-sdk-php": "^3.0",
         "guzzlehttp/psr7": "^1.7",
         "jetbrains/phpstorm-attributes": "^1.0",
-        "symfony/var-dumper": "^5.2",
+        "symfony/var-dumper": "^5.2|^6.0",
         "phpunit/phpunit": "^8.5|^9.5"
     },
     "autoload-dev": {

--- a/src/SendIt/composer.json
+++ b/src/SendIt/composer.json
@@ -23,7 +23,7 @@
         "spiral/logger": "^2.9",
         "spiral/mailer": "^2.9",
         "spiral/views": "^2.9",
-        "symfony/mailer": "^5.1"
+        "symfony/mailer": "^5.1|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5",

--- a/src/Storage/composer.json
+++ b/src/Storage/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5",
-        "symfony/var-dumper": "^5.2",
+        "symfony/var-dumper": "^5.2|^6.0",
         "vimeo/psalm": "^4.3",
         "jetbrains/phpstorm-attributes": "^1.0"
     },

--- a/src/Tokenizer/composer.json
+++ b/src/Tokenizer/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.2",
         "spiral/core": "^2.9",
         "spiral/logger": "^2.9",
-        "symfony/finder": "^5.1"
+        "symfony/finder": "^5.1|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5"

--- a/src/Translator/composer.json
+++ b/src/Translator/composer.json
@@ -19,7 +19,7 @@
         "spiral/core": "^2.9",
         "spiral/logger": "^2.9",
         "spiral/tokenizer": "^2.9",
-        "symfony/translation": "^5.1"
+        "symfony/translation": "^5.1|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5",

--- a/src/Translator/src/Translator.php
+++ b/src/Translator/src/Translator.php
@@ -94,7 +94,7 @@ final class Translator implements TranslatorInterface, SingletonInterface
      *
      * @throws LocaleException
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans(string $id, array $parameters = [], $domain = null, $locale = null): string
     {
         $domain = $domain ?? $this->config->getDefaultDomain();
         $locale = $locale ?? $this->locale;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | 
| Docs PR       | 

This pull request adds support for Symfony 6 components.

Also, I have updated `Translator::trans(...)` method with adding a return type for compatibility with `symfony/translation-contracts:^3.0.0`'s `TranslatorInterface` (https://github.com/symfony/translation-contracts/commit/529f21f126e6c696e1129435357180c1db882dc0#diff-3daf67a6c84ebcbad65c9c7f16852754ba584904519c443a5ab1bbe756242d00R66)