### PR TITLE
Fixes problem with replacing route middleware with group middleware when a route adds to a group.

### DIFF
--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -46,7 +46,7 @@ final class RouteGroup
 
     public function setCore(Autowire|CoreInterface|string $core): self
     {
-        if (!$core instanceof CoreInterface) {
+        if (! $core instanceof CoreInterface) {
             $core = $this->container->get($core);
         }
         $this->core = $core;
@@ -65,7 +65,7 @@ final class RouteGroup
      */
     public function addMiddleware(MiddlewareInterface|string $middleware): self
     {
-        if (!$middleware instanceof MiddlewareInterface) {
+        if (! $middleware instanceof MiddlewareInterface) {
             $middleware = $this->container->get($middleware);
         }
 
@@ -107,15 +107,12 @@ final class RouteGroup
             $target = $route->getTarget();
 
             if ($target instanceof AbstractTarget) {
-                return $route
-                    ->withTarget($target->withCore($this->core))
-                    ->withUriHandler($this->handler->withPrefix($this->prefix))
-                    ->withPipeline($this->pipeline);
+                $route = $route->withTarget($target->withCore($this->core));
             }
         }
 
         return $route
             ->withUriHandler($this->handler->withPrefix($this->prefix))
-            ->withPipeline($this->pipeline);
+            ->withMiddleware($this->pipeline);
     }
 }

--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -46,7 +46,7 @@ final class RouteGroup
 
     public function setCore(Autowire|CoreInterface|string $core): self
     {
-        if (! $core instanceof CoreInterface) {
+        if (!$core instanceof CoreInterface) {
             $core = $this->container->get($core);
         }
         $this->core = $core;
@@ -65,7 +65,7 @@ final class RouteGroup
      */
     public function addMiddleware(MiddlewareInterface|string $middleware): self
     {
-        if (! $middleware instanceof MiddlewareInterface) {
+        if (!$middleware instanceof MiddlewareInterface) {
             $middleware = $this->container->get($middleware);
         }
 

--- a/src/Router/tests/Stub/AnotherMiddleware.php
+++ b/src/Router/tests/Stub/AnotherMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\Stub;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class AnotherMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

Example 

We have a route with a middleware
```php
return function (RoutingConfigurator $routes) {
    $routes->add('signed', '/signed')
        ->action(SignedController::class, 'signed')
        ->middleware(ValidateSignature::class);
};
```

And route group with middleware 

```php
    protected function middlewareGroups(): array
    {
        return [
            'web' => [
                CookiesMiddleware::class,
                SessionMiddleware::class,
                CsrfMiddleware::class,
            ],
            // ...
        ];
    }
```

When we add `signed` to `web` group, `ValidateSignature` middleware will be lost, because group will completely replace it with group pipeline.