### PR TITLE
Adds EnumInjector for enums

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -26,6 +26,8 @@
             <errorLevel type="suppress">
                 <file name="src/Attributes/src/Psr16CachedReader.php"/>
                 <file name="src/Attributes/src/Psr6CachedReader.php"/>
+                <referencedClass name="Psr\Container\NotFoundExceptionInterface"/>
+                <referencedClass name="Psr\Container\ContainerExceptionInterface"/>
             </errorLevel>
         </InvalidThrow>
     </issueHandlers>

--- a/src/Boot/src/Environment/AppEnvironment.php
+++ b/src/Boot/src/Environment/AppEnvironment.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Environment;
+
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Boot\Injector\ProvideFrom;
+use Spiral\Boot\Injector\InjectableEnumInterface;
+
+#[ProvideFrom(method: 'detect')]
+enum AppEnvironment: string implements InjectableEnumInterface
+{
+    case Production = 'prod';
+    case Stage = 'stage';
+    case Testing = 'testing';
+    case Local = 'local';
+
+    public function isProduction(): bool
+    {
+        return $this === self::Production;
+    }
+
+    public function isTesting(): bool
+    {
+        return $this === self::Testing;
+    }
+
+    public function isLocal(): bool
+    {
+        return $this === self::Local;
+    }
+
+    public function isStage(): bool
+    {
+        return $this === self::Stage;
+    }
+
+    public static function detect(EnvironmentInterface $environment): self
+    {
+        $value = $environment->get('APP_ENV');
+
+        return \is_string($value)
+            ? (self::tryFrom($value) ?? self::Local)
+            : self::Local;
+    }
+}

--- a/src/Boot/src/Environment/AppEnvironment.php
+++ b/src/Boot/src/Environment/AppEnvironment.php
@@ -9,7 +9,7 @@ use Spiral\Boot\Injector\ProvideFrom;
 use Spiral\Boot\Injector\InjectableEnumInterface;
 
 #[ProvideFrom(method: 'detect')]
-enum AppEnvironment: string implements InjectableEnumInterface
+enum AppEnvironment : string implements InjectableEnumInterface
 {
     case Production = 'prod';
     case Stage = 'stage';

--- a/src/Boot/src/Environment/DebugMode.php
+++ b/src/Boot/src/Environment/DebugMode.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Environment;
+
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Boot\Injector\ProvideFrom;
+use Spiral\Boot\Injector\InjectableEnumInterface;
+
+#[ProvideFrom(method: 'detect')]
+enum DebugMode implements InjectableEnumInterface
+{
+    case Enabled;
+    case Disabled;
+
+    public function isEnabled(): bool
+    {
+        return $this === self::Enabled;
+    }
+
+    public static function detect(EnvironmentInterface $environment): self
+    {
+        return filter_var($environment->get('DEBUG'), FILTER_VALIDATE_BOOL) ? self::Enabled : self::Disabled;
+    }
+}

--- a/src/Boot/src/Environment/DebugMode.php
+++ b/src/Boot/src/Environment/DebugMode.php
@@ -21,6 +21,6 @@ enum DebugMode implements InjectableEnumInterface
 
     public static function detect(EnvironmentInterface $environment): self
     {
-        return filter_var($environment->get('DEBUG'), FILTER_VALIDATE_BOOL) ? self::Enabled : self::Disabled;
+        return \filter_var($environment->get('DEBUG'), \FILTER_VALIDATE_BOOL) ? self::Enabled : self::Disabled;
     }
 }

