### PR TITLE
Improves route group middleware

### DIFF
--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -7,6 +7,7 @@ namespace Spiral\Command\Router;
 use Spiral\Boot\KernelInterface;
 use Spiral\Console\Command;
 use Spiral\Core\Container\SingletonInterface;
+use Spiral\Router\GroupRegistry;
 use Spiral\Router\Route;
 use Spiral\Router\RouterInterface;
 use Spiral\Router\Target\Action;
@@ -16,15 +17,15 @@ use Spiral\Router\Target\Namespaced;
 
 final class ListCommand extends Command implements SingletonInterface
 {
-    protected const NAME        = 'route:list';
+    protected const NAME = 'route:list';
     protected const DESCRIPTION = 'List application routes';
 
     /**
      * @throws \ReflectionException
      */
-    public function perform(RouterInterface $router, KernelInterface $kernel): int
+    public function perform(RouterInterface $router, GroupRegistry $registry, KernelInterface $kernel): int
     {
-        $grid = $this->table(['Name:', 'Verbs:', 'Pattern:', 'Target:']);
+        $grid = $this->table(['Name:', 'Verbs:', 'Pattern:', 'Target:', 'Group:']);
 
         foreach ($router->getRoutes() as $name => $route) {
             if ($route instanceof Route) {
@@ -34,6 +35,7 @@ final class ListCommand extends Command implements SingletonInterface
                         $this->getVerbs($route),
                         $this->getPattern($route),
                         $this->getTarget($route, $kernel),
+                        \implode(', ', $this->getRouteGroups($registry, $name)),
                     ]
                 );
             }
@@ -42,6 +44,21 @@ final class ListCommand extends Command implements SingletonInterface
         $grid->render();
 
         return self::SUCCESS;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getRouteGroups(GroupRegistry $registry, string $routeName): array
+    {
+        $groups = [];
+        foreach ($registry as $groupName => $group) {
+            if ($group->hasRoute($routeName)) {
+                $groups[] = $groupName;
+            }
+        }
+
+        return $groups;
     }
 
     private function getVerbs(Route $route): string
@@ -74,7 +91,7 @@ final class ListCommand extends Command implements SingletonInterface
 
         return \preg_replace_callback(
             '/<([^>]*)>/',
-            static fn ($m) => \sprintf('<fg=magenta>%s</>', $m[0]),
+            static fn($m) => \sprintf('<fg=magenta>%s</>', $m[0]),
             $pattern
         );
     }
