### PR TITLE
Adding `methods` to the RouteConfigurator

### DIFF
--- a/src/Router/src/Loader/Configurator/RouteConfigurator.php
+++ b/src/Router/src/Loader/Configurator/RouteConfigurator.php
@@ -19,9 +19,10 @@ final class RouteConfigurator
 {
     private array $defaults = [];
     private ?string $group = null;
+    private ?array $methods = null;
     private string $prefix = '';
     private ?CoreInterface $core = null;
-    private MiddlewareInterface|string|array|null $middleware = null;
+    private ?array $middleware = null;
 
     /** @var string|callable|RequestHandlerInterface|TargetInterface */
     private mixed $target = null;
@@ -58,6 +59,7 @@ final class RouteConfigurator
             'defaults' => $this->defaults,
             'group' => $this->group,
             'middleware' => $this->middleware,
+            'methods' => $this->methods,
             'pattern' => $this->pattern,
             'prefix' => \trim($this->prefix, '/'),
             default => throw new \BadMethodCallException(\sprintf('Unable to access %s.', $name))
@@ -136,7 +138,18 @@ final class RouteConfigurator
 
     public function middleware(MiddlewareInterface|string|array $middleware): self
     {
-        $this->middleware = (array) $middleware;
+        if (!\is_array($middleware)) {
+            $middleware = [$middleware];
+        }
+
+        $this->middleware = $middleware;
+
+        return $this;
+    }
+
+    public function methods(string|array $methods): self
+    {
+        $this->methods = (array) $methods;
 
         return $this;
     }

--- a/src/Router/src/Router.php
+++ b/src/Router/src/Router.php
@@ -130,6 +130,10 @@ final class Router implements RouterInterface
                 $route = $route->withMiddleware(...$configurator->middleware);
             }
 
+            if ($configurator->methods !== null) {
+                $route = $route->withVerbs(...$configurator->methods);
+            }
+
             if (!isset($this->routes[$name]) && $name !== RoutingConfigurator::DEFAULT_ROUTE_NAME) {
                 $groups->getGroup($configurator->group ?? $groups->getDefaultGroup())->addRoute($name, $route);
 

--- a/src/Router/src/Router.php
+++ b/src/Router/src/Router.php
@@ -136,8 +136,6 @@ final class Router implements RouterInterface
 
             if (!isset($this->routes[$name]) && $name !== RoutingConfigurator::DEFAULT_ROUTE_NAME) {
                 $groups->getGroup($configurator->group ?? $groups->getDefaultGroup())->addRoute($name, $route);
-
-                $this->setRoute($name, $route);
             }
 
             if ($name === RoutingConfigurator::DEFAULT_ROUTE_NAME) {

--- a/src/Router/tests/Loader/Configurator/RouteConfiguratorTest.php
+++ b/src/Router/tests/Loader/Configurator/RouteConfiguratorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\Loader\Configurator;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Core\Container;
+use Spiral\Core\Core;
+use Spiral\Router\Exception\TargetException;
+use Spiral\Router\Loader\Configurator\RouteConfigurator;
+use Spiral\Router\RouteCollection;
+use Spiral\Router\Target\AbstractTarget;
+use Spiral\Router\Target\Action;
+use Spiral\Router\Target\Controller;
+use Spiral\Router\Target\Group;
+use Spiral\Router\Target\Namespaced;
+use Spiral\Tests\Router\BaseTest;
+
+final class RouteConfiguratorTest extends BaseTest
+{
+    public function testDestructException(): void
+    {
+        $routes = new RouteCollection();
+
+        $configurator = new RouteConfigurator('test', '/', $routes);
+        $this->assertCount(0, $routes);
+
+        $this->expectException(TargetException::class);
+        unset($configurator);
+    }
+
+    public function testDestruct(): void
+    {
+        $routes = new RouteCollection();
+
+        $configurator = new RouteConfigurator('test', '/', $routes);
+        $this->assertCount(0, $routes);
+
+        $configurator->controller('Controller');
+
+        unset($configurator);
+
+        $this->assertCount(1, $routes);
+    }
+
+    public function testController(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('SomeController');
+
+        $this->assertInstanceOf(Controller::class, $configurator->target);
+    }
+
+    public function testNamespaced(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->namespaced('App\\Controller');
+
+        $this->assertInstanceOf(Namespaced::class, $configurator->target);
+    }
+
+    public function testGroupControllers(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->groupControllers(['Controller']);
+
+        $this->assertInstanceOf(Group::class, $configurator->target);
+    }
+
+    public function testAction(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->action('Controller', 'action');
+
+        $this->assertInstanceOf(Action::class, $configurator->target);
+    }
+
+    public function testCallable(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->callable(fn () => null);
+
+        $this->assertInstanceOf(\Closure::class, $configurator->target);
+    }
+
+    public function testHandler(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->handler(new class ([], []) extends AbstractTarget
+        {
+            protected function resolveController(array $matches): string
+            {
+                return '';
+            }
+
+            protected function resolveAction(array $matches): ?string
+            {
+                return '';
+            }
+        });
+
+        $this->assertInstanceOf(AbstractTarget::class, $configurator->target);
+    }
+
+    public function testDefaults(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->defaults(['some', 'array']);
+
+        $this->assertSame(['some', 'array'], $configurator->defaults);
+    }
+
+    public function testGroup(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->group('api');
+
+        $this->assertSame('api', $configurator->group);
+    }
+
+    public function testPrefix(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->prefix('admin');
+
+        $this->assertSame('admin', $configurator->prefix);
+    }
+
+    public function testCore(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->core(new Core(new Container()));
+
+        $this->assertInstanceOf(Core::class, $configurator->core);
+    }
+
+    public function testMiddleware(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->middleware('class-string');
+        $this->assertSame(['class-string'], $configurator->middleware);
+
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->middleware(['class-string', 'other-class-string']);
+        $this->assertSame(['class-string', 'other-class-string'], $configurator->middleware);
+
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $testMiddleware = new class () implements MiddlewareInterface
+        {
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+            }
+        };
+        $configurator->controller('Controller')->middleware($testMiddleware);
+        $this->assertSame([$testMiddleware], $configurator->middleware);
+    }
+
+    public function testMethods(): void
+    {
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->methods('GET');
+        $this->assertSame(['GET'], $configurator->methods);
+
+        $configurator = new RouteConfigurator('test', '/', new RouteCollection());
+        $configurator->controller('Controller')->methods(['GET', 'POST']);
+        $this->assertSame(['GET', 'POST'], $configurator->methods);
+    }
+}

--- a/tests/Framework/Http/AuthSessionTest.php
+++ b/tests/Framework/Http/AuthSessionTest.php
@@ -12,13 +12,6 @@ final class AuthSessionTest extends HttpTest
         'ENCRYPTER_KEY' => self::ENCRYPTER_KEY,
     ];
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->enableMiddlewares();
-    }
-
     public function testNoToken(): void
     {
         $this->getHttp()->get(uri: '/auth/token')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added ability to configure route verbs via `RouteConfigurator`. For example:
```php
    $routes
        ->add('auth.login', '/login')
        ->action(AuthController::class, 'login')
        ->methods('POST');
    $routes
        ->add('auth.logout', '/logout')
        ->action(AuthController::class, 'logout')
        ->methods('GET');
    $routes
        ->add('other', '/other')
        ->action(AuthController::class, 'other')
        ->methods(['GET', 'POST']);
```

Fixed bug with adding middleware.
