### PR TITLE
Adding middlewares via Autowire

### DIFF
--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -11,6 +11,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Container\Autowire;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Http\Config\HttpConfig;
 use Spiral\Http\Http;
@@ -49,9 +50,9 @@ final class HttpBootloader extends Bootloader implements SingletonInterface
     /**
      * Register new http middleware.
      *
-     * @psalm-param MiddlewareInterface|class-string<MiddlewareInterface>
+     * @psalm-param MiddlewareInterface|Autowire|class-string<MiddlewareInterface>
      */
-    public function addMiddleware(string|MiddlewareInterface $middleware): void
+    public function addMiddleware(string|Autowire|MiddlewareInterface $middleware): void
     {
         $this->config->modify(HttpConfig::CONFIG, new Append('middleware', null, $middleware));
     }

--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -58,12 +58,12 @@ final class RouteGroup
     }
 
     /**
-     * @param MiddlewareInterface|class-string<MiddlewareInterface>|non-empty-string $middleware
+     * @param MiddlewareInterface|Autowire|class-string<MiddlewareInterface>|non-empty-string $middleware
      *
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function addMiddleware(MiddlewareInterface|string $middleware): self
+    public function addMiddleware(MiddlewareInterface|Autowire|string $middleware): self
     {
         if (!$middleware instanceof MiddlewareInterface) {
             $middleware = $this->container->get($middleware);

--- a/src/Router/src/Traits/PipelineTrait.php
+++ b/src/Router/src/Traits/PipelineTrait.php
@@ -6,6 +6,7 @@ namespace Spiral\Router\Traits;
 
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Spiral\Core\Container\Autowire;
 use Spiral\Http\Pipeline;
 use Spiral\Router\Exception\RouteException;
 use Spiral\Router\RouteInterface;
@@ -43,7 +44,7 @@ trait PipelineTrait
         }
 
         foreach ($middleware as $item) {
-            if (!\is_string($item) && !$item instanceof MiddlewareInterface) {
+            if (!\is_string($item) && !$item instanceof MiddlewareInterface && !$item instanceof Autowire) {
                 $name = get_debug_type($item);
 
                 throw new RouteException(\sprintf('Invalid middleware `%s`', $name));

--- a/src/Router/tests/BaseTest.php
+++ b/src/Router/tests/BaseTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Spiral\Core\Container;
+use Spiral\Core\Container\Autowire;
 use Spiral\Core\CoreInterface;
 use Spiral\Http\Config\HttpConfig;
 use Spiral\Router\GroupRegistry;
@@ -23,13 +24,14 @@ use Spiral\Tests\Router\Diactoros\ResponseFactory;
 use Spiral\Tests\Router\Diactoros\UriFactory;
 use Spiral\Router\UriHandler;
 use Spiral\Tests\Router\Stub\TestLoader;
+use Spiral\Tests\Router\Stub\TestMiddleware;
 
 abstract class BaseTest extends TestCase
 {
     protected Container $container;
     protected Router $router;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->initContainer();
         $this->initRouter();
@@ -41,6 +43,23 @@ abstract class BaseTest extends TestCase
             new UriFactory(),
             new Slugify()
         ), $this->container);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function getProperty(object $object, string $property): mixed
+    {
+        $r = new \ReflectionObject($object);
+
+        return $r->getProperty($property)->getValue($object);
+    }
+
+    protected function middlewaresDataProvider(): \Traversable
+    {
+        yield [TestMiddleware::class];
+        yield [new TestMiddleware()];
+        yield [new Autowire(TestMiddleware::class)];
     }
 
     private function initContainer(): void

--- a/src/Router/tests/RouteTest.php
+++ b/src/Router/tests/RouteTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Router;
 
-use PHPUnit\Framework\TestCase;
 use Spiral\Router\Exception\RouteException;
 use Spiral\Router\Route;
 use Spiral\Tests\Router\Diactoros\UriFactory;
 use Spiral\Router\UriHandler;
 use Nyholm\Psr7\ServerRequest;
+use Spiral\Tests\Router\Stub\TestMiddleware;
 
-class RouteTest extends TestCase
+class RouteTest extends BaseTest
 {
     public function testPrefix(): void
     {
@@ -37,5 +37,20 @@ class RouteTest extends TestCase
 
         $route = new Route('/action', Call::class);
         $route->handle(new ServerRequest('GET', ''));
+    }
+
+    /** @dataProvider middlewaresDataProvider */
+    public function testWithMiddleware(mixed $middleware): void
+    {
+        $route = new Route('/action', Call::class);
+        $route = $route->withMiddleware($middleware)->withContainer($this->container);
+
+        (new \ReflectionMethod($route, 'makePipeline'))->invoke($route);
+
+        $p = $this->getProperty($route, 'pipeline');
+        $m = $this->getProperty($p, 'middleware');
+
+        $this->assertCount(1, $m);
+        $this->assertInstanceOf(TestMiddleware::class, $m[0]);
     }
 }

