### PR TITLE
Adding `existsSection` in ConfigManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
     added return type `mixed` to the method `offsetGet`, added return type `mixed` and `mixed` parameter type
     of `$default` to the method `get`  in `Spiral\Http\Request\InputBag` class.
   - [spiral/config] Added return type `void` to the method `setDefaults` in `Spiral\Config\ConfiguratorInterface` interface.
+    - Added new `existsSection` method in `Spiral\Config\ConfiguratorInterface`. 
   - [spiral/core] Comprehensive code refactoring. A lot of signatures from `Spiral\Core` namespace has been changed.
     New features:
     - Added supporting for PHP 8.0 Union types.
@@ -165,6 +166,8 @@
   - `Spiral\Snapshots\SnapshotterInterface` usage replaced with `Spiral\Exceptions\ExceptionReporterInterface` in all classes.
   - Removed `bin/spiral`. Uses the `spiral/roadrunner-cli` package instead.
 - **Other Features**
+  - [spiral/config] Added new `existsSection` method in `Spiral\Config\ConfigManager`. Using this method, you can check 
+    if a section is defined in a configuration file. Nesting is supported using dot notation.
   - [spiral/debug] Added `Spiral\Debug\StateConsumerInterface`.
   - [spiral/boot] Added new `boot` method in `Bootloaders`. It will be executed after the `init` method is executed in all `Bootloaders`.
     The old `boot` method has been renamed to `init`. See **High Impact Changes** section.

--- a/src/Config/src/ConfigManager.php
+++ b/src/Config/src/ConfigManager.php
@@ -6,6 +6,7 @@ namespace Spiral\Config;
 
 use Spiral\Config\Exception\ConfigDeliveredException;
 use Spiral\Config\Exception\PatchException;
+use Spiral\Config\Patch\Traits\DotTrait;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\Exception\ConfiguratorException;
 
@@ -15,6 +16,8 @@ use Spiral\Core\Exception\ConfiguratorException;
  */
 final class ConfigManager implements ConfiguratorInterface, SingletonInterface
 {
+    use DotTrait;
+
     private array $data = [];
     private array $defaults = [];
     private array $instances = [];
@@ -35,9 +38,20 @@ final class ConfigManager implements ConfiguratorInterface, SingletonInterface
         $this->instances = [];
     }
 
-    public function exists(string $section): bool
+    public function exists(string $config): bool
     {
-        return isset($this->defaults[$section]) || isset($this->data[$section]) || $this->loader->has($section);
+        return isset($this->defaults[$config]) || isset($this->data[$config]) || $this->loader->has($config);
+    }
+
+    public function existsSection(string $config, string $section): bool
+    {
+        if (!$this->exists($config)) {
+            return false;
+        }
+
+        $data = $this->defaults[$config] ?? $this->data[$config] ?? $this->loader->load($config);
+
+        return $this->dotExists($data, $section);
     }
 
     public function setDefaults(string $section, array $data): void

--- a/src/Config/src/ConfiguratorInterface.php
+++ b/src/Config/src/ConfiguratorInterface.php
@@ -14,9 +14,14 @@ use Spiral\Core\Exception\ConfiguratorException;
 interface ConfiguratorInterface extends ConfigsInterface
 {
     /**
-     * Check if configuration sections exists or defined as default.
+     * Check if configuration exists or defined as default.
      */
-    public function exists(string $section): bool;
+    public function exists(string $config): bool;
+
+    /**
+     * Check if configuration section exists or defined as default.
+     */
+    public function existsSection(string $config, string $section): bool;
 
     /**
      * Set default value for configuration section. Default values will be overwritten by user specified config

--- a/src/Config/src/Patch/Traits/DotTrait.php
+++ b/src/Config/src/Patch/Traits/DotTrait.php
@@ -29,4 +29,19 @@ trait DotTrait
 
         return $data;
     }
+
+    private function dotExists(array &$data, string $name): bool
+    {
+        $path = (!empty($this->prefix) ? $this->prefix . '.' : '') . $name;
+
+        $path = \explode('.', \rtrim($path, '.'));
+        foreach ($path as $step) {
+            if (!\is_array($data) || !\array_key_exists($step, $data)) {
+                return false;
+            }
+            $data = &$data[$step];
+        }
+
+        return true;
+    }
 }

--- a/src/Config/tests/ConfigFactoryTest.php
+++ b/src/Config/tests/ConfigFactoryTest.php
@@ -43,6 +43,27 @@ class ConfigFactoryTest extends BaseTest
         $this->assertTrue($cf->exists('magic'));
     }
 
+    public function testExistsSection(): void
+    {
+        $cf = $this->getFactory();
+
+        // config isn't exists
+        $this->assertFalse($cf->existsSection('undefined', 'magic'));
+
+        // exists in defaults
+        $cf->setDefaults('undefined', ['magic' => 'value']);
+        $this->assertTrue($cf->existsSection('undefined', 'magic'));
+
+        // exists in loaded data
+        $cf = $this->getFactory();
+        $this->assertTrue($cf->existsSection('test', 'id'));
+        $this->assertTrue($cf->existsSection('nested', 'nested.other'));
+        $this->assertTrue($cf->existsSection('nested', 'nested.other.key'));
+
+        // isn't exists
+        $this->assertFalse($cf->existsSection('test', 'magic'));
+    }
+
     public function testConfigError(): void
     {
         $this->expectException(LoaderException::class);

--- a/src/Config/tests/fixtures/nested.php
+++ b/src/Config/tests/fixtures/nested.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'id'       => 'hello world',
+    'nested' => [
+        'other' => [
+            'key' => 'value'
+        ]
+    ]
+];

--- a/src/Console/src/Bootloader/ConsoleBootloader.php
+++ b/src/Console/src/Bootloader/ConsoleBootloader.php
@@ -100,7 +100,7 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
         string $footer = '',
         array $options = []
     ): void {
-        if (!isset($this->config->getConfig(ConsoleConfig::CONFIG)['sequences'][$name])) {
+        if (!$this->config->existsSection(ConsoleConfig::CONFIG, \sprintf('sequences.%s', $name))) {
             $this->config->modify(
                 ConsoleConfig::CONFIG,
                 new Append('sequences', $name, [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️
| New feature?  | ✔️

Added `existsSection` method. Allows to check if the section is defined in the configuration file. Not using the `getConfig` method and not provocate the error 'Unable to modify config file...' after that.
```php
if (!$config->existsSection(ConsoleConfig::CONFIG, 'sequences.name')) {
   //
}
```