### PR TITLE
Feature/console refactoring

### DIFF
--- a/src/Console/src/Bootloader/ConsoleBootloader.php
+++ b/src/Console/src/Bootloader/ConsoleBootloader.php
@@ -52,8 +52,7 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
             ConsoleConfig::CONFIG,
             [
                 'commands' => [],
-                'configure' => [],
-                'update' => [],
+                'sequences' => [],
             ]
         );
 
@@ -82,10 +81,7 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
         string $footer = '',
         array $options = []
     ): void {
-        $this->config->modify(
-            ConsoleConfig::CONFIG,
-            $this->sequence('configure', $sequence, $header, $footer, $options)
-        );
+        $this->addSequence('configure', $sequence, $header, $footer, $options);
     }
 
     public function addUpdateSequence(
@@ -94,9 +90,19 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
         string $footer = '',
         array $options = []
     ): void {
+        $this->addSequence('update', $sequence, $header, $footer, $options);
+    }
+
+    public function addSequence(
+        string $name,
+        string|array|\Closure $sequence,
+        string $header,
+        string $footer = '',
+        array $options = []
+    ): void {
         $this->config->modify(
             ConsoleConfig::CONFIG,
-            $this->sequence('update', $sequence, $header, $footer, $options)
+            $this->sequence('sequences.'.$name, $sequence, $header, $footer, $options)
         );
     }
 

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -65,6 +65,9 @@ abstract class Command extends SymfonyCommand
         }
     }
 
+    /**
+     * @deprecated
+     */
     private function confirmToPerform(): bool
     {
         $definition = $this->getConfirmationDefinition();
@@ -142,6 +145,9 @@ abstract class Command extends SymfonyCommand
         return static::ARGUMENTS;
     }
 
+    /**
+     * @deprecated
+     */
     protected function getConfirmationDefinition(): ?ConfirmationDefinitionInterface
     {
         return null;

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -65,30 +65,6 @@ abstract class Command extends SymfonyCommand
         }
     }
 
-    private function confirmToPerform(): bool
-    {
-        $definition = $this->getConfirmationDefinition();
-        if ($definition === null || !$definition->shouldBeConfirmed()) {
-            return true;
-        }
-
-        if ($this->hasOption('force') && $this->option('force')) {
-            return true;
-        }
-
-        $this->alert($definition->getWarningMessage());
-
-        $confirmed = $this->confirm(\sprintf('Do you really wish to run command [%s]?', $this->getName()));
-
-        if (! $confirmed) {
-            $this->comment('Command Canceled!');
-
-            return false;
-        }
-
-        return true;
-    }
-
     /**
      * Configures the command.
      */