--- a/src/Boot/src/Injector/EnumInjector.php
+++ b/src/Boot/src/Injector/EnumInjector.php
@@ -26,7 +26,7 @@ final class EnumInjector implements InjectorInterface
         if (!$attribute) {
             throw new ContainerException(
                 \sprintf(
-                    'Class `%s` should contain %s attribute with defined detector method.',
+                    'Class `%s` should contain `%s` attribute with defined detector method.',
                     $class->getName(),
                     ProvideFrom::class
                 )
@@ -36,7 +36,7 @@ final class EnumInjector implements InjectorInterface
         if (!$class->isEnum()) {
             throw new ContainerException(
                 \sprintf(
-                    'Class `%s` should be an enum class.',
+                    'Class `%s` should be an enum.',
                     $class->getName()
                 )
             );

--- a/src/Boot/src/Injector/EnumInjector.php
+++ b/src/Boot/src/Injector/EnumInjector.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Injector;
+
+use Spiral\Attributes\AttributeReader;
+use Spiral\Core\Container;
+use Spiral\Core\Container\InjectorInterface;
+use Spiral\Core\Exception\Container\ContainerException;
+
+/**
+ * @internal
+ */
+final class EnumInjector implements InjectorInterface
+{
+    public function __construct(
+        private readonly Container $container,
+        private readonly AttributeReader $reader
+    ) {
+    }
+
+    public function createInjection(\ReflectionClass $class, string $context = null): object
+    {
+        $attribute = $this->reader->firstClassMetadata($class, ProvideFrom::class);
+        if (! $attribute) {
+            throw new ContainerException(
+                \sprintf(
+                    'Class `%s` should contain %s attribute with defined detector method.',
+                    $class->getName(),
+                    ProvideFrom::class
+                )
+            );
+        }
+
+        if (! $class->isEnum()) {
+            throw new ContainerException(
+                \sprintf(
+                    'Class `%s` should be an enum class.',
+                    $class->getName()
+                )
+            );
+        }
+
+        $object = $this->container->invoke(
+            $class->getMethod($attribute->method)->getClosure()
+        );
+
+        $this->container->bind($class->getName(), $object);
+
+        return $object;
+    }
+}

--- a/src/Boot/src/Injector/EnumInjector.php
+++ b/src/Boot/src/Injector/EnumInjector.php
@@ -33,14 +33,7 @@ final class EnumInjector implements InjectorInterface
             );
         }
 
-        if (!$class->isEnum()) {
-            throw new InjectionException(
-                \sprintf(
-                    'Class `%s` should be an enum.',
-                    $class->getName()
-                )
-            );
-        }
+        $this->validateClass($class, $attribute);
 
         $object = $this->container->invoke(
             $class->getMethod($attribute->method)->getClosure()
@@ -49,5 +42,40 @@ final class EnumInjector implements InjectorInterface
         $this->container->bind($class->getName(), $object);
 
         return $object;
+    }
+
+    /**
+     * @throws InjectionException
+     */
+    private function validateClass(\ReflectionClass $class, ProvideFrom $attribute): void
+    {
+        if (! $class->isEnum()) {
+            throw new InjectionException(
+                \sprintf(
+                    'Class `%s` should be an enum.',
+                    $class->getName()
+                )
+            );
+        }
+
+        if (! $class->hasMethod($attribute->method)) {
+            throw new InjectionException(
+                \sprintf(
+                    'Class `%s` does not contain `%s` method.',
+                    $class->getName(),
+                    $attribute->method
+                )
+            );
+        }
+
+        if (! $class->getMethod($attribute->method)->isStatic()) {
+            throw new InjectionException(
+                \sprintf(
+                    'Class method `%s::%s` should be static.',
+                    $class->getName(),
+                    $attribute->method
+                )
+            );
+        }
     }
 }

