### PR TITLE
AliasTrait circle reference protection

### DIFF
--- a/src/Core/src/Traits/Config/AliasTrait.php
+++ b/src/Core/src/Traits/Config/AliasTrait.php
@@ -20,7 +20,13 @@ trait AliasTrait
 {
     public function resolveAlias(string $alias): string
     {
+        $antiCircleReference = [];
         while (is_string($alias) && isset($this->config) && isset($this->config['aliases'][$alias])) {
+            if (in_array($alias, $antiCircleReference)) {
+                throw new \LogicException("Circle reference detected for alias `$alias`");
+            }
+            $antiCircleReference[] = $alias;
+
             $alias = $this->config['aliases'][$alias];
         }
 

--- a/src/Core/tests/InjectableConfigTest.php
+++ b/src/Core/tests/InjectableConfigTest.php
@@ -132,4 +132,20 @@ class InjectableConfigTest extends TestCase
         $this->assertEquals('test', $this->resolveAlias('default'));
         $this->assertEquals('test', $this->resolveAlias('value'));
     }
+
+    public function testCircleReference(): void
+    {
+        self::expectException(\LogicException::class);
+        self::expectExceptionMessage('Circle reference detected for alias `foo`');
+
+        $config = new TestConfig([
+            'key' => 'value',
+            'aliases' => [
+                'foo' => 'bar',
+                'bar' => 'foo'
+            ]
+        ]);
+
+        $config->resolveAlias('foo');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

I've faced with infinity loop in databases aliases