@@ -145,5 +121,29 @@ abstract class Command extends SymfonyCommand
     protected function getConfirmationDefinition(): ?ConfirmationDefinitionInterface
     {
         return null;
+    }
+
+    private function confirmToPerform(): bool
+    {
+        $definition = $this->getConfirmationDefinition();
+        if ($definition === null || !$definition->shouldBeConfirmed()) {
+            return true;
+        }
+
+        if ($this->hasOption('force') && $this->option('force')) {
+            return true;
+        }
+
+        $this->alert($definition->getWarningMessage());
+
+        $confirmed = $this->confirm(\sprintf('Do you really wish to run command [%s]?', $this->getName()));
+
+        if (!$confirmed) {
+            $this->comment('Command Canceled!');
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -118,11 +118,17 @@ abstract class Command extends SymfonyCommand
         return static::ARGUMENTS;
     }
 
+    /**
+     * @deprecated will be replaced with attributes
+     */
     protected function getConfirmationDefinition(): ?ConfirmationDefinitionInterface
     {
         return null;
     }
 
+    /**
+     * Will be redesigned in the future for using attributes with different types of confirmation.
+     */
     private function confirmToPerform(): bool
     {
         $definition = $this->getConfirmationDefinition();

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Spiral\Console;
 
 use Psr\Container\ContainerInterface;
+use Spiral\Console\Signature\Parser;
 use Spiral\Console\Traits\HelpersTrait;
 use Spiral\Core\Exception\ScopeException;
-use Spiral\Core\ResolverInterface;
+use Spiral\Core\InvokerInterface;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,18 +20,15 @@ abstract class Command extends SymfonyCommand
 {
     use HelpersTrait;
 
-    // Command name.
+    /** Command name. */
     protected const NAME = '';
-
-    //  Short command description.
-    protected const DESCRIPTION = '';
-
-    // Command options specified in Symfony format. For more complex definitions redefine
-    // getOptions() method.
+    /** Short command description. */
+    protected const DESCRIPTION = null;
+    /** Command signature. */
+    protected const SIGNATURE = null;
+    /** Command options specified in Symfony format. For more complex definitions redefine getOptions() method. */
     protected const OPTIONS = [];
-
-    // Command arguments specified in Symfony format. For more complex definitions redefine
-    // getArguments() method.
+    /** Command arguments specified in Symfony format. For more complex definitions redefine getArguments() method. */
     protected const ARGUMENTS = [];
 
     protected ?ContainerInterface $container = null;
@@ -49,21 +47,46 @@ abstract class Command extends SymfonyCommand
             throw new ScopeException('Container is not set');
         }
 
-        $reflection = new \ReflectionMethod($this, 'perform');
+        $method = method_exists($this, 'perform') ? 'perform' : '__invoke';
 
-        $resolver = $this->container->get(ResolverInterface::class);
+        $invoker = $this->container->get(InvokerInterface::class);
 
         try {
             [$this->input, $this->output] = [$input, $output];
 
-            //Executing perform method with method injection
-            return (int)$reflection->invokeArgs($this, $resolver->resolveArguments(
-                $reflection,
-                \compact('input', 'output')
-            ));
+            if (! $this->confirmToPerform()) {
+                return Command::FAILURE;
+            }
+
+            // Executing perform method with method injection
+            return (int)$invoker->invoke([$this, $method], \compact('input', 'output'));
         } finally {
             [$this->input, $this->output] = [null, null];
         }
+    }
+
+    private function confirmToPerform(): bool
+    {
+        $definition = $this->getConfirmationDefinition();
+        if ($definition === null || !$definition->shouldBeConfirmed()) {
+            return true;
+        }
+
+        if ($this->hasOption('force') && $this->option('force')) {
+            return true;
+        }
+
+        $this->alert($definition->getWarningMessage());
+
+        $confirmed = $this->confirm(\sprintf('Do you really wish to run command [%s]?', $this->getName()));
+
+        if (! $confirmed) {
+            $this->comment('Command Canceled!');
+
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -71,8 +94,13 @@ abstract class Command extends SymfonyCommand
      */
     protected function configure(): void
     {
-        $this->setName(static::NAME);
-        $this->setDescription(static::DESCRIPTION);
+        if (static::SIGNATURE !== null) {
+            $this->configureViaSignature((string)static::SIGNATURE);
+        } else {
+            $this->setName(static::NAME);
+        }
+
+        $this->setDescription((string)static::DESCRIPTION);
 
         foreach ($this->defineOptions() as $option) {
             \call_user_func_array([$this, 'addOption'], $option);
@@ -80,6 +108,21 @@ abstract class Command extends SymfonyCommand
 
         foreach ($this->defineArguments() as $argument) {
             \call_user_func_array([$this, 'addArgument'], $argument);
+        }
+    }
+
+    protected function configureViaSignature(string $signature): void
+    {
+        $result = (new Parser())->parse($signature);
+
+        $this->setName($result->name);
+
+        foreach ($result->options as $option) {
+            $this->getDefinition()->addOption($option);
+        }
+
+        foreach ($result->arguments as $argument) {
+            $this->getDefinition()->addArgument($argument);
         }
     }
 
@@ -97,5 +140,10 @@ abstract class Command extends SymfonyCommand
     protected function defineArguments(): array
     {
         return static::ARGUMENTS;
+    }
+
+    protected function getConfirmationDefinition(): ?ConfirmationDefinitionInterface
+    {
+        return null;
     }
 }

--- a/src/Console/src/Command/ConfigureCommand.php
+++ b/src/Console/src/Command/ConfigureCommand.php
@@ -9,12 +9,13 @@ use Spiral\Console\Config\ConsoleConfig;
 
 final class ConfigureCommand extends SequenceCommand
 {
-    protected const NAME        = 'configure';
+    protected const NAME = 'configure';
     protected const DESCRIPTION = 'Configure project';
 
     public function perform(ConsoleConfig $config, ContainerInterface $container): int
     {
-        $this->writeln("<info>Configuring project:</info>\n");
+        $this->info("Configuring project:");
+        $this->newLine();
 
         return $this->runSequence($config->configureSequence(), $container);
     }

--- a/src/Console/src/Command/SequenceCommand.php
+++ b/src/Console/src/Command/SequenceCommand.php
@@ -31,19 +31,20 @@ abstract class SequenceCommand extends Command
                 $sequence->writeFooter($this->output);
             } catch (Throwable $e) {
                 $errors++;
-                $this->sprintf("<error>%s</error>\n", $e);
-                if (!$this->option('ignore') && $this->option('break')) {
-                    $this->writeln('<fg=red>Aborting.</fg=red>');
+                $this->error((string)$e);
+
+                if (! $this->option('ignore') && $this->option('break')) {
+                    $this->error('Aborting.');
 
                     return self::FAILURE;
                 }
             }
 
-            $this->writeln('');
+            $this->newLine();
         }
 
-        $this->writeln('<info>All done!</info>');
+        $this->info('All done!');
 
-        return ($errors && !$this->option('ignore')) ? self::FAILURE : self::SUCCESS;
+        return ($errors && ! $this->option('ignore')) ? self::FAILURE : self::SUCCESS;
     }
 }

--- a/src/Console/src/Command/UpdateCommand.php
+++ b/src/Console/src/Command/UpdateCommand.php
@@ -9,12 +9,13 @@ use Spiral\Console\Config\ConsoleConfig;
 
 final class UpdateCommand extends SequenceCommand
 {
-    protected const NAME        = 'update';
+    protected const NAME = 'update';
     protected const DESCRIPTION = 'Update project state';
 
     public function perform(ConsoleConfig $config, ContainerInterface $container): int
     {
-        $this->writeln("<info>Updating project state:</info>\n");
+        $this->info('Updating project state:');
+        $this->newLine();
 
         return $this->runSequence($config->updateSequence(), $container);
     }

--- a/src/Console/src/ConfirmationDefinitionInterface.php
+++ b/src/Console/src/ConfirmationDefinitionInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Console;
 
+/**
+ * @deprecated
+ */
 interface ConfirmationDefinitionInterface
 {
     public function shouldBeConfirmed(): bool;

--- a/src/Console/src/ConfirmationDefinitionInterface.php
+++ b/src/Console/src/ConfirmationDefinitionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Console;
+
+interface ConfirmationDefinitionInterface
+{
+    public function shouldBeConfirmed(): bool;
+    public function getWarningMessage(): string;
+}

--- a/src/Console/src/Signature/Parser.php
+++ b/src/Console/src/Signature/Parser.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Console\Signature;
+
+use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Console signature parser.
+ * @internal
+ */
+final class Parser
+{
+    /**
+     * Parse the given console command definition into an array.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function parse(string $signature): Result
+    {
+        $name = $this->parseName($signature);
+
+        if (\preg_match_all('/\{\s*(.*?)\s*\}/', $signature, $matches)) {
+            if (\count($matches[1])) {
+                return new Result($name, ...$this->parseParameters($matches[1]));
+            }
+        }
+
+        return new Result($name);
+    }
+
+    /**
+     * Extract the name of the command from the expression.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function parseName(string $signature): string
+    {
+        if (! \preg_match('/\S+/', $signature, $matches)) {
+            throw new InvalidArgumentException('Unable to determine command name from signature.');
+        }
+
+        return $matches[0];
+    }
+
+    /**
+     * Extract all the parameters from the tokens.
+     *
+     * @return array{0: InputArgument[], 1: InputOption[]}
+     */
+    private function parseParameters(array $tokens): array
+    {
+        $arguments = [];
+        $options = [];
+
+        foreach ($tokens as $token) {
+            if (\preg_match('/-{2,}(.*)/', $token, $matches)) {
+                $options[] = $this->parseOption($matches[1]);
+            } else {
+                $arguments[] = $this->parseArgument($token);
+            }
+        }
+
+        return [$arguments, $options];
+    }
+
+    /**
+     * Parse an argument expression.
+     */
+    private function parseArgument(string $token): InputArgument
+    {
+        [$token, $description] = $this->extractDescription($token);
+
+        return match (true) {
+            \str_ends_with($token, '[]?') => new InputArgument(
+                \rtrim($token, '[]?'),
+                InputArgument::IS_ARRAY,
+                $description
+            ),
+            \str_ends_with($token, '[]') => new InputArgument(
+                \rtrim($token, '[]'),
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                $description
+            ),
+            \str_ends_with($token, '?') => new InputArgument(
+                \rtrim($token, '?'),
+                InputArgument::OPTIONAL,
+                $description
+            ),
+            (bool)\preg_match('/(.+)\[\]\=(.+)/', $token, $matches) => new InputArgument(
+                $matches[1],
+                InputArgument::IS_ARRAY,
+                $description,
+                \preg_split('/,\s?/', $matches[2])
+            ),
+            (bool)\preg_match('/(.+)\=(.+)?/', $token, $matches) => new InputArgument(
+                $matches[1],
+                InputArgument::OPTIONAL,
+                $description,
+                $matches[2] ?? null
+            ),
+            default => new InputArgument(
+                $token,
+                InputArgument::REQUIRED,
+                $description
+            ),
+        };
+    }
+
+    /**
+     * Parse an option expression.
+     */
+    private function parseOption(string $token): InputOption
+    {
+        [$token, $description] = $this->extractDescription($token);
+
+        $matches = \preg_split('/\s*\|\s*/', $token, 2);
+        $shortcut = null;
+
+        if (isset($matches[1])) {
+            [$shortcut, $token] = $matches;
+        }
+
+        return match (true) {
+            \str_ends_with($token, '[]=') => new InputOption(
+                \rtrim($token, '[]='),
+                $shortcut,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                $description
+            ),
+            \str_ends_with($token, '=') => new InputOption(
+                \rtrim($token, '='),
+                $shortcut,
+                InputOption::VALUE_OPTIONAL,
+                $description
+            ),
+            (bool)\preg_match('/(.+)\[\]\=(.+)/', $token, $matches) => new InputOption(
+                $matches[1],
+                $shortcut,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                $description,
+                \preg_split('/,\s?/', $matches[2])
+            ),
+            (bool)\preg_match('/(.+)\=(.+)/', $token, $matches) => new InputOption(
+                $matches[1],
+                $shortcut,
+                InputOption::VALUE_OPTIONAL,
+                $description,
+                $matches[2]
+            ),
+            default => new InputOption(
+                $token,
+                $shortcut,
+                InputOption::VALUE_NONE,
+                $description
+            ),
+        };
+    }
+
+    /**
+     * Parse the token into its token and description segments.
+     *
+     * @return array{
+     *     0: non-empty-string,
+     *     1: string
+     * }
+     */
+    private function extractDescription(string $token): array
+    {
+        $token = \trim($token);
+
+        $parts = \array_map('trim', \explode(':', $token, 2));
+
+        return \count($parts) === 2 ? $parts : [$token, ''];
+    }
+}

--- a/src/Console/src/Signature/Result.php
+++ b/src/Console/src/Signature/Result.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Console\Signature;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+final class Result
+{
+    public function __construct(
+        /** @var non-empty-string*/
+        public readonly string $name,
+        /** @var InputArgument[] */
+        public readonly array $arguments = [],
+        /** @var InputOption[] */
+        public readonly array $options = [],
+    ) {
+    }
+}

--- a/src/Console/src/StaticLocator.php
+++ b/src/Console/src/StaticLocator.php
@@ -17,15 +17,23 @@ final class StaticLocator implements LocatorInterface
      * @param array<array-key, class-string<SymfonyCommand>> $commands
      */
     public function __construct(
-        private array $commands,
+        private readonly array $commands,
         private ContainerInterface $container = new Container()
     ) {
     }
 
+    /**
+     * @return SymfonyCommand[]
+     */
     public function locateCommands(): array
     {
         $commands = [];
         foreach ($this->commands as $command) {
+            if ($command instanceof SymfonyCommand) {
+                $commands[] = $command;
+                continue;
+            }
+
             $commands[] = $this->supportsLazyLoading($command)
                 ? $this->createLazyCommand($command)
                 : $this->container->get($command);

--- a/src/Console/src/Traits/LazyTrait.php
+++ b/src/Console/src/Traits/LazyTrait.php
@@ -21,7 +21,7 @@ trait LazyTrait
     private function supportsLazyLoading(string $class): bool
     {
         return \is_subclass_of($class, SpiralCommand::class)
-            && \defined(sprintf('%s::%s', $class, 'NAME'));
+            && \defined(\sprintf('%s::%s', $class, 'NAME'));
     }
 
     /**

--- a/src/Console/tests/ConfigTest.php
+++ b/src/Console/tests/ConfigTest.php
@@ -22,8 +22,10 @@ class ConfigTest extends TestCase
         $this->expectException(ConfigException::class);
 
         $config = new ConsoleConfig([
-            'updateSequence' => [
-                [],
+            'sequences' => [
+                'update' => [
+                    []
+                ],
             ],
         ]);
 
@@ -33,8 +35,10 @@ class ConfigTest extends TestCase
     public function testForcedSequence(): void
     {
         $config = new ConsoleConfig([
-            'updateSequence' => [
-                new CallableSequence('test'),
+            'sequences' => [
+                'update' => [
+                    new CallableSequence('test'),
+                ],
             ],
         ]);
 

--- a/src/Console/tests/ConfigureTest.php
+++ b/src/Console/tests/ConfigureTest.php
@@ -24,20 +24,22 @@ use Throwable;
 class ConfigureTest extends BaseTest
 {
     public const TOKENIZER_CONFIG = [
-        'directories' => [__DIR__ . '/../src/Command', __DIR__ . '/Fixtures/'],
-        'exclude'     => []
+        'directories' => [__DIR__.'/../src/Command', __DIR__.'/Fixtures/'],
+        'exclude' => [],
     ];
 
     public const CONFIG = [
         'locateCommands' => false,
-        'configure'      => [
-            ['command' => 'test', 'header' => 'Test Command'],
-            ['command' => 'helper', 'options' => ['helper' => 'writeln'], 'footer' => 'Good!'],
-            ['invoke' => [self::class, 'do']],
-            ['invoke' => self::class . '::do'],
-            'Spiral\Tests\Console\ok',
-            ['invoke' => self::class . '::err'],
-        ]
+        'sequences' => [
+            'configure' => [
+                ['command' => 'test', 'header' => 'Test Command'],
+                ['command' => 'helper', 'options' => ['helper' => 'writeln'], 'footer' => 'Good!'],
+                ['invoke' => [self::class, 'do']],
+                ['invoke' => self::class.'::do'],
+                'Spiral\Tests\Console\ok',
+                ['invoke' => self::class.'::err'],
+            ],
+        ],
     ];
 
     /**
@@ -45,11 +47,14 @@ class ConfigureTest extends BaseTest
      */
     public function testConfigure(): void
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class,
-            ConfigureCommand::class,
-            TestCommand::class
-        ]));
+        $core = $this->getCore(
+            new StaticLocator([
+                HelperCommand::class,
+                ConfigureCommand::class,
+                TestCommand::class,
+            ])
+        );
+
         $this->container->bind(Console::class, $core);
 
         $actual = $core->run('configure')->getOutput()->fetch();
@@ -141,20 +146,27 @@ class ConfigureTest extends BaseTest
      */
     private function bindFailure(): Console
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class,
-            ConfigureCommand::class,
-            TestCommand::class,
-            FailedCommand::class,
-            AnotherFailedCommand::class,
-        ]));
-        $this->container->bind(ConsoleConfig::class, new ConsoleConfig([
-            'locateCommands' => false,
-            'configure'      => [
-                ['command' => 'failed', 'header' => 'Failed Command'],
-                ['command' => 'failed:another', 'header' => 'Another failed Command'],
-            ]
-        ]));
+        $core = $this->getCore(
+            new StaticLocator([
+                HelperCommand::class,
+                ConfigureCommand::class,
+                TestCommand::class,
+                FailedCommand::class,
+                AnotherFailedCommand::class,
+            ])
+        );
+        $this->container->bind(
+            ConsoleConfig::class,
+            new ConsoleConfig([
+                'locateCommands' => false,
+                'sequences' => [
+                    'configure' => [
+                        ['command' => 'failed', 'header' => 'Failed Command'],
+                        ['command' => 'failed:another', 'header' => 'Another failed Command'],
+                    ],
+                ]
+            ])
+        );
         $this->container->bind(Console::class, $core);
 
         return $core;

