### PR TITLE
Console command refactoring

### DIFF
--- a/src/Console/src/Bootloader/ConsoleBootloader.php
+++ b/src/Console/src/Bootloader/ConsoleBootloader.php
@@ -19,6 +19,7 @@ use Spiral\Console\LocatorInterface;
 use Spiral\Console\Sequence\CallableSequence;
 use Spiral\Console\Sequence\CommandSequence;
 use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
 
@@ -58,6 +59,17 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
 
         $this->addCommand(CleanCommand::class);
         $this->addCommand(PublishCommand::class);
+    }
+
+    /**
+     * @param class-string<CoreInterceptorInterface>|string $interceptor
+     */
+    public function addInterceptor(string $interceptor): void
+    {
+        $this->config->modify(
+            ConsoleConfig::CONFIG,
+            new Append('interceptors', null, $interceptor)
+        );
     }
 
     /**

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -39,12 +39,14 @@ abstract class Command extends SymfonyCommand
     /** @var array<class-string<CoreInterceptorInterface>> */
     protected array $interceptors = [];
 
+    /** {@internal} */
     public function setContainer(ContainerInterface $container): void
     {
         $this->container = $container;
     }
 
     /**
+     * {@internal}
      * @param array<class-string<CoreInterceptorInterface>> $interceptors
      */
     public function setInterceptors(array $interceptors): void

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -7,11 +7,14 @@ namespace Spiral\Console;
 use Psr\Container\ContainerInterface;
 use Spiral\Console\Signature\Parser;
 use Spiral\Console\Traits\HelpersTrait;
+use Spiral\Core\CoreInterceptorInterface;
+use Spiral\Core\CoreInterface;
 use Spiral\Core\Exception\ScopeException;
-use Spiral\Core\InvokerInterface;
+use Spiral\Core\InterceptableCore;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Provides automatic command configuration and access to global container scope.
@@ -33,9 +36,20 @@ abstract class Command extends SymfonyCommand
 
     protected ?ContainerInterface $container = null;
 
+    /** @var array<class-string<CoreInterceptorInterface>> */
+    protected array $interceptors = [];
+
     public function setContainer(ContainerInterface $container): void
     {
         $this->container = $container;
+    }
+
+    /**
+     * @param array<class-string<CoreInterceptorInterface>> $interceptors
+     */
+    public function setInterceptors(array $interceptors): void
+    {
+        $this->interceptors = $interceptors;
     }
 
     /**
@@ -49,16 +63,42 @@ abstract class Command extends SymfonyCommand
 
         $method = method_exists($this, 'perform') ? 'perform' : '__invoke';
 
-        $invoker = $this->container->get(InvokerInterface::class);
+        $core = $this->buildCore();
 
         try {
-            [$this->input, $this->output] = [$input, $output];
+            [$this->input, $this->output] = [$this->prepareInput($input), $this->prepareOutput($input, $output)];
 
             // Executing perform method with method injection
-            return (int)$invoker->invoke([$this, $method], \compact('input', 'output'));
+            return (int)$core->callAction(static::class, $method, [
+                'input' => $this->input,
+                'output' => $this->output,
+                'command' => $this,
+            ]);
         } finally {
             [$this->input, $this->output] = [null, null];
         }
+    }
+
+    protected function buildCore(): CoreInterface
+    {
+        $core = $this->container->get(CommandCore::class);
+        $interceptableCore = new InterceptableCore($core);
+
+        foreach ($this->interceptors as $interceptor) {
+            $interceptableCore->addInterceptor($this->container->get($interceptor));
+        }
+
+        return $interceptableCore;
+    }
+
+    protected function prepareInput(InputInterface $input): InputInterface
+    {
+        return $input;
+    }
+
+    protected function prepareOutput(InputInterface $input, OutputInterface $output): OutputInterface
+    {
+        return new SymfonyStyle($input, $output);
     }
 
     /**

--- a/src/Console/src/CommandCore.php
+++ b/src/Console/src/CommandCore.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Console;
+
+use Spiral\Core\CoreInterface;
+use Spiral\Core\InvokerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CommandCore implements CoreInterface
+{
+    public function __construct(
+        private readonly InvokerInterface $invoker
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     input: InputInterface,
+     *     output: OutputInterface,
+     *     command: Command
+     * } $parameters
+     */
+    public function callAction(string $commandName, string $method, array $parameters = []): int
+    {
+        $input = $parameters['input'];
+        $output = $parameters['output'];
+        $command = $parameters['command'];
+
+        return (int)$this->invoker->invoke([$command, $method], \compact('input', 'output'));
+    }
+}