--- a/src/Router/tests/RoutesGroupTest.php
+++ b/src/Router/tests/RoutesGroupTest.php
@@ -6,7 +6,6 @@ namespace Spiral\Tests\Router;
 
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Spiral\Core\Container;
-use Spiral\Core\Container\Autowire;
 use Spiral\Http\Pipeline;
 use Spiral\Router\Loader\LoaderInterface;
 use Spiral\Router\Route;
@@ -19,10 +18,8 @@ use Spiral\Tests\Router\Stub\AnotherMiddleware;
 use Spiral\Tests\Router\Stub\RoutesTestCore;
 use Spiral\Tests\Router\Stub\TestMiddleware;
 
-class RoutesGroupTest extends TestCase
+class RoutesGroupTest extends BaseTest
 {
-    private Container $container;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -108,23 +105,6 @@ class RoutesGroupTest extends TestCase
 
         $this->assertInstanceOf(TestMiddleware::class, $this->getProperty($m[1], 'middleware')[0]);
         $this->assertInstanceOf(AnotherMiddleware::class, $m[0]);
-    }
-
-    public function middlewaresDataProvider(): \Traversable
-    {
-        yield [TestMiddleware::class];
-        yield [new TestMiddleware()];
-        yield [new Autowire(TestMiddleware::class)];
-    }
-
-    /**
-     * @throws \ReflectionException
-     */
-    private function getProperty(object $object, string $property): mixed
-    {
-        $r = new \ReflectionObject($object);
-
-        return $r->getProperty($property)->getValue($object);
     }
 
     /**

--- a/tests/Framework/Bootloader/Http/HttpBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/HttpBootloaderTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Framework\Bootloader\Http;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Bootloader\Http\HttpBootloader;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;
+use Spiral\Core\Container\Autowire;
 use Spiral\Http\Config\HttpConfig;
 use Spiral\Tests\Framework\BaseTest;
 
@@ -20,13 +25,37 @@ final class HttpBootloaderTest extends BaseTest
     public function testAddInputBag(): void
     {
         $configs = new ConfigManager($this->createMock(LoaderInterface::class));
-        $configs->setDefaults('http', ['inputBags' => []]);
+        $configs->setDefaults(HttpConfig::CONFIG, ['inputBags' => []]);
 
         $bootloader = new HttpBootloader($configs);
         $bootloader->addInputBag('test', ['class' => 'foo', 'source' => 'bar']);
 
         $this->assertSame([
             'test' => ['class' => 'foo', 'source' => 'bar']
-        ], $configs->getConfig('http')['inputBags']);
+        ], $configs->getConfig(HttpConfig::CONFIG)['inputBags']);
+    }
+
+    /** @dataProvider middlewaresDataProvider */
+    public function testAddMiddleware(mixed $middleware): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(HttpConfig::CONFIG, ['middleware' => []]);
+
+        $bootloader = new HttpBootloader($configs);
+        $bootloader->addMiddleware($middleware);
+
+        $this->assertSame([$middleware], $configs->getConfig(HttpConfig::CONFIG)['middleware']);
+    }
+
+    public function middlewaresDataProvider(): \Traversable
+    {
+        yield ['class-string'];
+        yield [new class () implements MiddlewareInterface
+        {
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+            }
+        }];
+        yield [new Autowire('class-string')];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 


```php
$route->withMiddleware(new \Spiral\Core\Container\Autowire(MyMiddleware::class));
```