--- a/src/Console/tests/Fixtures/TestCommand.php
+++ b/src/Console/tests/Fixtures/TestCommand.php
@@ -15,13 +15,13 @@ use Spiral\Core\Container\SingletonInterface;
 
 class TestCommand extends Command implements SingletonInterface
 {
-    public const NAME        = 'test';
+    public const NAME = 'test';
     public const DESCRIPTION = 'Test Command';
 
     private $count = 0;
 
     public function perform(): void
     {
-        $this->write('Hello World - ' . ($this->count++));
+        $this->write('Hello World - '.($this->count++));
     }
 }

--- a/src/Console/tests/HelpersTest.php
+++ b/src/Console/tests/HelpersTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
@@ -17,74 +11,70 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class HelpersTest extends BaseTest
 {
-    public function testVerbose(): void
+    private \Spiral\Console\Console $core;
+
+    public function setUp(): void
     {
-        $core = $this->getCore(new StaticLocator([
+        parent::setUp();
+
+        $this->core = $this->getCore(new StaticLocator([
             HelperCommand::class
         ]));
+    }
 
-        $actual = $core->run('helper', ['helper' => 'verbose'])
+    public function testVerbose(): void
+    {
+        $actual = $this->core->run('helper', ['helper' => 'verbose'])
             ->getOutput()
             ->fetch();
+        
         $this->assertSame('false', $actual);
 
         $output = new BufferedOutput();
         $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-        $actual = $core->run('helper', ['helper' => 'verbose', '-v' => true], $output)
+        $actual = $this->core->run('helper', ['helper' => 'verbose', '-v' => true], $output)
             ->getOutput()
             ->fetch();
 
         $this->assertSame('true', $actual);
     }
 
-    public function testSprinf(): void
+    public function testSprintf(): void
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class
-        ]));
-
         $this->assertStringContainsString(
             'hello world',
-            $core->run('helper', ['helper' => 'sprintf'])->getOutput()->fetch()
+            $this->core->run('helper', ['helper' => 'sprintf'])->getOutput()->fetch()
         );
     }
 
     public function testWriteln(): void
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class
-        ]));
-
         $this->assertStringContainsString(
             "\n",
-            $core->run('helper', ['helper' => 'writeln'])->getOutput()->fetch()
+            $this->core->run('helper', ['helper' => 'writeln'])->getOutput()->fetch()
         );
     }
 
     public function testTable(): void
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class
-        ]));
-
         $this->assertStringContainsString(
             'id',
-            $core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
+            $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
         );
 
         $this->assertStringContainsString(
             'value',
-            $core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
+            $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
         );
 
         $this->assertStringContainsString(
             '1',
-            $core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
+            $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
         );
 
         $this->assertStringContainsString(
             'true',
-            $core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
+            $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch()
         );
     }
 }

