### PR TITLE
Adds queue interceptors for consumers

### DIFF
--- a/src/Queue/src/Config/QueueConfig.php
+++ b/src/Queue/src/Config/QueueConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Queue\Config;
 
+use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\InjectableConfig;
 use Spiral\Queue\Exception\InvalidArgumentException;
 
@@ -16,6 +17,7 @@ final class QueueConfig extends InjectableConfig
         'aliases' => [],
         'driverAliases' => [],
         'connections' => [],
+        'interceptors' => [],
     ];
 
     /**
@@ -24,6 +26,15 @@ final class QueueConfig extends InjectableConfig
     public function getAliases(): array
     {
         return (array)($this->config['aliases'] ?? []);
+    }
+
+    /**
+     * Get consumer interceptors
+     * @return array<class-string<CoreInterceptorInterface>>
+     */
+    public function getInterceptors(): array
+    {
+        return (array)($this->config['interceptors'] ?? []);
     }
 
     /**

--- a/src/Queue/src/Interceptor/Core.php
+++ b/src/Queue/src/Interceptor/Core.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Interceptor;
+
+use Spiral\Core\CoreInterface;
+use Spiral\Queue\HandlerRegistryInterface;
+
+final class Core implements CoreInterface
+{
+    public function __construct(
+        private readonly HandlerRegistryInterface $registry
+    ) {
+    }
+
+    /**
+     * @param array{driver: non-empty-string, queue: non-empty-string, id: non-empty-string, payload: array}|array<empty, empty> $parameters
+     */
+    public function callAction(string $controller, string $action, array $parameters = []): mixed
+    {
+        $this->registry
+            ->getHandler($controller)
+            ->handle($controller, $parameters['id'], $parameters['payload']);
+
+        return null;
+    }
+}