@@ -89,6 +106,7 @@ final class ListCommand extends Command implements SingletonInterface
         switch (true) {
             case $target instanceof \Closure:
                 $reflection = new \ReflectionFunction($target);
+
                 return \sprintf(
                     'Closure(%s:%s)',
                     \basename($reflection->getFileName()),
@@ -99,7 +117,7 @@ final class ListCommand extends Command implements SingletonInterface
                 return \sprintf(
                     '%s->%s',
                     $this->relativeClass($this->getValue($target, 'controller'), $kernel),
-                    \implode('|', (array) $this->getValue($target, 'action'))
+                    \implode('|', (array)$this->getValue($target, 'action'))
                 );
 
             case $target instanceof Controller:

--- a/src/Router/src/GroupRegistry.php
+++ b/src/Router/src/GroupRegistry.php
@@ -11,9 +11,7 @@ use Spiral\Core\FactoryInterface;
  */
 final class GroupRegistry implements \IteratorAggregate
 {
-    private string $defaultGroup = 'web';
-
-    /** @var RouteGroup[] */
+    /** @var array<non-empty-string, RouteGroup> */
     private array $groups = [];
 
     public function __construct(
@@ -28,18 +26,6 @@ final class GroupRegistry implements \IteratorAggregate
         }
 
         return $this->groups[$name];
-    }
-
-    public function setDefaultGroup(string $group): self
-    {
-        $this->defaultGroup = $group;
-
-        return $this;
-    }
-
-    public function getDefaultGroup(): string
-    {
-        return $this->defaultGroup;
     }
 
     /**

--- a/src/Router/src/GroupRegistry.php
+++ b/src/Router/src/GroupRegistry.php
@@ -11,6 +11,8 @@ use Spiral\Core\FactoryInterface;
  */
 final class GroupRegistry implements \IteratorAggregate
 {
+    private string $defaultGroup = 'web';
+
     /** @var array<non-empty-string, RouteGroup> */
     private array $groups = [];
 
@@ -26,6 +28,18 @@ final class GroupRegistry implements \IteratorAggregate
         }
 
         return $this->groups[$name];
+    }
+
+    public function setDefaultGroup(string $group): self
+    {
+        $this->defaultGroup = $group;
+
+        return $this;
+    }
+
+    public function getDefaultGroup(): string
+    {
+        return $this->defaultGroup;
     }
 
     /**

--- a/src/Router/src/PipelineFactory.php
+++ b/src/Router/src/PipelineFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Router;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Spiral\Core\Container;
+use Spiral\Core\Container\Autowire;
+use Spiral\Http\Pipeline;
+use Spiral\Router\Exception\RouteException;
+
+final class PipelineFactory
+{
+    public function __construct(
+        private readonly Container $container
+    ) {
+    }
+
+    /**
+     * @throws RouteException
+     * @throws ContainerExceptionInterface
+     */
+    public function createWithMiddleware(array $middleware): Pipeline
+    {
+        if (\count($middleware) === 1 && $middleware[0] instanceof Pipeline) {
+            return $middleware[0];
+        }
+
+        $pipeline = $this->container->get(Pipeline::class);
+
+        foreach ($middleware as $item) {
+            if ($item instanceof MiddlewareInterface) {
+                $pipeline->pushMiddleware($item);
+            } elseif (\is_string($item) || $item instanceof Autowire) {
+                $pipeline->pushMiddleware($this->container->get($item));
+            } else {
+                $name = get_debug_type($item);
+                throw new RouteException(\sprintf('Invalid middleware `%s`', $name));
+            }
+        }
+
+        return $pipeline;
+    }
+}

--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -21,14 +21,24 @@ final class RouteGroup
     /** @var string[] */
     private array $routes = [];
 
+    /** @var array<class-string<MiddlewareInterface>>|MiddlewareInterface|Autowire */
+    private array $middleware = [];
+
     private ?CoreInterface $core = null;
 
     public function __construct(
         private readonly ContainerInterface $container,
         private readonly RouterInterface $router,
-        private readonly Pipeline $pipeline,
         private readonly UriHandler $handler
     ) {
+    }
+
+    /**
+     * Check if group has a route with given name
+     */
+    public function hasRoute(string $name): bool
+    {
+        return \in_array($name, $this->routes);
     }
 
     /**
@@ -46,7 +56,7 @@ final class RouteGroup
 
     public function setCore(Autowire|CoreInterface|string $core): self
     {
-        if (!$core instanceof CoreInterface) {
+        if (! $core instanceof CoreInterface) {
             $core = $this->container->get($core);
         }
         $this->core = $core;
@@ -59,17 +69,10 @@ final class RouteGroup
 
     /**
      * @param MiddlewareInterface|Autowire|class-string<MiddlewareInterface>|non-empty-string $middleware
-     *
-     * @throws \Psr\Container\ContainerExceptionInterface
-     * @throws \Psr\Container\NotFoundExceptionInterface
      */
     public function addMiddleware(MiddlewareInterface|Autowire|string $middleware): self
     {
-        if (!$middleware instanceof MiddlewareInterface) {
-            $middleware = $this->container->get($middleware);
-        }
-
-        $this->pipeline->pushMiddleware($middleware);
+        $this->middleware[] = $middleware;
 
         // update routes
         $this->flushRoutes();
@@ -113,6 +116,6 @@ final class RouteGroup
 
         return $route
             ->withUriHandler($this->handler->withPrefix($this->prefix))
-            ->withMiddleware($this->pipeline);
+            ->withMiddleware(...$this->middleware);
     }
 }