--- a/src/Console/tests/OptionsTest.php
+++ b/src/Console/tests/OptionsTest.php
@@ -23,17 +23,17 @@ class OptionsTest extends BaseTest
 
         $this->assertSame(
             'no option',
-            $core->run('optional')->getOutput()->fetch()
+            $core->run(command: 'optional')->getOutput()->fetch()
         );
 
         $this->assertSame(
             'hello',
-            $core->run('optional', ['-o' => true, 'arg' => 'hello'])->getOutput()->fetch()
+            $core->run(command: 'optional', input: ['-o' => true, 'arg' => 'hello'])->getOutput()->fetch()
         );
 
         $this->assertSame(
             0,
-            $core->run('optional', ['-o' => true, 'arg' => 'hello'])->getCode()
+            $core->run(command: 'optional', input: ['-o' => true, 'arg' => 'hello'])->getCode()
         );
     }
 }

--- a/src/Console/tests/Signature/ParserTest.php
+++ b/src/Console/tests/Signature/ParserTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Console\Signature;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Console\Signature\Parser;
+
+final class ParserTest extends TestCase
+{
+    private Parser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new Parser();
+    }
+
+    public function testParse(): void
+    {
+        // Only name
+        $result = $this->parser->parse('foo:bar');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame([], $result->options);
+    }
+
+    public function testParseArgument(): void
+    {
+        // Name with argument
+        $result = $this->parser->parse('foo:bar {baz}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertTrue($result->arguments[0]->isRequired());
+        $this->assertSame([], $result->options);
+
+        // Name with not required argument
+        $result = $this->parser->parse('foo:bar {baz?}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertFalse($result->arguments[0]->isRequired());
+        $this->assertSame([], $result->options);
+
+        // Name with not required argument with default value
+        $result = $this->parser->parse('foo:bar {baz=baf}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertSame('baf', $result->arguments[0]->getDefault());
+        $this->assertFalse($result->arguments[0]->isRequired());
+        $this->assertSame([], $result->options);
+
+        // Name with not required argument with default value and description
+        $result = $this->parser->parse('foo:bar { baz=baf : Argument description. }');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertSame('baf', $result->arguments[0]->getDefault());
+        $this->assertSame('Argument description.', $result->arguments[0]->getDescription());
+        $this->assertFalse($result->arguments[0]->isRequired());
+        $this->assertSame([], $result->options);
+
+        // Name with not required argument with nullable default value and description
+        $result = $this->parser->parse('foo:bar { baz= : Argument description. }');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertNull($result->arguments[0]->getDefault());
+        $this->assertSame('Argument description.', $result->arguments[0]->getDescription());
+        $this->assertFalse($result->arguments[0]->isRequired());
+        $this->assertSame([], $result->options);
+
+        // Name with argument with required array
+        $result = $this->parser->parse('foo:bar {baz[]}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertTrue($result->arguments[0]->isRequired());
+        $this->assertTrue($result->arguments[0]->isArray());
+        $this->assertSame([], $result->options);
+
+        // Name with argument with not required array
+        $result = $this->parser->parse('foo:bar {baz[]?}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertFalse($result->arguments[0]->isRequired());
+        $this->assertTrue($result->arguments[0]->isArray());
+        $this->assertSame([], $result->options);
+
+        // Name with argument with not required array and description
+        $result = $this->parser->parse('foo:bar {baz[]? : Argument description. }');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baz', $result->arguments[0]->getName());
+        $this->assertFalse($result->arguments[0]->isRequired());
+        $this->assertTrue($result->arguments[0]->isArray());
+        $this->assertSame('Argument description.', $result->arguments[0]->getDescription());
+        $this->assertSame([], $result->options);
+    }
+
+    public function testParseOption(): void
+    {
+        $result = $this->parser->parse('foo:bar {--baz}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertFalse($result->options[0]->acceptValue());
+
+        // Parse option with acceptable value
+        $result = $this->parser->parse('foo:bar {--baz=}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertFalse($result->options[0]->isArray());
+
+        // Parse option with shortcut
+        $result = $this->parser->parse('foo:bar {--o|baz=}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertSame('o', $result->options[0]->getShortcut());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertFalse($result->options[0]->isArray());
+
+        // Parse option with acceptable array
+        $result = $this->parser->parse('foo:bar {--baz[]=}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertTrue($result->options[0]->isArray());
+
+        // Parse option with acceptable array with shortcut
+        $result = $this->parser->parse('foo:bar {--b|baz[]=}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('b', $result->options[0]->getShortcut());
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertTrue($result->options[0]->isArray());
+
+        // Parse option with description
+        $result = $this->parser->parse('foo:bar {--baz : Option description.}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertFalse($result->options[0]->acceptValue());
+        $this->assertSame('Option description.', $result->options[0]->getDescription());
+
+        // Parse option with description with shortcut
+        $result = $this->parser->parse('foo:bar {--b|baz : Option description.}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('b', $result->options[0]->getShortcut());
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertFalse($result->options[0]->acceptValue());
+        $this->assertSame('Option description.', $result->options[0]->getDescription());
+
+        // Parse option with acceptable value and description
+        $result = $this->parser->parse('foo:bar {--baz= : Option description.}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertNull($result->options[0]->getDefault());
+        $this->assertSame('Option description.', $result->options[0]->getDescription());
+
+        // Parse option with default value and description
+        $result = $this->parser->parse('foo:bar {--baz=defaultValue : Option description.}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame([], $result->arguments);
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertSame('defaultValue', $result->options[0]->getDefault());
+        $this->assertSame('Option description.', $result->options[0]->getDescription());
+    }
+
+    public function testParseWithArgumentAndOption(): void
+    {
+        $result = $this->parser->parse('foo:bar {baf} {--baz}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baf', $result->arguments[0]->getName());
+        $this->assertTrue($result->arguments[0]->isRequired());
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertFalse($result->options[0]->acceptValue());
+
+        // Parse option and argument with description
+        $result = $this->parser->parse('foo:bar {baf:Argument description.} {--baz : Option description.}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baf', $result->arguments[0]->getName());
+        $this->assertTrue($result->arguments[0]->isRequired());
+        $this->assertSame('Argument description.', $result->arguments[0]->getDescription());
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertFalse($result->options[0]->acceptValue());
+        $this->assertSame('Option description.', $result->options[0]->getDescription());
+
+        // Parse option with shortcut and argument with description
+        $result = $this->parser->parse('foo:bar {baf:Argument description.} {--b|baz : Option description.}');
+
+        $this->assertSame('foo:bar', $result->name);
+        $this->assertSame('baf', $result->arguments[0]->getName());
+        $this->assertTrue($result->arguments[0]->isRequired());
+        $this->assertSame('Argument description.', $result->arguments[0]->getDescription());
+        $this->assertSame('b', $result->options[0]->getShortcut());
+        $this->assertSame('baz', $result->options[0]->getName());
+        $this->assertFalse($result->options[0]->acceptValue());
+        $this->assertSame('Option description.', $result->options[0]->getDescription());
+    }
+}

--- a/src/Console/tests/SignatureTest.php
+++ b/src/Console/tests/SignatureTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Console;
+
+use Spiral\Console\Command;
+use Spiral\Console\StaticLocator;
+use Symfony\Component\Console\Input\StringInput;
+
+final class SignatureTest extends BaseTest
+{
+    public function testOptions(): void
+    {
+        $core = $this->getCore(
+            new StaticLocator([
+                new class extends Command {
+                    protected const SIGNATURE = 'foo:bar {arg?} {--o|option}';
+
+                    public function perform(): int
+                    {
+                        $argument = $this->argument('arg');
+                        $option = $this->option('option');
+
+                        if ($argument) {
+                            $this->write('argument : '.$argument);
+                        }
+
+                        if ($option) {
+                            $this->write('option : '.$option);
+                        }
+
+                        return 1;
+                    }
+                },
+            ])
+        );
+
+        $this->assertSame(
+            '',
+            $core->run(command: 'foo:bar')->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'argument : baz',
+            $core->run(command: 'foo:bar', input: ['arg' => 'baz'])->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'option : baz',
+            $core->run(command: 'foo:bar', input: ['-o' => 'baz'])->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'option : baz',
+            $core->run(command: 'foo:bar', input: ['--option' => 'baz'])->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'argument : bazoption : baf',
+            $core->run(command: 'foo:bar', input: ['arg' => 'baz', '-o' => 'baf'])->getOutput()->fetch()
+        );
+    }
+
+    public function testArrayableOptions(): void
+    {
+        $core = $this->getCore(
+            new StaticLocator([
+                new class extends Command {
+                    protected const SIGNATURE = 'foo:bar {arg[]?} {--o|option[]=}';
+
+                    public function perform(): int
+                    {
+                        $argument = (array) $this->argument('arg');
+                        $option = (array) $this->option('option');
+
+                        if ($argument) {
+                            $this->write('argument : '.\implode(',', $argument));
+                        }
+
+                        if ($option) {
+                            $this->write('option : '.\implode(',', $option));
+                        }
+
+                        return 1;
+                    }
+                },
+            ])
+        );
+
+        $this->assertSame(
+            '',
+            $core->run(command: 'foo:bar')->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'argument : bar,baz,bak',
+            $core->run(command: 'foo:bar', input: new StringInput('foo:bar bar baz bak'))->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'option : far,faz',
+            $core->run(command: 'foo:bar', input: new StringInput('foo:bar -ofar --option=faz'))->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'option : baz',
+            $core->run(command: 'foo:bar', input: ['--option' => 'baz'])->getOutput()->fetch()
+        );
+
+        $this->assertSame(
+            'argument : bar,baz,bakoption : far,faz',
+            $core->run(command: 'foo:bar', input: new StringInput('foo:bar bar baz bak -ofar --option=faz'))->getOutput()->fetch()
+        );
+    }
+
+    public function testDescription(): void
+    {
+        $core = $this->getCore(
+            new StaticLocator([
+                new class extends Command {
+                    protected const SIGNATURE = 'foo:bar 
+                                    {foo : Foo arg description. }  
+                                    {bar=default : Bar arg description. } 
+                                    {baz[]? : Baz arg description. } 
+                                    {--o|id[]= : Id option description. }
+                                    {--Q|quit : Quit option description. }
+                                    {--naf=default : Naf option description. }
+                    ';
+
+                    public function perform(): int
+                    {
+                        return 1;
+                    }
+                },
+            ])
+        );
+
+        $this->assertSame(
+            <<<'HELP'
+Usage:
+  foo:bar [options] [--] <foo> [<bar> [<baz>...]]
+
+Arguments:
+  foo                   Foo arg description.
+  bar                   Bar arg description. [default: "default"]
+  baz                   Baz arg description.
+
+Options:
+  -o, --id[=ID]         Id option description. (multiple values allowed)
+  -Q, --quit            Quit option description.
+      --naf[=NAF]       Naf option description. [default: "default"]
+  -h, --help            Display help for the given command. When no command is given display help for the list command
+  -q, --quiet           Do not output any message
+  -V, --version         Display this application version
+      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction  Do not ask any interactive question
+  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+HELP
+,
+            $core->run(command: 'help', input: ['command_name' => 'foo:bar'])->getOutput()->fetch()
+        );
+    }
+}

--- a/src/Console/tests/UpdateTest.php
+++ b/src/Console/tests/UpdateTest.php
@@ -24,30 +24,34 @@ use Throwable;
 class UpdateTest extends BaseTest
 {
     public const TOKENIZER_CONFIG = [
-        'directories' => [__DIR__ . '/../src/Command', __DIR__ . '/Fixtures/'],
-        'exclude'     => []
+        'directories' => [__DIR__.'/../src/Command', __DIR__.'/Fixtures/'],
+        'exclude' => [],
     ];
 
     public const CONFIG = [
         'locateCommands' => false,
-        'commands'       => [],
-        'update'         => [
-            ['command' => 'test', 'header' => 'Test Command'],
-            ['command' => 'helper', 'options' => ['helper' => 'writeln'], 'footer' => 'Good!'],
-            ['invoke' => [self::class, 'do']],
-            ['invoke' => self::class . '::do'],
-            'Spiral\Tests\Console\ok',
-            ['invoke' => self::class . '::err'],
-        ]
+        'commands' => [],
+        'sequences' => [
+            'update' => [
+                ['command' => 'test', 'header' => 'Test Command'],
+                ['command' => 'helper', 'options' => ['helper' => 'writeln'], 'footer' => 'Good!'],
+                ['invoke' => [self::class, 'do']],
+                ['invoke' => self::class.'::do'],
+                'Spiral\Tests\Console\ok',
+                ['invoke' => self::class.'::err'],
+            ],
+        ],
     ];
 
     public function testConfigure(): void
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class,
-            TestCommand::class,
-            UpdateCommand::class
-        ]));
+        $core = $this->getCore(
+            new StaticLocator([
+                HelperCommand::class,
+                TestCommand::class,
+                UpdateCommand::class,
+            ])
+        );
 
         $this->container->bind(Console::class, $core);
 
@@ -140,21 +144,28 @@ text;
      */
     private function bindFailure(): Console
     {
-        $core = $this->getCore(new StaticLocator([
-            HelperCommand::class,
-            TestCommand::class,
-            UpdateCommand::class,
-            FailedCommand::class,
-            AnotherFailedCommand::class,
-        ]));
-        $this->container->bind(ConsoleConfig::class, new ConsoleConfig([
-            'locateCommands' => false,
-            'commands'       => [],
-            'update'         => [
-                ['command' => 'failed', 'header' => 'Failed Command'],
-                ['command' => 'failed:another', 'header' => 'Another failed Command'],
-            ]
-        ]));
+        $core = $this->getCore(
+            new StaticLocator([
+                HelperCommand::class,
+                TestCommand::class,
+                UpdateCommand::class,
+                FailedCommand::class,
+                AnotherFailedCommand::class,
+            ])
+        );
+        $this->container->bind(
+            ConsoleConfig::class,
+            new ConsoleConfig([
+                'locateCommands' => false,
+                'commands' => [],
+                'sequences' => [
+                    'update' => [
+                        ['command' => 'failed', 'header' => 'Failed Command'],
+                        ['command' => 'failed:another', 'header' => 'Another failed Command'],
+                    ],
+                ],
+            ])
+        );
         $this->container->bind(Console::class, $core);
 
         return $core;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️
| New feature?  | ✔️
| Issues        | #507 

--------

- [ ] Attributes for confirmation
- [ ] Event dispatcher for sequences

--------

#### Adds console signature

```php
class CheckHttpCommand extends Command 
{
      protected const SIGNATURE = 'check:http
                                                  {url : Site url} 
                                                  {--S|skip-ssl-errors : Skip SSL errors}';

      public function perform(): int
      {
             $url = $this->argument('url');
             $skipErrors = $this->option('skip-ssl-errors');

             // ...
      }
}
```

#### Adds ability to use `__invoke` method instead of `perform`

```php
class CheckHttpCommand extends Command 
{
       // ...

      public function __invoke(): int
      {
             // ...
      }
}
```


#### Adds more sugar methods

```php
class SomeCommand extends Command 
{
       // ...

      public function perform(): int
      {
             // Determine if the input option is present.
             $this->hasOption(...);

             // Determine if the input argument is present.
             $this->hasArgument(...);

             // Asks for confirmation.
            $status = $this->confirm('Are you sure?', default: false): bool;

            // Asks a question.
            $status = $this->ask('Are you sure?', default: 'no'): mixed;

            // Prompt the user for input but hide the answer from the console.
            $status = $this->secret('User password'): string;

            // Writes a message as information output.
             $this->info(...);

            // Writes a message as comment output.
             $this->comment(...);

            // Writes a message as question output.
             $this->question(...);

            // Writes a message as error output.
             $this->error(...);

            // Writes a message as warning output.
             $this->warning(...);

            // Writes a message as alert output.
             $this->alert(...);

            // Writes a message as standard output.
             $this->line(..., 'error');

            // Writes a blank line.
             $this->newLine();

             $this->newLine(count: 5);
      }
}
```

#### Adds ability to use Confirmation for console commands based on definition

```php
use Spiral\Console\ConfirmationDefinitionInterface;
use Spiral\Boot\EnvironmentInterface;

class CheckHttpCommand extends Command 
{
       // ...

      public function getConfirmationDefinition(): ?ConfirmationDefinitionInterface
      {
             $env = $this->container->get(EnvironmentInterface::class);

             return new class($env) implements ConfirmationDefinitionInterface
             {
                     public function __construnct(
                            private EnvironmentInterface $env
                     ) {}

                     public function shouldBeConfirmed(): bool
                     {
                              return $this->env->get('APP_ENV') === 'production';
                     }

                     public function getWarningMessage(): string
                     {
                             return 'Application In Production!';
                     }
             };
      }
}
```

#### Adds named sequences

```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Console\Bootloader\ConsoleBootloader;

class AssetsBootloader extends Bootloader
{
    public function init(ConsoleBootloader $console): void
    {
           $console->addSequence('publish:assets', PublishCSSFilesCommand::class);
           $console->addSequence('publish:assets', PublishJavascriptFilesCommand::class);
    }

}
```

```php
use Spiral\Console\Command\SequenceCommand;
use Psr\Container\ContainerInterface;
use Spiral\Console\Config\ConsoleConfig;

class PublishAssetsCommand extends SequenceCommand
{
      public function perform(ConsoleConfig $config, ContainerInterface $container): int
      {
            $this->info("Publishing assets:");
            $this->newLine();

            return $this->runSequence($config->getSequence('publish:assets'), $container);
      }
}
```