### PR TITLE
Adding headers from HTTP config

### DIFF
--- a/src/Http/src/Bootloader/DiactorosBootloader.php
+++ b/src/Http/src/Bootloader/DiactorosBootloader.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Http\Response\ResponseFactory;
 
 /**
  * PSR-17 factories using Nyholm/Psr7 (default package).
@@ -19,7 +20,7 @@ final class DiactorosBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         ServerRequestFactoryInterface::class => Psr17Factory::class,
-        ResponseFactoryInterface::class      => Psr17Factory::class,
+        ResponseFactoryInterface::class      => ResponseFactory::class,
         StreamFactoryInterface::class        => Psr17Factory::class,
         UploadedFileFactoryInterface::class  => Psr17Factory::class,
         UriFactoryInterface::class           => Psr17Factory::class,

--- a/src/Http/src/Response/ResponseFactory.php
+++ b/src/Http/src/Response/ResponseFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Http\Response;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Http\Config\HttpConfig;
+
+final class ResponseFactory implements ResponseFactoryInterface
+{
+    public function __construct(
+        private readonly HttpConfig $config,
+        private readonly Psr17Factory $factory
+    ) {
+    }
+
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        $response = $this->factory->createResponse($code, $reasonPhrase);
+        foreach ($this->config->getBaseHeaders() as $header => $value) {
+            $response = $response->withAddedHeader($header, $value);
+        }
+
+        return $response;
+    }
+}

--- a/tests/Framework/Http/ResponseFactoryTest.php
+++ b/tests/Framework/Http/ResponseFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Spiral\Http\Config\HttpConfig;
+use Spiral\Tests\Framework\BaseTest;
+
+final class ResponseFactoryTest extends BaseTest
+{
+    public function testDefaultBaseHeaders(): void
+    {
+        $app = $this->makeApp();
+
+        /** @var ResponseFactoryInterface $factory */
+        $factory = $app->get(ResponseFactoryInterface::class);
+
+        $response = $factory->createResponse(200, 'test');
+
+        $this->assertSame(['Content-Type' => ['text/html; charset=UTF-8']], $response->getHeaders());
+    }
+
+    public function testAddBaseHeaders(): void
+    {
+        $app = $this->makeApp();
+        $app->getContainer()->bind(
+            HttpConfig::class,
+            new HttpConfig(['headers' => ['test' => 'test', 'test2' => 'test2']])
+        );
+
+        /** @var ResponseFactoryInterface $factory */
+        $factory = $app->get(ResponseFactoryInterface::class);
+
+        $response = $factory->createResponse(200, 'test');
+
+        $this->assertSame(['test' => ['test'], 'test2' => ['test2']], $response->getHeaders());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

Fixed bug with adding headers from `HttpConfig`. 

The same implementation was here:
https://github.com/spiral/nyholm-bridge/blob/master/src/ResponseFactory.php