--- a/src/Queue/src/Interceptor/ErrorHandlerInterceptor.php
+++ b/src/Queue/src/Interceptor/ErrorHandlerInterceptor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Interceptor;
+
+use Spiral\Core\CoreInterceptorInterface;
+use Spiral\Core\CoreInterface;
+use Spiral\Queue\Failed\FailedJobHandlerInterface;
+
+final class ErrorHandlerInterceptor implements CoreInterceptorInterface
+{
+    public function __construct(
+        private readonly FailedJobHandlerInterface $handler
+    ) {
+    }
+
+    public function process(string $controller, string $action, array $parameters, CoreInterface $core): mixed
+    {
+        try {
+            return $core->callAction($controller, $action, $parameters);
+        } catch (\Throwable $e) {
+            $this->handler->handle(
+                $parameters['driver'],
+                $parameters['queue'],
+                $controller,
+                $parameters['payload'],
+                $e
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/Queue/src/Interceptor/Handler.php
+++ b/src/Queue/src/Interceptor/Handler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Interceptor;
+
+use Spiral\Core\CoreInterface;
+
+final class Handler
+{
+    public function __construct(
+        readonly CoreInterface $core
+    ) {
+    }
+
+    public function handle(string $name, string $driver, string $queue, string $id, array $payload): mixed
+    {
+        return $this->core->callAction($name, 'handle', [
+            'driver' => $driver,
+            'queue' => $queue,
+            'id' => $id,
+            'payload' => $payload,
+        ]);
+    }
+}

--- a/src/Queue/tests/Config/QueueConfigTest.php
+++ b/src/Queue/tests/Config/QueueConfigTest.php
@@ -19,6 +19,15 @@ final class QueueConfigTest extends TestCase
         $this->assertSame(['foo', 'bar'], $config->getAliases());
     }
 
+    public function testInterceptorsAliases(): void
+    {
+        $config = new QueueConfig([
+            'interceptors' => ['foo', 'bar'],
+        ]);
+
+        $this->assertSame(['foo', 'bar'], $config->getInterceptors());
+    }
+
     public function testGetNotExistsAliases(): void
     {
         $config = new QueueConfig();

--- a/src/Queue/tests/Interceptor/CoreTest.php
+++ b/src/Queue/tests/Interceptor/CoreTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Interceptor;
+
+use Mockery as m;
+use Spiral\Queue\HandlerInterface;
+use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\Interceptor\Core;
+use Spiral\Tests\Queue\TestCase;
+
+final class CoreTest extends TestCase
+{
+    public function testCallAction(): void
+    {
+        $core = new Core(
+            $registry = m::mock(HandlerRegistryInterface::class)
+        );
+
+        $registry->shouldReceive('getHandler')->with('foo')->once()
+            ->andReturn($handler = m::mock(HandlerInterface::class));
+
+        $handler->shouldReceive('handle')->once()
+            ->with('foo', 'job-id', ['baz' => 'baf']);
+
+        $core->callAction('foo', 'bar', [
+            'id' => 'job-id',
+            'payload' => ['baz' => 'baf'],
+        ]);
+    }
+}

--- a/src/Queue/tests/Interceptor/ErrorHandlerInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/ErrorHandlerInterceptorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Interceptor;
+
+use Mockery as m;
+use Spiral\Core\CoreInterface;
+use Spiral\Queue\Failed\FailedJobHandlerInterface;
+use Spiral\Queue\Interceptor\ErrorHandlerInterceptor;
+use Spiral\Tests\Queue\TestCase;
+
+final class ErrorHandlerInterceptorTest extends TestCase
+{
+    public function testProcessError(): void
+    {
+        $interceptor = new ErrorHandlerInterceptor(
+            $handler = m::mock(FailedJobHandlerInterface::class)
+        );
+
+        $parameters = ['driver' => 'sync', 'queue' => 'default', 'payload' => ['baz' => 'bar']];
+        $exception = new \Exception('Something went wrong');
+        $core = m::mock(CoreInterface::class);
+        $core->shouldReceive('callAction')
+            ->once()
+            ->with('foo', 'bar', $parameters)
+            ->andThrow($exception);
+
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with('sync', 'default', 'foo', ['baz' => 'bar'], $exception);
+
+        $interceptor->process('foo', 'bar', $parameters, $core);
+    }
+
+    public function testHandlerShouldBeHandledWithoutError(): void
+    {
+        $interceptor = new ErrorHandlerInterceptor(
+            $handler = m::mock(FailedJobHandlerInterface::class)
+        );
+
+        $parameters = ['driver' => 'sync', 'queue' => 'default', 'payload' => ['baz' => 'bar']];
+        $core = m::mock(CoreInterface::class);
+        $core->shouldReceive('callAction')
+            ->once()
+            ->with('foo', 'bar', $parameters)
+            ->andReturnNull();
+
+        $interceptor->process('foo', 'bar', $parameters, $core);
+    }
+}

--- a/src/Queue/tests/Interceptor/HandlerTest.php
+++ b/src/Queue/tests/Interceptor/HandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Interceptor;
+
+use Mockery as m;
+use Spiral\Core\CoreInterface;
+use Spiral\Queue\Interceptor\Handler;
+use Spiral\Tests\Queue\TestCase;
+
+final class HandlerTest extends TestCase
+{
+    public function testHandle(): void
+    {
+        $handler = new Handler($core = m::mock(CoreInterface::class));
+
+        $core->shouldReceive('callAction')
+            ->once()
+            ->with('foo', 'handle', [
+                'driver' => 'sync',
+                'queue' => 'default',
+                'id' => 'job-id',
+                'payload' => ['baz' => 'bar'],
+            ]);
+
+        $handler->handle('foo', 'sync', 'default', 'job-id', ['baz' => 'bar']);
+    }
+}

--- a/src/Queue/tests/QueueManagerTest.php
+++ b/src/Queue/tests/QueueManagerTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Queue;
 
 use Mockery as m;
 use Spiral\Core\Container;
+use Spiral\Core\CoreInterface;
 use Spiral\Queue\Config\QueueConfig;
 use Spiral\Queue\Failed\FailedJobHandlerInterface;
 use Spiral\Queue\HandlerRegistryInterface;
@@ -32,9 +33,7 @@ final class QueueManagerTest extends TestCase
         ]);
 
         $container = new Container();
-        $container->bind(QueueConfig::class, $config);
-        $container->bind(HandlerRegistryInterface::class, m::mock(HandlerRegistryInterface::class));
-        $container->bind(FailedJobHandlerInterface::class, m::mock(FailedJobHandlerInterface::class));
+        $container->bind(CoreInterface::class, m::mock(CoreInterface::class));
 
         parent::setUp();
 

--- a/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
+++ b/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Bootloader\Queue;
+
+use Spiral\Config\ConfigManager;
+use Spiral\Config\LoaderInterface;
+use Spiral\Queue\Bootloader\QueueBootloader;
+use Spiral\Queue\Config\QueueConfig;
+use Spiral\Queue\Failed\FailedJobHandlerInterface;
+use Spiral\Queue\Failed\LogFailedJobHandler;
+use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\Interceptor\Handler;
+use Spiral\Queue\QueueConnectionProviderInterface;
+use Spiral\Queue\QueueManager;
+use Spiral\Queue\QueueRegistry;
+use Spiral\Tests\Framework\BaseTest;
+
+final class QueueBootloaderTest extends BaseTest
+{
+    public const ENV = [
+        'QUEUE_CONNECTION' => 'foo',
+    ];
+
+    public function testHandlerRegistryInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(HandlerRegistryInterface::class, QueueRegistry::class);
+    }
+
+    public function testFailedJobHandlerInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(FailedJobHandlerInterface::class, LogFailedJobHandler::class);
+    }
+
+    public function testQueueConnectionProviderInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(QueueConnectionProviderInterface::class, QueueManager::class);
+    }
+
+    public function testQueueManagerBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(QueueManager::class, QueueManager::class);
+    }
+
+    public function testQueueRegistryBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(QueueRegistry::class, QueueRegistry::class);
+    }
+
+    public function testHandlerBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(Handler::class, Handler::class);
+    }
+
+    public function testConfig(): void
+    {
+        $this->assertConfigMatches(QueueConfig::CONFIG, [
+            'default' => 'foo',
+            'connections' => [
+                'sync' => ['driver' => 'sync'],
+            ],
+
+            'registry' => [
+                'handlers' => [],
+            ],
+            'driverAliases' => [
+                'sync' => \Spiral\Queue\Driver\SyncDriver::class,
+                'null' => \Spiral\Queue\Driver\NullDriver::class,
+            ],
+            'interceptors' => [
+                \Spiral\Queue\Interceptor\ErrorHandlerInterceptor::class,
+            ],
+        ]);
+    }
+
+    public function testAddInterceptor(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(QueueConfig::CONFIG, ['interceptors' => []]);
+
+        $bootloader = new QueueBootloader($configs);
+        $bootloader->addInterceptor('foo');
+        $bootloader->addInterceptor('bar');
+
+        $this->assertSame([
+            'foo', 'bar'
+        ], $configs->getConfig(QueueConfig::CONFIG)['interceptors']);
+    }
+
+    public function testRegisterDriverAlias(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(QueueConfig::CONFIG, ['driverAliases' => []]);
+
+        $bootloader = new QueueBootloader($configs);
+        $bootloader->registerDriverAlias('foo', 'bar');
+
+        $this->assertSame([
+            'bar' => 'foo'
+        ], $configs->getConfig(QueueConfig::CONFIG)['driverAliases']);
+    }
+}