--- a/src/Router/src/Router.php
+++ b/src/Router/src/Router.php
@@ -111,6 +111,7 @@ final class Router implements RouterInterface
 
     public function import(RoutingConfigurator $routes): void
     {
+        /** @var GroupRegistry $groups */
         $groups = $this->container->get(GroupRegistry::class);
 
         /** @var RouteConfigurator $configurator */

--- a/src/Router/tests/RoutesGroupTest.php
+++ b/src/Router/tests/RoutesGroupTest.php
@@ -32,7 +32,7 @@ class RoutesGroupTest extends BaseTest
     {
         $handler = new UriHandler(new Psr17Factory());
         $router = new Router('/', $handler, $this->container);
-        $group = new RouteGroup($this->container, $router, new Pipeline($this->container), $handler);
+        $group = new RouteGroup($this->container, $router, $handler);
 
         $group->setCore(RoutesTestCore::class);
 
@@ -51,7 +51,7 @@ class RoutesGroupTest extends BaseTest
     {
         $handler = new UriHandler(new Psr17Factory());
         $router = new Router('/', $handler, $this->container);
-        $group = new RouteGroup($this->container, $router, new Pipeline($this->container), $handler);
+        $group = new RouteGroup($this->container, $router, $handler);
 
         $group->setCore(new RoutesTestCore($this->container));
 
@@ -66,12 +66,23 @@ class RoutesGroupTest extends BaseTest
         $this->assertInstanceOf(RoutesTestCore::class, $this->getActionProperty($t, 'core'));
     }
 
+    public function testGroupHasRoute(): void
+    {
+        $handler = new UriHandler(new Psr17Factory());
+        $router = new Router('/', $handler, $this->container);
+        $group = new RouteGroup($this->container, $router, $handler);
+
+        $group->addRoute('foo', new Route('/', new Action('controller', 'method')));
+        $this->assertTrue($group->hasRoute('foo'));
+        $this->assertFalse($group->hasRoute('bar'));
+    }
+
     /** @dataProvider middlewaresDataProvider */
     public function testMiddleware(mixed $middleware): void
     {
         $handler = new UriHandler(new Psr17Factory());
         $router = new Router('/', $handler, $this->container);
-        $group = new RouteGroup($this->container, $router, new Pipeline($this->container), $handler);
+        $group = new RouteGroup($this->container, $router, $handler);
         $group->addMiddleware($middleware);
 
         $group->addRoute('name', new Route('/', new Action('controller', 'method')));
@@ -89,7 +100,7 @@ class RoutesGroupTest extends BaseTest
         $handler = new UriHandler(new Psr17Factory());
         $router = new Router('/', $handler, $this->container);
 
-        $group = new RouteGroup($this->container, $router, new Pipeline($this->container), $handler);
+        $group = new RouteGroup($this->container, $router, $handler);
         $group->addMiddleware(TestMiddleware::class);
 
         $route = new Route('/', new Action('controller', 'method'));
@@ -103,7 +114,7 @@ class RoutesGroupTest extends BaseTest
 
         $this->assertCount(2, $m);
 
-        $this->assertInstanceOf(TestMiddleware::class, $this->getProperty($m[1], 'middleware')[0]);
+        $this->assertInstanceOf(TestMiddleware::class, $m[1]);
         $this->assertInstanceOf(AnotherMiddleware::class, $m[0]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

With this PR for all middleware groups will register container bindings with alias `middleware:<group>` and Pipeline, that contains all middleware from the group.
It will allow to do something like this:

```php
protected function middlewareGroups(): array
{
    return [
        'web' => [
            CookiesMiddleware::class,
            SessionMiddleware::class,
            CsrfMiddleware::class,
            AuthMiddleware::class,
        ],
        'admin' => [
            'middleware:web',
            new OverwriteFirewall(new Uri('/login'), 303),
        ],
    ];
}
``` 

or

```php
$route = new Route(....);

$route->withMiddleware('middleware:web');
```
