### PR TITLE
remove `final` from MailerBootloader

### DIFF
--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -35,7 +35,7 @@ use Symfony\Component\Mailer\Transport;
 /**
  * Enables email sending pipeline.
  */
-final class MailerBootloader extends Bootloader
+class MailerBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         JobsBootloader::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #353 partially <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->

As mentioned in https://github.com/spiral/framework/issues/353 it's hard to customize framework.
In my case I need to add extra transport factory to mailer. This fix will helps me a lot