--- a/src/Console/src/CommandCore.php
+++ b/src/Console/src/CommandCore.php
@@ -17,18 +17,14 @@ final class CommandCore implements CoreInterface
     }
 
     /**
-     * @param array{
-     *     input: InputInterface,
-     *     output: OutputInterface,
-     *     command: Command
-     * } $parameters
+     * @param array{input: InputInterface, output: OutputInterface, command: Command}|array<empty, empty> $parameters
      */
-    public function callAction(string $commandName, string $method, array $parameters = []): int
+    public function callAction(string $controller, string $action, array $parameters = []): int
     {
         $input = $parameters['input'];
         $output = $parameters['output'];
         $command = $parameters['command'];
 
-        return (int)$this->invoker->invoke([$command, $method], \compact('input', 'output'));
+        return (int)$this->invoker->invoke([$command, $action], \compact('input', 'output'));
     }
 }

--- a/src/Console/src/Config/ConsoleConfig.php
+++ b/src/Console/src/Config/ConsoleConfig.php
@@ -8,6 +8,7 @@ use Spiral\Console\Exception\ConfigException;
 use Spiral\Console\Sequence\CallableSequence;
 use Spiral\Console\Sequence\CommandSequence;
 use Spiral\Console\SequenceInterface;
+use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\InjectableConfig;
 
 final class ConsoleConfig extends InjectableConfig
@@ -19,6 +20,7 @@ final class ConsoleConfig extends InjectableConfig
         'version' => null,
         'commands' => [],
         'sequences' => [],
+        'interceptors' => [],
     ];
 
     public function getName(): string
@@ -29,6 +31,18 @@ final class ConsoleConfig extends InjectableConfig
     public function getVersion(): string
     {
         return $this->config['version'] ?? 'UNKNOWN';
+    }
+
+    /**
+     * @return array<class-string<CoreInterceptorInterface>>
+     */
+    public function getInterceptors(): array
+    {
+        if (!\array_key_exists('interceptors', $this->config)) {
+            return [];
+        }
+
+        return $this->config['interceptors'];
     }
 
     /**

--- a/src/Console/src/Console.php
+++ b/src/Console/src/Console.php
@@ -96,7 +96,7 @@ final class Console
         }
 
         // Register user defined commands
-        $static = new StaticLocator($this->config->getCommands(), $this->container);
+        $static = new StaticLocator($this->config->getCommands(), $this->config, $this->container);
         $this->addCommands($static->locateCommands());
 
         return $this->application;
@@ -104,9 +104,12 @@ final class Console
 
     private function addCommands(iterable $commands): void
     {
+        $interceptors = $this->config->getInterceptors();
+
         foreach ($commands as $command) {
             if ($command instanceof Command) {
                 $command->setContainer($this->container);
+                $command->setInterceptors($interceptors);
             }
 
             $this->application->add($command);

--- a/src/Console/src/StaticLocator.php
+++ b/src/Console/src/StaticLocator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Console;
 
 use Psr\Container\ContainerInterface;
+use Spiral\Console\Config\ConsoleConfig;
 use Spiral\Console\Traits\LazyTrait;
 use Spiral\Core\Container;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -18,6 +19,7 @@ final class StaticLocator implements LocatorInterface
      */
     public function __construct(
         private readonly array $commands,
+        private ConsoleConfig $config,
         private ContainerInterface $container = new Container()
     ) {
     }

--- a/src/Console/src/Traits/HelpersTrait.php
+++ b/src/Console/src/Traits/HelpersTrait.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Trait expect command to set $output and $input scopes.
@@ -18,6 +19,7 @@ trait HelpersTrait
     /**
      * OutputInterface is the interface implemented by all Output classes. Only exists when command
      * are being executed.
+     * @var OutputInterface|SymfonyStyle|null
      */
     protected ?OutputInterface $output = null;
 