--- a/tests/app/src/TestApp.php
+++ b/tests/app/src/TestApp.php
@@ -49,6 +49,9 @@ class TestApp extends Kernel implements \Spiral\Testing\TestableKernelInterface
         // Cache
         \Spiral\Cache\Bootloader\CacheBootloader::class,
 
+        // Queue
+        \Spiral\Queue\Bootloader\QueueBootloader::class,
+
         // Broadcasting
         \Spiral\Broadcasting\Bootloader\BroadcastingBootloader::class,
         \Spiral\Broadcasting\Bootloader\WebsocketsBootloader::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

## Interceptors
```php
use Spiral\Queue\Bootloader\QueueBootloader;

class AppBootloader extends Bootloader
{
    public function init(QueueBootloader $console): void
    {
           $console->addInterceptor(ValidatePayloadInterceptor::class);
    }
}
```


```php
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Spiral\Console\Command;

class ValidatePayloadInterceptor implements \Spiral\Core\CoreInterceptorInterface
{
    /**
     * @param array{
     *     driver: string,
     *     queue: string,
     *     id: string,
     *     payload: array
     * } $parameters
     */
    public function process(string $commandClass, string $method, array $parameters, CoreInterface $core): int
    {
         // validate payload ....

         if (!$valid) {
             throw new \Exception('...');
         }

         return $core->callAction($commandClass, $method, $parameters);
    }
}
```