### PR TITLE
Improving Printer in Reactor

### DIFF
--- a/src/Reactor/src/FileDeclaration.php
+++ b/src/Reactor/src/FileDeclaration.php
@@ -33,7 +33,7 @@ class FileDeclaration implements \Stringable, DeclarationInterface
 
     public function __toString(): string
     {
-        return $this->element->__toString();
+        return (new Printer())->print($this);
     }
 
     public static function fromCode(string $code): static

--- a/src/Reactor/src/Printer.php
+++ b/src/Reactor/src/Printer.php
@@ -5,26 +5,11 @@ declare(strict_types=1);
 namespace Spiral\Reactor;
 
 use Nette\PhpGenerator\PsrPrinter;
-use Spiral\Files\FilesInterface;
 
 class Printer
 {
-    public function __construct(
-        protected FilesInterface $files
-    ) {
-    }
-
     public function print(FileDeclaration $file): string
     {
         return (new PsrPrinter())->printFile($file->getElement());
-    }
-
-    public function write(string $filename, FileDeclaration $file): bool
-    {
-        return $this->files->write(
-            filename: $filename,
-            data: $this->print($file),
-            ensureDirectory: true
-        );
     }
 }

--- a/src/Reactor/src/Writer.php
+++ b/src/Reactor/src/Writer.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Reactor;
+
+use Spiral\Files\FilesInterface;
+
+class Writer
+{
+    public function __construct(
+        protected FilesInterface $files
+    ) {
+    }
+
+    public function write(string $filename, FileDeclaration $file): bool
+    {
+        return $this->files->write(
+            filename: $filename,
+            data: (new Printer())->print($file),
+            ensureDirectory: true
+        );
+    }
+}

--- a/src/Scaffolder/src/Command/AbstractCommand.php
+++ b/src/Scaffolder/src/Command/AbstractCommand.php
@@ -8,7 +8,7 @@ use Psr\Container\ContainerInterface;
 use Spiral\Console\Command;
 use Spiral\Core\FactoryInterface;
 use Spiral\Files\FilesInterface;
-use Spiral\Reactor\Printer;
+use Spiral\Reactor\Writer;
 use Spiral\Scaffolder\Config\ScaffolderConfig;
 use Spiral\Scaffolder\Declaration\DeclarationInterface;
 
@@ -55,7 +55,7 @@ abstract class AbstractCommand extends Command
         }
 
         //File declaration
-        (new Printer($this->files))->write($filename, $declaration->getFile());
+        (new Writer($this->files))->write($filename, $declaration->getFile());
 
         $this->writeln(
             \sprintf("Declaration of '<info>%s</info>' ", $className)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️ (only in 3.0.x-dev branch)
| New feature?  | ✔️

Removed the ability to write to a file in Printer, now it can only return a string result. It will return string data without the `spiral/files` dependency.

Added Writer class with dependency `spiral/files` that can write the result to a file.

The __toString method on the FileDeclaration now uses the Printer and it is possible to return a formatted string result without having to create a Printer manually.

```php
$file = new FileDeclaration();
var_dump((string) $file);
// or
var_dump($file->render());
// or
var_dump($file->__toString());
```