@@ -174,7 +176,7 @@ trait HelpersTrait
      */
     protected function newLine(int $count = 1): void
     {
-        $this->output->write(\str_repeat(\PHP_EOL, $count));
+        $this->output->newLine($count);
     }
 
     /**

--- a/src/Console/src/Traits/LazyTrait.php
+++ b/src/Console/src/Traits/LazyTrait.php
@@ -6,12 +6,14 @@ namespace Spiral\Console\Traits;
 
 use Psr\Container\ContainerInterface;
 use Spiral\Console\Command as SpiralCommand;
+use Spiral\Console\Config\ConsoleConfig;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Command\LazyCommand;
 
 trait LazyTrait
 {
     private ContainerInterface $container;
+    private ConsoleConfig $config;
 
     /**
      * Check if command can be lazy-loaded.
@@ -41,6 +43,7 @@ trait LazyTrait
             function () use ($class): SymfonyCommand {
                 $command = $this->container->get($class);
                 $command->setContainer($this->container);
+                $command->setInterceptors($this->config->getInterceptors());
 
                 return $command;
             }

--- a/src/Console/tests/BaseTest.php
+++ b/src/Console/tests/BaseTest.php
@@ -1,22 +1,18 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Console\CommandLocator;
 use Spiral\Console\Config\ConsoleConfig;
 use Spiral\Console\Console;
 use Spiral\Console\LocatorInterface;
 use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\User\UserCommand;
 use Spiral\Core\Container;
+use Spiral\Tokenizer\ScopedClassesInterface;
 
 abstract class BaseTest extends TestCase
 {
@@ -27,11 +23,13 @@ abstract class BaseTest extends TestCase
 
     public const CONFIG = [
         'locateCommands' => false,
-        'commands'       => [
-            UserCommand::class
-        ]
+        'commands' => [
+            UserCommand::class,
+        ],
+        'interceptors' => []
     ];
-    protected $container;
+
+    protected Container $container;
 
     public function setUp(): void
     {
@@ -45,9 +43,29 @@ abstract class BaseTest extends TestCase
 
     protected function getCore(LocatorInterface $locator = null): Console
     {
+        $config = $this->container->get(ConsoleConfig::class);
+
         return new Console(
+            $config,
+            $locator ?? $this->getStaticLocator([]),
+            $this->container
+        );
+    }
+
+    protected function getStaticLocator(array $commands): StaticLocator
+    {
+        return new StaticLocator(
+            $commands,
             $this->container->get(ConsoleConfig::class),
-            $locator ?? new StaticLocator([], $this->container),
+            $this->container
+        );
+    }
+
+    protected function getCommandLocator(ScopedClassesInterface $classes): CommandLocator
+    {
+        return new CommandLocator(
+            $classes,
+            $this->container->get(ConsoleConfig::class),
             $this->container
         );
     }

--- a/src/Console/tests/ConfigTest.php
+++ b/src/Console/tests/ConfigTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;

--- a/src/Console/tests/ConfigureTest.php
+++ b/src/Console/tests/ConfigureTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
@@ -13,7 +7,6 @@ namespace Spiral\Tests\Console;
 use Spiral\Console\Command\ConfigureCommand;
 use Spiral\Console\Config\ConsoleConfig;
 use Spiral\Console\Console;
-use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\AnotherFailedCommand;
 use Spiral\Tests\Console\Fixtures\FailedCommand;
 use Spiral\Tests\Console\Fixtures\HelperCommand;
@@ -48,11 +41,11 @@ class ConfigureTest extends BaseTest
     public function testConfigure(): void
     {
         $core = $this->getCore(
-            new StaticLocator([
-                HelperCommand::class,
-                ConfigureCommand::class,
-                TestCommand::class,
-            ])
+           $this->getStaticLocator([
+               HelperCommand::class,
+               ConfigureCommand::class,
+               TestCommand::class,
+           ])
         );
 
         $this->container->bind(Console::class, $core);
@@ -147,7 +140,7 @@ class ConfigureTest extends BaseTest
     private function bindFailure(): Console
     {
         $core = $this->getCore(
-            new StaticLocator([
+            $this->getStaticLocator([
                 HelperCommand::class,
                 ConfigureCommand::class,
                 TestCommand::class,

--- a/src/Console/tests/CoreTest.php
+++ b/src/Console/tests/CoreTest.php
@@ -1,16 +1,9 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
 
-use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\TestCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -19,7 +12,7 @@ class CoreTest extends BaseTest
 {
     public function testWelcome(): void
     {
-        $core = $this->getCore(new StaticLocator([
+        $core = $this->getCore($this->getStaticLocator([
             TestCommand::class
         ]));
 
@@ -36,7 +29,7 @@ class CoreTest extends BaseTest
 
     public function testStart(): void
     {
-        $core = $this->getCore(new StaticLocator([
+        $core = $this->getCore($this->getStaticLocator([
             TestCommand::class
         ]));
 

--- a/src/Console/tests/Fixtures/AbstractCommand.php
+++ b/src/Console/tests/Fixtures/AbstractCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;

--- a/src/Console/tests/Fixtures/AnotherFailedCommand.php
+++ b/src/Console/tests/Fixtures/AnotherFailedCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;

--- a/src/Console/tests/Fixtures/FailedCommand.php
+++ b/src/Console/tests/Fixtures/FailedCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;

--- a/src/Console/tests/Fixtures/HelperCommand.php
+++ b/src/Console/tests/Fixtures/HelperCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;

--- a/src/Console/tests/Fixtures/LazyLoadedCommand.php
+++ b/src/Console/tests/Fixtures/LazyLoadedCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Vladislav Gorenkin (vladgorenkin)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;

--- a/src/Console/tests/Fixtures/OptionalCommand.php
+++ b/src/Console/tests/Fixtures/OptionalCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;

--- a/src/Console/tests/Fixtures/TestCommand.php
+++ b/src/Console/tests/Fixtures/TestCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures;
@@ -18,7 +12,7 @@ class TestCommand extends Command implements SingletonInterface
     public const NAME = 'test';
     public const DESCRIPTION = 'Test Command';
 
-    private $count = 0;
+    private int $count = 0;
 
     public function perform(): void
     {

--- a/src/Console/tests/Fixtures/User/UserCommand.php
+++ b/src/Console/tests/Fixtures/User/UserCommand.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Fixtures\User;

--- a/src/Console/tests/HelpersTest.php
+++ b/src/Console/tests/HelpersTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
 
-use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\HelperCommand;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,7 +16,7 @@ class HelpersTest extends BaseTest
     {
         parent::setUp();
 
-        $this->core = $this->getCore(new StaticLocator([
+        $this->core = $this->getCore($this->getStaticLocator([
             HelperCommand::class
         ]));
     }

--- a/src/Console/tests/InterceptorTest.php
+++ b/src/Console/tests/InterceptorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Console;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Spiral\Core\CoreInterceptorInterface;
+use Spiral\Core\CoreInterface;
+use Spiral\Tests\Console\Fixtures\TestCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class InterceptorTest extends BaseTest
+{
+    use MockeryPHPUnitIntegration;
+
+    public const CONFIG = [
+        'interceptors' => [
+            'foo'
+        ]
+    ];
+
+    public function testInterceptorShouldBeResolved(): void
+    {
+        $this->container->bind('foo', $interceptor = \Mockery::mock(CoreInterceptorInterface::class));
+
+        $interceptor->shouldReceive('process')
+            ->once()
+            ->withArgs(function (string $controller, string $action, array $parameters, CoreInterface $core) {
+                return $controller === TestCommand::class
+                    && $action === 'perform'
+                    && $parameters['input'] instanceof InputInterface
+                    && $parameters['output'] instanceof OutputInterface
+                    && $parameters['command'] instanceof TestCommand;
+            })
+            ->andReturnUsing(function (string $controller, string $action, array $parameters, CoreInterface $core) {
+                return $core->callAction($controller, $action, $parameters);
+            });
+
+        $core = $this->getCore($this->getStaticLocator([
+            TestCommand::class
+        ]));
+
+        $core->run('test');
+    }
+}

--- a/src/Console/tests/LazyTest.php
+++ b/src/Console/tests/LazyTest.php
@@ -1,19 +1,11 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Vladislav Gorenkin (vladgorenkin)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
 
 use Spiral\Console\CommandLocator;
-use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\LazyLoadedCommand;
-use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Tokenizer\ScopedClassesInterface;
 use Symfony\Component\Console\Command\LazyCommand;
 
@@ -21,7 +13,7 @@ class LazyTest extends BaseTest
 {
     public function testLazyCommandCreationInCommandLocator(): void
     {
-        $locator = new CommandLocator(
+        $locator = $this->getCommandLocator(
             new class() implements ScopedClassesInterface {
                 public function getScopedClasses(string $scope, $target = null): array
                 {
@@ -29,8 +21,7 @@ class LazyTest extends BaseTest
                         new \ReflectionClass(LazyLoadedCommand::class),
                     ];
                 }
-            },
-            $this->container
+            }
         );
         $commands = $locator->locateCommands();
         $command = reset($commands);
@@ -42,7 +33,7 @@ class LazyTest extends BaseTest
 
     public function testLazyCommandCreationInStaticLocator(): void
     {
-        $locator = new StaticLocator([LazyLoadedCommand::class]);
+        $locator = $this->getStaticLocator([LazyLoadedCommand::class]);
         $commands = $locator->locateCommands();
         $command = reset($commands);
 
@@ -53,7 +44,7 @@ class LazyTest extends BaseTest
 
     public function testLazyCommandExecution(): void
     {
-        $core = $this->getCore(new StaticLocator([LazyLoadedCommand::class]));
+        $core = $this->getCore($this->getStaticLocator([LazyLoadedCommand::class]));
         $output = $core->run('lazy');
         $this->assertSame('OK', $output->getOutput()->fetch());
     }

--- a/src/Console/tests/OptionsTest.php
+++ b/src/Console/tests/OptionsTest.php
@@ -1,23 +1,16 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
 
-use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\OptionalCommand;
 
 class OptionsTest extends BaseTest
 {
     public function testOptions(): void
     {
-        $core = $this->getCore(new StaticLocator([
+        $core = $this->getCore($this->getStaticLocator([
             OptionalCommand::class
         ]));
 

--- a/src/Console/tests/ScopeTest.php
+++ b/src/Console/tests/ScopeTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;

--- a/src/Console/tests/ShortException.php
+++ b/src/Console/tests/ShortException.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * Spiral Framework.
- *
- * @license   MIT
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;

--- a/src/Console/tests/SignatureTest.php
+++ b/src/Console/tests/SignatureTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Tests\Console;
 
 use Spiral\Console\Command;
-use Spiral\Console\StaticLocator;
 use Symfony\Component\Console\Input\StringInput;
 
 final class SignatureTest extends BaseTest
@@ -13,7 +12,7 @@ final class SignatureTest extends BaseTest
     public function testOptions(): void
     {
         $core = $this->getCore(
-            new StaticLocator([
+            $this->getStaticLocator([
                 new class extends Command {
                     protected const SIGNATURE = 'foo:bar {arg?} {--o|option}';
 
@@ -65,14 +64,14 @@ final class SignatureTest extends BaseTest
     public function testArrayableOptions(): void
     {
         $core = $this->getCore(
-            new StaticLocator([
+            $this->getStaticLocator([
                 new class extends Command {
                     protected const SIGNATURE = 'foo:bar {arg[]?} {--o|option[]=}';
 
                     public function perform(): int
                     {
-                        $argument = (array) $this->argument('arg');
-                        $option = (array) $this->option('option');
+                        $argument = (array)$this->argument('arg');
+                        $option = (array)$this->option('option');
 
                         if ($argument) {
                             $this->write('argument : '.\implode(',', $argument));
@@ -110,14 +109,15 @@ final class SignatureTest extends BaseTest
 
         $this->assertSame(
             'argument : bar,baz,bakoption : far,faz',
-            $core->run(command: 'foo:bar', input: new StringInput('foo:bar bar baz bak -ofar --option=faz'))->getOutput()->fetch()
+            $core->run(command: 'foo:bar', input: new StringInput('foo:bar bar baz bak -ofar --option=faz'))->getOutput(
+            )->fetch()
         );
     }
 
     public function testDescription(): void
     {
         $core = $this->getCore(
-            new StaticLocator([
+            $this->getStaticLocator([
                 new class extends Command {
                     protected const SIGNATURE = 'foo:bar 
                                     {foo : Foo arg description. }  
@@ -158,7 +158,7 @@ Options:
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 HELP
-,
+            ,
             $core->run(command: 'help', input: ['command_name' => 'foo:bar'])->getOutput()->fetch()
         );
     }

--- a/src/Console/tests/UpdateTest.php
+++ b/src/Console/tests/UpdateTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * Spiral Framework, SpiralScout LLC.
- *
- * @author    Anton Titov (Wolfy-J)
- */
-
 declare(strict_types=1);
 
 namespace Spiral\Tests\Console;
