### PR TITLE
Improves Spiral\Http\ErrorHandler\RendererInterface class.

### DIFF
--- a/src/Http/src/ErrorHandler/PlainRenderer.php
+++ b/src/Http/src/ErrorHandler/PlainRenderer.php
@@ -19,8 +19,9 @@ final class PlainRenderer implements RendererInterface
     ) {
     }
 
-    public function renderException(Request $request, int $code, string $message): Response
+    public function renderException(Request $request, int $code, \Throwable $exception): Response
     {
+        $message = $exception->getMessage();
         $acceptItems = AcceptHeader::fromString($request->getHeaderLine('Accept'))->getAll();
 
         $response = $this->responseFactory->createResponse($code);

--- a/src/Http/src/ErrorHandler/RendererInterface.php
+++ b/src/Http/src/ErrorHandler/RendererInterface.php
@@ -12,5 +12,5 @@ use Psr\Http\Message\ServerRequestInterface as Request;
  */
 interface RendererInterface
 {
-    public function renderException(Request $request, int $code, string $message): Response;
+    public function renderException(Request $request, int $code, \Throwable $exception): Response;
 }

--- a/src/Http/src/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Http/src/Middleware/ErrorHandlerMiddleware.php
@@ -54,7 +54,7 @@ final class ErrorHandlerMiddleware implements MiddlewareInterface
 
         $this->logError($request, $code, $e->getMessage());
 
-        return $this->renderer->renderException($request, $code, $e->getMessage());
+        return $this->renderer->renderException($request, $code, $e);
     }
 
     /**

--- a/tests/Framework/Http/ErrorHandler/PlainRendererTest.php
+++ b/tests/Framework/Http/ErrorHandler/PlainRendererTest.php
@@ -22,7 +22,7 @@ final class PlainRendererTest extends TestCase
             'Accept' => 'application/json',
         ]);
 
-        $response = $renderer->renderException($request, 400, 'message');
+        $response = $renderer->renderException($request, 400, new \Exception('message'));
         self::assertTrue($response->hasHeader('Content-Type'));
         self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
 
@@ -36,7 +36,7 @@ final class PlainRendererTest extends TestCase
         $renderer = new PlainRenderer($this->mockResponseFactory());
         $request = new ServerRequest('GET', '', body: 'php://input');
 
-        $response = $renderer->renderException($request, 400, 'message');
+        $response = $renderer->renderException($request, 400, new \Exception('message'));
         $stream = $response->getBody();
         $stream->rewind();
         self::assertEquals('Error code: 400', $stream->getContents());
@@ -55,7 +55,7 @@ final class PlainRendererTest extends TestCase
             ],
         ], 'php://input');
 
-        $response = $renderer->renderException($request, 400, 'message');
+        $response = $renderer->renderException($request, 400, new \Exception('message'));
         self::assertTrue($response->hasHeader('Content-Type'));
         self::assertSame(['application/json; charset=UTF-8'], $response->getHeader('Content-Type'));
 
@@ -95,7 +95,7 @@ final class PlainRendererTest extends TestCase
         $renderer = new PlainRenderer($this->mockResponseFactory());
         $request = new ServerRequest('GET', '', ['Accept' => $acceptHeader], 'php://input');
 
-        $response = $renderer->renderException($request, 400, 'message');
+        $response = $renderer->renderException($request, 400, new \Exception('message'));
         $stream = $response->getBody();
         $stream->rewind();
         self::assertEquals('Error code: 400', $stream->getContents());


### PR DESCRIPTION
Replaces message string as a second argument with Throwable object

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️
| New feature?  | ✔️

```php

namespace App\ErrorHandler;

use Psr\Http\Message\ResponseFactoryInterface;
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\ServerRequestInterface as Request;
use Spiral\Http\ErrorHandler\RendererInterface;
use Spiral\Http\Header\AcceptHeader;
use Spiral\Views\Exception\ViewException;
use Spiral\Views\ViewsInterface;

class ViewRenderer implements RendererInterface
{
    public function __construct(
        private readonly ViewsInterface $views,
        private readonly ResponseFactoryInterface $responseFactory
    ) {
    }

    public function renderException(Request $request, int $code, \Throwable $exception): ResponseInterface
    {
        $response = $this->responseFactory->createResponse($code);

        try {
            $view = $this->views->get(\sprintf('exception/%d', $code));
        } catch (ViewException) {
            $view = $this->views->get('exception/error');
        }

        $content = $view->render(['code' => $code, 'exception' => $exception]);
        $response->getBody()->write($content);

        return $response;
    }
}
```