--- a/src/Boot/src/Injector/EnumInjector.php
+++ b/src/Boot/src/Injector/EnumInjector.php
@@ -49,7 +49,7 @@ final class EnumInjector implements InjectorInterface
      */
     private function validateClass(\ReflectionClass $class, ProvideFrom $attribute): void
     {
-        if (! $class->isEnum()) {
+        if (!$class->isEnum()) {
             throw new InjectionException(
                 \sprintf(
                     'Class `%s` should be an enum.',
@@ -58,7 +58,7 @@ final class EnumInjector implements InjectorInterface
             );
         }
 
-        if (! $class->hasMethod($attribute->method)) {
+        if (!$class->hasMethod($attribute->method)) {
             throw new InjectionException(
                 \sprintf(
                     'Class `%s` does not contain `%s` method.',
@@ -68,7 +68,7 @@ final class EnumInjector implements InjectorInterface
             );
         }
 
-        if (! $class->getMethod($attribute->method)->isStatic()) {
+        if (!$class->getMethod($attribute->method)->isStatic()) {
             throw new InjectionException(
                 \sprintf(
                     'Class method `%s::%s` should be static.',

--- a/src/Boot/src/Injector/EnumInjector.php
+++ b/src/Boot/src/Injector/EnumInjector.php
@@ -7,7 +7,7 @@ namespace Spiral\Boot\Injector;
 use Spiral\Attributes\AttributeReader;
 use Spiral\Core\Container;
 use Spiral\Core\Container\InjectorInterface;
-use Spiral\Core\Exception\Container\ContainerException;
+use Spiral\Core\Exception\Container\InjectionException;
 
 /**
  * @internal
@@ -23,8 +23,8 @@ final class EnumInjector implements InjectorInterface
     public function createInjection(\ReflectionClass $class, string $context = null): object
     {
         $attribute = $this->reader->firstClassMetadata($class, ProvideFrom::class);
-        if (!$attribute) {
-            throw new ContainerException(
+        if ($attribute === null) {
+            throw new InjectionException(
                 \sprintf(
                     'Class `%s` should contain `%s` attribute with defined detector method.',
                     $class->getName(),
@@ -34,7 +34,7 @@ final class EnumInjector implements InjectorInterface
         }
 
         if (!$class->isEnum()) {
-            throw new ContainerException(
+            throw new InjectionException(
                 \sprintf(
                     'Class `%s` should be an enum.',
                     $class->getName()

--- a/src/Boot/src/Injector/EnumInjector.php
+++ b/src/Boot/src/Injector/EnumInjector.php
@@ -23,7 +23,7 @@ final class EnumInjector implements InjectorInterface
     public function createInjection(\ReflectionClass $class, string $context = null): object
     {
         $attribute = $this->reader->firstClassMetadata($class, ProvideFrom::class);
-        if (! $attribute) {
+        if (!$attribute) {
             throw new ContainerException(
                 \sprintf(
                     'Class `%s` should contain %s attribute with defined detector method.',
@@ -33,7 +33,7 @@ final class EnumInjector implements InjectorInterface
             );
         }
 
-        if (! $class->isEnum()) {
+        if (!$class->isEnum()) {
             throw new ContainerException(
                 \sprintf(
                     'Class `%s` should be an enum class.',

--- a/src/Boot/src/Injector/InjectableEnumInterface.php
+++ b/src/Boot/src/Injector/InjectableEnumInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Injector;
+
+use Spiral\Core\Container\InjectableInterface;
+
+interface InjectableEnumInterface extends InjectableInterface
+{
+    public const INJECTOR = EnumInjector::class;
+}

--- a/src/Boot/src/Injector/ProvideFrom.php
+++ b/src/Boot/src/Injector/ProvideFrom.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Injector;
+
+use Spiral\Attributes\NamedArgumentConstructor;
+
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+final class ProvideFrom
+{
+    public function __construct(
+        public readonly string $method
+    ) {
+    }
+}

--- a/src/Boot/tests/Environment/AppEnvironmentTest.php
+++ b/src/Boot/tests/Environment/AppEnvironmentTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Environment;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Spiral\Boot\Environment\AppEnvironment;
+use Spiral\Boot\EnvironmentInterface;
+
+final class AppEnvironmentTest extends TestCase
+{
+    public function testDetectWithoutEnvironmentVariable(): void
+    {
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->with('APP_ENV')->andReturnNull();
+
+        $enum = AppEnvironment::detect($env);
+
+        $this->assertSame(AppEnvironment::Local, $enum);
+    }
+
+    /** @dataProvider envVariablesDataProvider */
+    public function testDetectWithWrongEnvironmentVariable($name, AppEnvironment $expected): void
+    {
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->with('APP_ENV')->andReturn($name);
+
+        $enum = AppEnvironment::detect($env);
+
+        $this->assertSame($expected, $enum);
+    }
+
+    public function envVariablesDataProvider()
+    {
+        return [
+            ['wrong', AppEnvironment::Local],
+            ['prod', AppEnvironment::Production],
+            ['stage', AppEnvironment::Stage],
+            ['local', AppEnvironment::Local],
+            ['testing', AppEnvironment::Testing]
+        ];
+    }
+
+    public function testClassMethods(): void
+    {
+        $prod = AppEnvironment::Production;
+        $this->assertTrue($prod->isProduction());
+        $this->assertFalse($prod->isLocal());
+        $this->assertFalse($prod->isStage());
+        $this->assertFalse($prod->isTesting());
+
+        $prod = AppEnvironment::Local;
+        $this->assertFalse($prod->isProduction());
+        $this->assertTrue($prod->isLocal());
+        $this->assertFalse($prod->isStage());
+        $this->assertFalse($prod->isTesting());
+
+        $prod = AppEnvironment::Stage;
+        $this->assertFalse($prod->isProduction());
+        $this->assertFalse($prod->isLocal());
+        $this->assertTrue($prod->isStage());
+        $this->assertFalse($prod->isTesting());
+
+        $prod = AppEnvironment::Testing;
+        $this->assertFalse($prod->isProduction());
+        $this->assertFalse($prod->isLocal());
+        $this->assertFalse($prod->isStage());
+        $this->assertTrue($prod->isTesting());
+    }
+}

--- a/src/Boot/tests/Environment/DebugModeTest.php
+++ b/src/Boot/tests/Environment/DebugModeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Environment;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Spiral\Boot\Environment\DebugMode;
+use Spiral\Boot\EnvironmentInterface;
+
+final class DebugModeTest extends TestCase
+{
+    public function testDetectWithoutEnvironmentVariable(): void
+    {
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->with('DEBUG')->andReturnNull();
+
+        $enum = DebugMode::detect($env);
+
+        $this->assertSame(DebugMode::Disabled, $enum);
+    }
+
+    /** @dataProvider envVariablesDataProvider */
+    public function testDetectWithWrongEnvironmentVariable($name, DebugMode $expected): void
+    {
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->with('DEBUG')->andReturn($name);
+
+        $enum = DebugMode::detect($env);
+
+        $this->assertSame($expected, $enum);
+
+        if ($enum === DebugMode::Enabled) {
+            $this->assertTrue($enum->isEnabled());
+        } else {
+            $this->assertFalse($enum->isEnabled());
+        }
+    }
+
+    public function envVariablesDataProvider()
+    {
+        return [
+            [true, DebugMode::Enabled],
+            ['true', DebugMode::Enabled],
+            ['1', DebugMode::Enabled],
+            ['on', DebugMode::Enabled],
+            ['false', DebugMode::Disabled],
+            ['0', DebugMode::Disabled],
+            ['off', DebugMode::Disabled],
+            [false, DebugMode::Disabled],
+        ];
+    }
+}

--- a/src/Boot/tests/Fixtures/InjectableEnum.php
+++ b/src/Boot/tests/Fixtures/InjectableEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\Injector\InjectableEnumInterface;
+use Spiral\Boot\Injector\ProvideFrom;
+
+#[ProvideFrom(method: 'detect')]
+enum InjectableEnum implements InjectableEnumInterface
+{
+    case Foo;
+    case Bar;
+
+    public static function detect(): self
+    {
+        return self::Bar;
+    }
+}

--- a/src/Boot/tests/Fixtures/InjectableEnumWithNonStaticMethod.php
+++ b/src/Boot/tests/Fixtures/InjectableEnumWithNonStaticMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\Injector\InjectableEnumInterface;
+use Spiral\Boot\Injector\ProvideFrom;
+
+#[ProvideFrom(method: 'detect')]
+enum InjectableEnumWithNonStaticMethod implements InjectableEnumInterface
+{
+    case Foo;
+    case Bar;
+
+    public function detect(): void
+    {
+    }
+}

--- a/src/Boot/tests/Fixtures/InjectableEnumWithoutMethod.php
+++ b/src/Boot/tests/Fixtures/InjectableEnumWithoutMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\Injector\InjectableEnumInterface;
+use Spiral\Boot\Injector\ProvideFrom;
+
+#[ProvideFrom(method: 'detect')]
+enum InjectableEnumWithoutMethod implements InjectableEnumInterface
+{
+    case Foo;
+    case Bar;
+}

--- a/src/Boot/tests/Injector/EnumInjectorTest.php
+++ b/src/Boot/tests/Injector/EnumInjectorTest.php
@@ -10,14 +10,17 @@ use Spiral\Boot\Injector\EnumInjector;
 use Spiral\Boot\Injector\ProvideFrom;
 use Spiral\Core\Container;
 use Spiral\Core\Exception\Container\ContainerException;
+use Spiral\Core\Exception\Container\InjectionException;
 use Spiral\Tests\Boot\Fixtures\InjectableEnum;
+use Spiral\Tests\Boot\Fixtures\InjectableEnumWithNonStaticMethod;
+use Spiral\Tests\Boot\Fixtures\InjectableEnumWithoutMethod;
 use Spiral\Tests\Boot\Fixtures\SampleClass;
 
 final class EnumInjectorTest extends TestCase
 {
     public function testCreateInjectionForClassWithoutAttribute(): void
     {
-        $this->expectException(ContainerException::class);
+        $this->expectException(InjectionException::class);
         $this->expectErrorMessage(
             "Class `Spiral\Tests\Boot\Fixtures\SampleClass` should contain ".
             "`Spiral\Boot\Injector\ProvideFrom` attribute with defined detector method."
@@ -36,7 +39,7 @@ final class EnumInjectorTest extends TestCase
 
         $ref = new \ReflectionClass($class);
 
-        $this->expectException(ContainerException::class);
+        $this->expectException(InjectionException::class);
         $this->expectErrorMessage(\sprintf('Class `%s` should be an enum.', $ref->getName()));
 
         $injector = new EnumInjector(new Container(), new AttributeReader());
@@ -49,5 +52,27 @@ final class EnumInjectorTest extends TestCase
         $enum = $container->get(InjectableEnum::class);
 
         $this->assertSame(InjectableEnum::Bar, $enum);
+    }
+
+    public function testCreateInjectionForClassWithoutMethod(): void
+    {
+        $this->expectException(InjectionException::class);
+        $this->expectErrorMessage(
+            "Class `Spiral\Tests\Boot\Fixtures\InjectableEnumWithoutMethod` does not contain `detect` method."
+        );
+
+        $container = new Container();
+        $enum = $container->get(InjectableEnumWithoutMethod::class);
+    }
+
+    public function testCreateInjectionForClassWithoutStaticMethod(): void
+    {
+        $this->expectException(InjectionException::class);
+        $this->expectErrorMessage(
+            "Spiral\Tests\Boot\Fixtures\InjectableEnumWithNonStaticMethod::detect` should be static."
+        );
+
+        $container = new Container();
+        $enum = $container->get(InjectableEnumWithNonStaticMethod::class);
     }
 }

--- a/src/Boot/tests/Injector/EnumInjectorTest.php
+++ b/src/Boot/tests/Injector/EnumInjectorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Injector;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Attributes\AttributeReader;
+use Spiral\Boot\Injector\EnumInjector;
+use Spiral\Boot\Injector\ProvideFrom;
+use Spiral\Core\Container;
+use Spiral\Core\Exception\Container\ContainerException;
+use Spiral\Tests\Boot\Fixtures\InjectableEnum;
+use Spiral\Tests\Boot\Fixtures\SampleClass;
+
+final class EnumInjectorTest extends TestCase
+{
+    public function testCreateInjectionForClassWithoutAttribute(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectErrorMessage(
+            "Class `Spiral\Tests\Boot\Fixtures\SampleClass` should contain ".
+            "`Spiral\Boot\Injector\ProvideFrom` attribute with defined detector method."
+        );
+
+        $class = new SampleClass();
+
+        $injector = new EnumInjector(new Container(), new AttributeReader());
+        $injector->createInjection(new \ReflectionClass($class));
+    }
+
+    public function testCreateInjectionNotForClass(): void
+    {
+        $class = new #[ProvideFrom(method: 'test')] class {
+        };
+
+        $ref = new \ReflectionClass($class);
+
+        $this->expectException(ContainerException::class);
+        $this->expectErrorMessage(\sprintf('Class `%s` should be an enum.', $ref->getName()));
+
+        $injector = new EnumInjector(new Container(), new AttributeReader());
+        $injector->createInjection($ref);
+    }
+
+    public function testCreateInjectionNotForEnum(): void
+    {
+        $container = new Container();
+        $enum = $container->get(InjectableEnum::class);
+
+        $this->assertSame(InjectableEnum::Bar, $enum);
+    }
+}

--- a/src/Console/src/Signature/Parser.php
+++ b/src/Console/src/Signature/Parser.php
@@ -69,6 +69,8 @@ final class Parser
 
     /**
      * Parse an argument expression.
+     *
+     * @psalm-suppress PossiblyUndefinedVariable
      */
     private function parseArgument(string $token): InputArgument
     {

--- a/src/Console/src/Signature/Parser.php
+++ b/src/Console/src/Signature/Parser.php
@@ -70,7 +70,7 @@ final class Parser
     /**
      * Parse an argument expression.
      *
-     * @psalm-suppress PossiblyUndefinedVariable
+     * @noRector \Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector
      */
     private function parseArgument(string $token): InputArgument
     {

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -132,6 +132,8 @@ final class Container implements
      *
      * @throws ContainerException
      * @throws \Throwable
+     *
+     * @psalm-suppress MethodSignatureMismatch
      */
     public function get(string|Autowire $id, string $context = null): mixed
     {

--- a/src/Core/src/Internal/Container.php
+++ b/src/Core/src/Internal/Container.php
@@ -45,6 +45,8 @@ final class Container implements ContainerInterface
      *
      * @throws ContainerException
      * @throws \Throwable
+     *
+     * @psalm-suppress MethodSignatureMismatch
      */
     public function get(string|Autowire $id, string $context = null): mixed
     {

--- a/src/Filters/src/Config/FiltersConfig.php
+++ b/src/Filters/src/Config/FiltersConfig.php
@@ -10,7 +10,7 @@ final class FiltersConfig extends InjectableConfig
 {
     public const CONFIG = 'filters';
 
-    protected $config = [
+    protected array $config = [
         'interceptors' => [],
     ];
 

--- a/src/Filters/src/Interceptors/AuthorizeFilterInterceptor.php
+++ b/src/Filters/src/Interceptors/AuthorizeFilterInterceptor.php
@@ -25,9 +25,9 @@ final class AuthorizeFilterInterceptor implements CoreInterceptorInterface
     /**
      * @param array{filterBag: FilterBag} $parameters
      */
-    public function process(string $name, string $action, array $parameters, CoreInterface $core): FilterInterface
+    public function process(string $controller, string $action, array $parameters, CoreInterface $core): FilterInterface
     {
-        $filter = $core->callAction($name, $action, $parameters);
+        $filter = $core->callAction($controller, $action, $parameters);
 
         if ($filter instanceof ShouldBeAuthorized) {
             $auth = $this->container->has(AuthContextInterface::class)

--- a/src/Filters/src/Interceptors/Core.php
+++ b/src/Filters/src/Interceptors/Core.php
@@ -11,9 +11,9 @@ use Spiral\Filters\FilterInterface;
 final class Core implements CoreInterface
 {
     /**
-     * @param array{filterBag: FilterBag} $parameters
+     * @param array{filterBag: FilterBag}|array<string, mixed> $parameters
      */
-    public function callAction(string $name, string $action, array $parameters = []): FilterInterface
+    public function callAction(string $controller, string $action, array $parameters = []): FilterInterface
     {
         return $parameters['filterBag']->filter;
     }

--- a/src/Filters/src/Interceptors/PopulateDataFromEntityInterceptor.php
+++ b/src/Filters/src/Interceptors/PopulateDataFromEntityInterceptor.php
@@ -15,7 +15,7 @@ final class PopulateDataFromEntityInterceptor implements CoreInterceptorInterfac
     /**
      * @param array{filterBag: FilterBag} $parameters
      */
-    public function process(string $name, string $action, array $parameters, CoreInterface $core): FilterInterface
+    public function process(string $controller, string $action, array $parameters, CoreInterface $core): FilterInterface
     {
         $bag = $parameters['filterBag'];
 
@@ -23,6 +23,6 @@ final class PopulateDataFromEntityInterceptor implements CoreInterceptorInterfac
             $bag->filter->setData($bag->entity->toArray());
         }
 
-        return $core->callAction($name, $action, $parameters);
+        return $core->callAction($controller, $action, $parameters);
     }
 }

--- a/src/Filters/src/Interceptors/ValidateFilterInterceptor.php
+++ b/src/Filters/src/Interceptors/ValidateFilterInterceptor.php
@@ -27,10 +27,10 @@ class ValidateFilterInterceptor implements CoreInterceptorInterface
     /**
      * @param array{filterBag: FilterBag} $parameters
      */
-    public function process(string $name, string $action, array $parameters, CoreInterface $core): FilterInterface
+    public function process(string $controller, string $action, array $parameters, CoreInterface $core): FilterInterface
     {
         $bag = $parameters['filterBag'];
-        $filter = $core->callAction($name, $action, $parameters);
+        $filter = $core->callAction($controller, $action, $parameters);
 
         if ($filter instanceof HasFilterDefinition) {
             $this->validateFilter(

--- a/src/Filters/src/Schema/AttributeMapper.php
+++ b/src/Filters/src/Schema/AttributeMapper.php
@@ -90,7 +90,6 @@ final class AttributeMapper
 
     private function setValue(FilterInterface $filter, \ReflectionProperty $property, mixed $value): void
     {
-        /** @var Setter|null $setter */
         $setter = $this->reader->firstPropertyMetadata($property, Setter::class);
 
         if ($value === null) {

--- a/src/Validation/src/ValidationProvider.php
+++ b/src/Validation/src/ValidationProvider.php
@@ -10,7 +10,7 @@ use Spiral\Validation\Exception\ValidationException;
 
 final class ValidationProvider implements ValidationProviderInterface, SingletonInterface
 {
-    /** @var array<class-string, Closure> */
+    /** @var array<class-string, \Closure> */
     private array $validations = [];
 
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

- [x] Unit tests
- [ ] Docs

### Enum 
```php
use Spiral\Boot\EnvironmentInterface;
use Spiral\Boot\Injector\ProvideFrom;
use Spiral\Boot\Injector\InjectableEnumInterface;

#[ProvideFrom(method: 'detect')]
enum AppEnvironment: string implements InjectableEnumInterface
{
    case Production = 'prod';
    case Stage = 'stage';
    case Testing = 'testing';
    case Local = 'local';

    public function isProduction(): bool
    {
        return $this === self::Production;
    }

    public static function detect(EnvironmentInterface $environment): self
    {
        $value = $environment->get('APP_ENV');

        return \is_string($value)
            ? (self::tryFrom($value) ?? self::Local)
            : self::Local;
    }
}
```

### Using

Enum will be automatically resolved by the container with current environment

```php
$appEnv = $container->get(AppEnvironment::class);

dump($appEnv->isProduction());
```