@@ -13,7 +7,6 @@ namespace Spiral\Tests\Console;
 use Spiral\Console\Command\UpdateCommand;
 use Spiral\Console\Config\ConsoleConfig;
 use Spiral\Console\Console;
-use Spiral\Console\StaticLocator;
 use Spiral\Tests\Console\Fixtures\AnotherFailedCommand;
 use Spiral\Tests\Console\Fixtures\FailedCommand;
 use Spiral\Tests\Console\Fixtures\HelperCommand;
@@ -46,7 +39,7 @@ class UpdateTest extends BaseTest
     public function testConfigure(): void
     {
         $core = $this->getCore(
-            new StaticLocator([
+            $this->getStaticLocator([
                 HelperCommand::class,
                 TestCommand::class,
                 UpdateCommand::class,
@@ -145,7 +138,7 @@ text;
     private function bindFailure(): Console
     {
         $core = $this->getCore(
-            new StaticLocator([
+            $this->getStaticLocator([
                 HelperCommand::class,
                 TestCommand::class,
                 UpdateCommand::class,

--- a/src/Framework/Console/CommandLocator.php
+++ b/src/Framework/Console/CommandLocator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Console;
 
 use Psr\Container\ContainerInterface;
+use Spiral\Console\Config\ConsoleConfig;
 use Spiral\Console\Traits\LazyTrait;
 use Spiral\Tokenizer\ScopedClassesInterface;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -15,6 +16,7 @@ final class CommandLocator implements LocatorInterface
 
     public function __construct(
         private readonly ScopedClassesInterface $classes,
+        private ConsoleConfig $config,
         ContainerInterface $container
     ) {
         $this->container = $container;

--- a/tests/Framework/Bootloader/Console/ConsoleBootloaderTest.php
+++ b/tests/Framework/Bootloader/Console/ConsoleBootloaderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Bootloader\Console;
+
+use Spiral\Config\ConfigManager;
+use Spiral\Config\LoaderInterface;
+use Spiral\Console\Bootloader\ConsoleBootloader;
+use Spiral\Console\CommandLocator;
+use Spiral\Console\Config\ConsoleConfig;
+use Spiral\Console\Console;
+use Spiral\Console\ConsoleDispatcher;
+use Spiral\Console\LocatorInterface;
+use Spiral\Console\Sequence\CommandSequence;
+use Spiral\Tests\Framework\BaseTest;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class ConsoleBootloaderTest extends BaseTest
+{
+    public function testConsoleBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(Console::class, Console::class);
+    }
+
+    public function testLocatorInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(LocatorInterface::class, CommandLocator::class);
+    }
+
+    public function testConsoleDispatcher(): void
+    {
+        $this->assertDispatcherRegistered(ConsoleDispatcher::class);
+    }
+
+    public function testAddInterceptor(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(ConsoleConfig::CONFIG, ['interceptors' => []]);
+
+        $bootloader = new ConsoleBootloader($configs);
+        $bootloader->addInterceptor('foo');
+        $bootloader->addInterceptor('bar');
+
+        $this->assertSame([
+            'foo', 'bar'
+        ], $configs->getConfig(ConsoleConfig::CONFIG)['interceptors']);
+    }
+
+    public function testAddCommand(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(ConsoleConfig::CONFIG, ['commands' => []]);
+
+        $bootloader = new ConsoleBootloader($configs);
+        $bootloader->addCommand('foo');
+        $bootloader->addCommand('bar');
+        $bootloader->addCommand('baz', true);
+        $bootloader->addCommand('baf');
+
+        $this->assertSame([
+            'baz', 'foo', 'bar', 'baf'
+        ], $configs->getConfig(ConsoleConfig::CONFIG)['commands']);
+    }
+
+    public function testAddConfigureSequence(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
+
+        $bootloader = new ConsoleBootloader($configs);
+        $bootloader->addConfigureSequence('foo', 'header', 'footer');
+
+        $sequences = $configs->getConfig(ConsoleConfig::CONFIG)['sequences']['configure'];
+
+        $output = new BufferedOutput();
+        $this->assertInstanceOf(CommandSequence::class, $sequences[0]);
+        $sequences[0]->writeHeader($output);
+        $sequences[0]->writeFooter($output);
+        $this->assertSame('header
+footer
+', $output->fetch());
+    }
+
+    public function testAddUpdateSequence(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
+
+        $bootloader = new ConsoleBootloader($configs);
+        $bootloader->addUpdateSequence('foo', 'header', 'footer');
+
+        $sequences = $configs->getConfig(ConsoleConfig::CONFIG)['sequences']['update'];
+
+        $output = new BufferedOutput();
+        $this->assertInstanceOf(CommandSequence::class, $sequences[0]);
+        $sequences[0]->writeHeader($output);
+        $sequences[0]->writeFooter($output);
+        $this->assertSame('header
+footer
+', $output->fetch());
+    }
+
+    public function testAddCustomSequence(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
+
+        $bootloader = new ConsoleBootloader($configs);
+        $bootloader->addSequence('custom', 'foo', 'header', 'footer');
+
+        $sequences = $configs->getConfig(ConsoleConfig::CONFIG)['sequences']['custom'];
+
+        $output = new BufferedOutput();
+        $this->assertInstanceOf(CommandSequence::class, $sequences[0]);
+        $sequences[0]->writeHeader($output);
+        $sequences[0]->writeFooter($output);
+        $this->assertSame('header
+footer
+', $output->fetch());
+    }
+}

--- a/tests/Framework/Bootloader/Http/HttpBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/HttpBootloaderTest.php
@@ -13,10 +13,16 @@ use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;
 use Spiral\Core\Container\Autowire;
 use Spiral\Http\Config\HttpConfig;
+use Spiral\Http\Http;
 use Spiral\Tests\Framework\BaseTest;
 
 final class HttpBootloaderTest extends BaseTest
 {
+    public function testHttpBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(Http::class, Http::class);
+    }
+
     public function testDefaultInputBags(): void
     {
         $this->assertSame([], $this->getContainer()->get(HttpConfig::class)->getInputBags());

--- a/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
+++ b/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
@@ -53,6 +53,7 @@ final class ApplicationInProductionTest extends TestCase
 
         $output->shouldReceive('writeln');
         $output->shouldReceive('write');
+        $output->shouldReceive('newLine');
 
         $output->shouldReceive('confirm')->once()->with('Do you really wish to run command?', false)->andReturnTrue();
 
@@ -71,6 +72,7 @@ final class ApplicationInProductionTest extends TestCase
 
         $output->shouldReceive('writeln');
         $output->shouldReceive('write');
+        $output->shouldReceive('newLine');
 
         $output->shouldReceive('confirm')->once()->with('Do you really wish to run command?', false)->andReturnFalse();
 


### PR DESCRIPTION
- Adds `SymfonyStyle` output by default with ability to replace with custom output object.
- Adds command interceptors

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ✔️


## Output object replacing
```php

use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

abstract class MyCommand extends \Spiral\Console\Command 
{
    protected function prepareOutput(InputInterface $input, OutputInterface $output): OutputInterface
    {
        return new \App\Console\MyOutput($input, $output);
    }
}
```

## Interceptors
```php
class AppBootloader extends Bootloader
{
    public function init(ConsoleBootloader $console): void
    {
           $console->addInterceptor(ValidateInputInterceptor::class);
    }
}
```


```php
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Spiral\Console\Command;

class ValidateInputInterceptor implements \Spiral\Core\CoreInterceptorInterface
{
    /**
     * @param array{
     *     input: InputInterface,
     *     output: OutputInterface,
     *     command: Command
     * } $parameters
     */
    public function process(string $commandClass, string $method, array $parameters, CoreInterface $core): int
    {
         // validate ....

         return $core->callAction($commandClass, $method, $parameters);
    }
}
```
