### PR TITLE
[Rector] Update rector and re-run with LevelSetList::UP_TO_PHP_74 - take 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
         "phpunit/phpunit": "^8.5|^9.5",
         "nyholm/psr7": "^1.5.0",
         "ramsey/uuid": "^4.2",
-        "rector/rector": "0.12.15",
+        "rector/rector": "0.13.8",
         "spiral/broadcast": "^2.0",
         "spiral/broadcast-ws": "^1.0",
         "spiral/code-style": "^1.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,6 +22,7 @@
     <issueHandlers>
         <UndefinedClass>
             <errorLevel type="suppress">
+                <file name="src/Framework/Bootloader/I18nBootloader.php" />
                 <file name="src/Framework/Bootloader/Server/RoadRunnerBootloader.php" />
                 <file name="src/Framework/Bootloader/Server/LegacyRoadRunnerBootloader.php" />
                 <file name="src/Framework/Bootloader/Jobs/JobsBootloader.php" />

--- a/rector.php
+++ b/rector.php
@@ -2,33 +2,31 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
+use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
-use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
         __DIR__ . '/src/*/src',
     ]);
 
-    $parameters->set(Option::PARALLEL, true);
-    $parameters->set(Option::SKIP, [
+    $rectorConfig->importShortClasses(false);
+    $rectorConfig->importNames();
+    $rectorConfig->parallel();
+    $rectorConfig->skip([
         CountOnNullRector::class,
-
-        // for PHP 8
-        RemoveUnusedPromotedPropertyRector::class,
 
         RemoveUnusedPrivateMethodRector::class => [
             __DIR__ . '/src/Boot/src/Bootloader/ConfigurationBootloader.php',
+            __DIR__ . '/src/Broadcasting/src/Bootloader/BroadcastingBootloader.php',
         ],
-    ]);
 
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
-    $containerConfigurator->import(SetList::DEAD_CODE);
+        // deprecated classes
+        __DIR__ . '/src/Http/src/Exception/EmitterException.php',
+        __DIR__ . '/src/Dumper/src/Exception/DumperException.php',
+    ]);
+    $rectorConfig->sets([LevelSetList::UP_TO_PHP_74, SetList::DEAD_CODE]);
 };

--- a/src/AnnotatedRoutes/src/Bootloader/AnnotatedRoutesBootloader.php
+++ b/src/AnnotatedRoutes/src/Bootloader/AnnotatedRoutesBootloader.php
@@ -40,11 +40,9 @@ final class AnnotatedRoutesBootloader extends Bootloader implements SingletonInt
         GroupRegistry::class => [self::class, 'getGroups'],
     ];
 
-    /** @var MemoryInterface */
-    private $memory;
+    private MemoryInterface $memory;
 
-    /** @var GroupRegistry */
-    private $groups;
+    private GroupRegistry $groups;
 
     public function __construct(MemoryInterface $memory, GroupRegistry $groupRegistry)
     {

--- a/src/AnnotatedRoutes/src/RouteLocator.php
+++ b/src/AnnotatedRoutes/src/RouteLocator.php
@@ -19,8 +19,7 @@ final class RouteLocator
 {
     private ScopedClassesInterface $locator;
 
-    /** @var ReaderInterface */
-    private $reader;
+    private ReaderInterface $reader;
 
     public function __construct(ScopedClassesInterface $locator, ReaderInterface $reader)
     {
@@ -54,7 +53,7 @@ final class RouteLocator
                     continue;
                 }
 
-                $route->name = $route->name ?? $this->generateName($route);
+                $route->name ??= $this->generateName($route);
                 $result[$route->name] = [
                     'pattern'    => $route->route,
                     'controller' => $class->getName(),
@@ -68,9 +67,7 @@ final class RouteLocator
             }
         }
 
-        \uasort($result, static function (array $route1, array $route2) {
-            return $route1['priority'] <=> $route2['priority'];
-        });
+        \uasort($result, static fn(array $route1, array $route2) => $route1['priority'] <=> $route2['priority']);
 
         return $result;
     }

--- a/src/AnnotatedRoutes/src/RouteLocator.php
+++ b/src/AnnotatedRoutes/src/RouteLocator.php
@@ -67,7 +67,7 @@ final class RouteLocator
             }
         }
 
-        \uasort($result, static fn(array $route1, array $route2) => $route1['priority'] <=> $route2['priority']);
+        \uasort($result, static fn (array $route1, array $route2) => $route1['priority'] <=> $route2['priority']);
 
         return $result;
     }

--- a/src/Annotations/src/AnnotatedClass.php
+++ b/src/Annotations/src/AnnotatedClass.php
@@ -16,8 +16,7 @@ namespace Spiral\Annotations;
  */
 final class AnnotatedClass
 {
-    /** @var \ReflectionClass */
-    private $class;
+    private \ReflectionClass $class;
 
     /** @var mixed */
     private $annotation;

--- a/src/Annotations/src/AnnotatedMethod.php
+++ b/src/Annotations/src/AnnotatedMethod.php
@@ -16,8 +16,7 @@ namespace Spiral\Annotations;
  */
 final class AnnotatedMethod
 {
-    /** @var \ReflectionMethod */
-    private $method;
+    private \ReflectionMethod $method;
 
     /** @var mixed */
     private $annotation;

--- a/src/Annotations/src/AnnotatedProperty.php
+++ b/src/Annotations/src/AnnotatedProperty.php
@@ -16,8 +16,7 @@ namespace Spiral\Annotations;
  */
 final class AnnotatedProperty
 {
-    /** @var \ReflectionProperty */
-    private $property;
+    private \ReflectionProperty $property;
 
     /** @var mixed */
     private $annotation;

--- a/src/Annotations/src/AnnotationLocator.php
+++ b/src/Annotations/src/AnnotationLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Annotations;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\Factory;
 use Spiral\Attributes\ReaderInterface;
@@ -24,20 +25,17 @@ use Spiral\Tokenizer\ClassesInterface;
  */
 final class AnnotationLocator implements SingletonInterface
 {
-    /** @var ClassesInterface */
-    private $classLocator;
+    private ClassesInterface $classLocator;
 
-    /** @var ReaderInterface */
-    private $reader;
+    private ReaderInterface $reader;
 
-    /** @var array */
-    private $targets = [];
+    private array $targets = [];
 
     /**
      * AnnotationLocator constructor.
      *
      * @param ReaderInterface|null $reader
-     * @throws \Doctrine\Common\Annotations\AnnotationException
+     * @throws AnnotationException
      */
     public function __construct(ClassesInterface $classLocator, ReaderInterface $reader = null)
     {

--- a/src/Attributes/src/Composite/Composite.php
+++ b/src/Attributes/src/Composite/Composite.php
@@ -34,7 +34,8 @@ abstract class Composite extends Reader
      */
     public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
     {
-        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getClassMetadata($class, $name));
+        return $this->each(static fn (ReaderInterface $reader): iterable =>
+            $reader->getClassMetadata($class, $name));
     }
 
     /**
@@ -42,7 +43,8 @@ abstract class Composite extends Reader
      */
     public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
     {
-        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getFunctionMetadata($function, $name));
+        return $this->each(static fn (ReaderInterface $reader): iterable =>
+            $reader->getFunctionMetadata($function, $name));
     }
 
     /**
@@ -50,7 +52,8 @@ abstract class Composite extends Reader
      */
     public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
     {
-        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getPropertyMetadata($property, $name));
+        return $this->each(static fn (ReaderInterface $reader): iterable =>
+            $reader->getPropertyMetadata($property, $name));
     }
 
     /**
@@ -58,7 +61,8 @@ abstract class Composite extends Reader
      */
     public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
     {
-        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getConstantMetadata($constant, $name));
+        return $this->each(static fn (ReaderInterface $reader): iterable =>
+            $reader->getConstantMetadata($constant, $name));
     }
 
     /**
@@ -66,7 +70,8 @@ abstract class Composite extends Reader
      */
     public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
     {
-        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getParameterMetadata($parameter, $name));
+        return $this->each(static fn (ReaderInterface $reader): iterable =>
+            $reader->getParameterMetadata($parameter, $name));
     }
 
 

--- a/src/Attributes/src/Composite/Composite.php
+++ b/src/Attributes/src/Composite/Composite.php
@@ -34,9 +34,7 @@ abstract class Composite extends Reader
      */
     public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
     {
-        return $this->each(static function (ReaderInterface $reader) use ($class, $name): iterable {
-            return $reader->getClassMetadata($class, $name);
-        });
+        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getClassMetadata($class, $name));
     }
 
     /**
@@ -44,9 +42,7 @@ abstract class Composite extends Reader
      */
     public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
     {
-        return $this->each(static function (ReaderInterface $reader) use ($function, $name): iterable {
-            return $reader->getFunctionMetadata($function, $name);
-        });
+        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getFunctionMetadata($function, $name));
     }
 
     /**
@@ -54,9 +50,7 @@ abstract class Composite extends Reader
      */
     public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
     {
-        return $this->each(static function (ReaderInterface $reader) use ($property, $name): iterable {
-            return $reader->getPropertyMetadata($property, $name);
-        });
+        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getPropertyMetadata($property, $name));
     }
 
     /**
@@ -64,9 +58,7 @@ abstract class Composite extends Reader
      */
     public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
     {
-        return $this->each(static function (ReaderInterface $reader) use ($constant, $name): iterable {
-            return $reader->getConstantMetadata($constant, $name);
-        });
+        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getConstantMetadata($constant, $name));
     }
 
     /**
@@ -74,9 +66,7 @@ abstract class Composite extends Reader
      */
     public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
     {
-        return $this->each(static function (ReaderInterface $reader) use ($parameter, $name): iterable {
-            return $reader->getParameterMetadata($parameter, $name);
-        });
+        return $this->each(static fn(ReaderInterface $reader): iterable => $reader->getParameterMetadata($parameter, $name));
     }
 
 

--- a/src/Attributes/src/Exception/AttributeException.php
+++ b/src/Attributes/src/Exception/AttributeException.php
@@ -13,11 +13,4 @@ namespace Spiral\Attributes\Exception;
 
 class AttributeException extends \RuntimeException
 {
-    /**
-     * {@inheritDoc}
-     */
-    final public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-    }
 }

--- a/src/Attributes/src/Internal/AttributeReader.php
+++ b/src/Attributes/src/Internal/AttributeReader.php
@@ -26,10 +26,7 @@ abstract class AttributeReader extends Reader
      * @var ContextRenderer
      */
     protected $renderer;
-    /**
-     * @var InstantiatorInterface
-     */
-    private $instantiator;
+    private InstantiatorInterface $instantiator;
 
     /**
      * @param InstantiatorInterface|null $instantiator

--- a/src/Attributes/src/Internal/CachedReader.php
+++ b/src/Attributes/src/Internal/CachedReader.php
@@ -40,7 +40,8 @@ abstract class CachedReader extends Decorator
      */
     public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forClass($class), fn() => $this->iterableToArray(parent::getClassMetadata($class)));
+        $result = $this->cached($this->key->forClass($class), fn () =>
+            $this->iterableToArray(parent::getClassMetadata($class)));
 
         return $this->filter($name, $result);
     }
@@ -50,7 +51,8 @@ abstract class CachedReader extends Decorator
      */
     public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forFunction($function), fn() => $this->iterableToArray(parent::getFunctionMetadata($function)));
+        $result = $this->cached($this->key->forFunction($function), fn () =>
+            $this->iterableToArray(parent::getFunctionMetadata($function)));
 
         return $this->filter($name, $result);
     }
@@ -60,7 +62,8 @@ abstract class CachedReader extends Decorator
      */
     public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forProperty($property), fn() => $this->iterableToArray(parent::getPropertyMetadata($property)));
+        $result = $this->cached($this->key->forProperty($property), fn () =>
+            $this->iterableToArray(parent::getPropertyMetadata($property)));
 
         return $this->filter($name, $result);
     }
@@ -70,7 +73,8 @@ abstract class CachedReader extends Decorator
      */
     public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forConstant($constant), fn() => $this->iterableToArray(parent::getConstantMetadata($constant)));
+        $result = $this->cached($this->key->forConstant($constant), fn () =>
+            $this->iterableToArray(parent::getConstantMetadata($constant)));
 
         return $this->filter($name, $result);
     }
@@ -80,7 +84,8 @@ abstract class CachedReader extends Decorator
      */
     public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forParameter($parameter), fn() => $this->iterableToArray(parent::getParameterMetadata($parameter)));
+        $result = $this->cached($this->key->forParameter($parameter), fn () =>
+            $this->iterableToArray(parent::getParameterMetadata($parameter)));
 
         return $this->filter($name, $result);
     }

--- a/src/Attributes/src/Internal/CachedReader.php
+++ b/src/Attributes/src/Internal/CachedReader.php
@@ -40,9 +40,7 @@ abstract class CachedReader extends Decorator
      */
     public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forClass($class), function () use ($class) {
-            return $this->iterableToArray(parent::getClassMetadata($class));
-        });
+        $result = $this->cached($this->key->forClass($class), fn() => $this->iterableToArray(parent::getClassMetadata($class)));
 
         return $this->filter($name, $result);
     }
@@ -52,9 +50,7 @@ abstract class CachedReader extends Decorator
      */
     public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forFunction($function), function () use ($function) {
-            return $this->iterableToArray(parent::getFunctionMetadata($function));
-        });
+        $result = $this->cached($this->key->forFunction($function), fn() => $this->iterableToArray(parent::getFunctionMetadata($function)));
 
         return $this->filter($name, $result);
     }
@@ -64,9 +60,7 @@ abstract class CachedReader extends Decorator
      */
     public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forProperty($property), function () use ($property) {
-            return $this->iterableToArray(parent::getPropertyMetadata($property));
-        });
+        $result = $this->cached($this->key->forProperty($property), fn() => $this->iterableToArray(parent::getPropertyMetadata($property)));
 
         return $this->filter($name, $result);
     }
@@ -76,9 +70,7 @@ abstract class CachedReader extends Decorator
      */
     public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forConstant($constant), function () use ($constant) {
-            return $this->iterableToArray(parent::getConstantMetadata($constant));
-        });
+        $result = $this->cached($this->key->forConstant($constant), fn() => $this->iterableToArray(parent::getConstantMetadata($constant)));
 
         return $this->filter($name, $result);
     }
@@ -88,9 +80,7 @@ abstract class CachedReader extends Decorator
      */
     public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
     {
-        $result = $this->cached($this->key->forParameter($parameter), function () use ($parameter) {
-            return $this->iterableToArray(parent::getParameterMetadata($parameter));
-        });
+        $result = $this->cached($this->key->forParameter($parameter), fn() => $this->iterableToArray(parent::getParameterMetadata($parameter)));
 
         return $this->filter($name, $result);
     }

--- a/src/Attributes/src/Internal/Decorator.php
+++ b/src/Attributes/src/Internal/Decorator.php
@@ -20,10 +20,7 @@ use Spiral\Attributes\ReaderInterface;
  */
 abstract class Decorator extends Reader
 {
-    /**
-     * @var FallbackAttributeReader|NativeAttributeReader
-     */
-    private $reader;
+    private ReaderInterface $reader;
 
     public function __construct(ReaderInterface $reader)
     {

--- a/src/Attributes/src/Internal/DoctrineAnnotationReader.php
+++ b/src/Attributes/src/Internal/DoctrineAnnotationReader.php
@@ -44,9 +44,7 @@ final class DoctrineAnnotationReader extends BaseReader
      */
     public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
     {
-        $result = $this->wrapDoctrineExceptions(function () use ($class) {
-            return $this->reader->getClassAnnotations($class);
-        });
+        $result = $this->wrapDoctrineExceptions(fn() => $this->reader->getClassAnnotations($class));
 
         yield from $this->filter($name, $result);
 
@@ -61,9 +59,7 @@ final class DoctrineAnnotationReader extends BaseReader
     public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
     {
         if ($function instanceof \ReflectionMethod) {
-            $result = $this->wrapDoctrineExceptions(function () use ($function) {
-                return $this->reader->getMethodAnnotations($function);
-            });
+            $result = $this->wrapDoctrineExceptions(fn() => $this->reader->getMethodAnnotations($function));
 
             return $this->filter($name, $result);
         }
@@ -76,9 +72,7 @@ final class DoctrineAnnotationReader extends BaseReader
      */
     public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
     {
-        $result = $this->wrapDoctrineExceptions(function () use ($property) {
-            return $this->reader->getPropertyAnnotations($property);
-        });
+        $result = $this->wrapDoctrineExceptions(fn() => $this->reader->getPropertyAnnotations($property));
 
         return $this->filter($name, $result);
     }

--- a/src/Attributes/src/Internal/DoctrineAnnotationReader.php
+++ b/src/Attributes/src/Internal/DoctrineAnnotationReader.php
@@ -44,7 +44,7 @@ final class DoctrineAnnotationReader extends BaseReader
      */
     public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
     {
-        $result = $this->wrapDoctrineExceptions(fn() => $this->reader->getClassAnnotations($class));
+        $result = $this->wrapDoctrineExceptions(fn () => $this->reader->getClassAnnotations($class));
 
         yield from $this->filter($name, $result);
 
@@ -59,7 +59,7 @@ final class DoctrineAnnotationReader extends BaseReader
     public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
     {
         if ($function instanceof \ReflectionMethod) {
-            $result = $this->wrapDoctrineExceptions(fn() => $this->reader->getMethodAnnotations($function));
+            $result = $this->wrapDoctrineExceptions(fn () => $this->reader->getMethodAnnotations($function));
 
             return $this->filter($name, $result);
         }
@@ -72,7 +72,7 @@ final class DoctrineAnnotationReader extends BaseReader
      */
     public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
     {
-        $result = $this->wrapDoctrineExceptions(fn() => $this->reader->getPropertyAnnotations($property));
+        $result = $this->wrapDoctrineExceptions(fn () => $this->reader->getPropertyAnnotations($property));
 
         return $this->filter($name, $result);
     }

--- a/src/Attributes/src/Internal/FallbackAttributeReader.php
+++ b/src/Attributes/src/Internal/FallbackAttributeReader.php
@@ -47,10 +47,7 @@ final class FallbackAttributeReader extends AttributeReader
      */
     private const KEY_PARAMETERS = 0x04;
 
-    /**
-     * @var AttributeParser
-     */
-    private $parser;
+    private AttributeParser $parser;
 
     /**
      * @psalm-type ClassName       = string
@@ -70,7 +67,7 @@ final class FallbackAttributeReader extends AttributeReader
      *  4: array<FunctionEndLine, array<ParameterName, AttributesList>>
      * }
      */
-    private $attributes = [
+    private array $attributes = [
         self::KEY_CLASSES    => [],
         self::KEY_CONSTANTS  => [],
         self::KEY_PROPERTIES => [],

--- a/src/Attributes/src/Internal/FallbackAttributeReader/AttributeFinderVisitor.php
+++ b/src/Attributes/src/Internal/FallbackAttributeReader/AttributeFinderVisitor.php
@@ -11,6 +11,13 @@ declare(strict_types=1);
 
 namespace Spiral\Attributes\Internal\FallbackAttributeReader;
 
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Trait_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeTraverser;
@@ -44,37 +51,31 @@ final class AttributeFinderVisitor extends NodeVisitorAbstract
     /**
      * @var array<ClassName, AttributePrototypeList>
      */
-    private $classes = [];
+    private array $classes = [];
 
     /**
      * @var array<FunctionEndLine, AttributePrototypeList>
      */
-    private $functions = [];
+    private array $functions = [];
 
     /**
      * @var array<ClassName, array<ConstantName, AttributePrototypeList>>
      */
-    private $constants = [];
+    private array $constants = [];
 
     /**
      * @var array<ClassName, array<PropertyName, AttributePrototypeList>>
      */
-    private $properties = [];
+    private array $properties = [];
 
     /**
      * @var array<FunctionEndLine, array<ParameterName, AttributePrototypeList>>
      */
-    private $parameters = [];
+    private array $parameters = [];
 
-    /**
-     * @var string
-     */
-    private $file;
+    private string $file;
 
-    /**
-     * @var AttributeParser
-     */
-    private $parser;
+    private AttributeParser $parser;
 
     public function __construct(string $file, AttributeParser $parser)
     {
@@ -140,7 +141,7 @@ final class AttributeFinderVisitor extends NodeVisitorAbstract
     {
         $this->updateContext($node);
 
-        if ($node instanceof Node\Stmt\ClassLike) {
+        if ($node instanceof ClassLike) {
             foreach ($this->parse($node->attrGroups) as $prototype) {
                 $this->classes[$node->namespacedName->toString()][] = $prototype;
             }
@@ -148,7 +149,7 @@ final class AttributeFinderVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        if ($node instanceof Node\FunctionLike) {
+        if ($node instanceof FunctionLike) {
             $line = $node->getEndLine();
 
             foreach ($this->parse($node->getAttrGroups()) as $prototype) {
@@ -166,7 +167,7 @@ final class AttributeFinderVisitor extends NodeVisitorAbstract
             return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
         }
 
-        if ($node instanceof Node\Stmt\ClassConst) {
+        if ($node instanceof ClassConst) {
             $class = $this->fqn();
 
             foreach ($this->parse($node->attrGroups) as $prototype) {
@@ -195,20 +196,20 @@ final class AttributeFinderVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): void
     {
-        if ($node instanceof Node\Stmt\Namespace_) {
+        if ($node instanceof Namespace_) {
             $this->context[AttributeParser::CTX_NAMESPACE] = '';
 
             return;
         }
 
-        if ($node instanceof Node\Stmt\ClassLike) {
+        if ($node instanceof ClassLike) {
             $this->context[AttributeParser::CTX_CLASS] = '';
             $this->context[AttributeParser::CTX_TRAIT] = '';
 
             return;
         }
 
-        if ($node instanceof Node\FunctionLike) {
+        if ($node instanceof FunctionLike) {
             $this->context[AttributeParser::CTX_FUNCTION] = '';
         }
     }
@@ -216,20 +217,20 @@ final class AttributeFinderVisitor extends NodeVisitorAbstract
     private function updateContext(Node $node): void
     {
         switch (true) {
-            case $node instanceof Node\Stmt\Namespace_:
+            case $node instanceof Namespace_:
                 $this->context[AttributeParser::CTX_NAMESPACE] = $this->name($node->name);
                 break;
 
-            case $node instanceof Node\Stmt\ClassLike:
+            case $node instanceof ClassLike:
                 $this->context[AttributeParser::CTX_CLASS] = $this->name($node->name);
 
             // no break
-            case $node instanceof Node\Stmt\Trait_:
+            case $node instanceof Trait_:
                 $this->context[AttributeParser::CTX_TRAIT] = $this->name($node->name);
                 break;
 
-            case $node instanceof Node\Stmt\Function_:
-            case $node instanceof Node\Stmt\ClassMethod:
+            case $node instanceof Function_:
+            case $node instanceof ClassMethod:
                 $this->context[AttributeParser::CTX_FUNCTION] = $this->name($node->name);
                 break;
         }

--- a/src/Attributes/src/Internal/FallbackAttributeReader/AttributeParser.php
+++ b/src/Attributes/src/Internal/FallbackAttributeReader/AttributeParser.php
@@ -11,6 +11,12 @@ declare(strict_types=1);
 
 namespace Spiral\Attributes\Internal\FallbackAttributeReader;
 
+use PhpParser\Node\Scalar\MagicConst\File;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\MagicConst\Line;
+use PhpParser\Node\Scalar\MagicConst\Method;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Scalar\MagicConst;
 use PhpParser\ConstExprEvaluationException;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node\Attribute;
@@ -59,15 +65,9 @@ final class AttributeParser
      */
     private const ERROR_BAD_CONSTANT = 'Undefined constant %s';
 
-    /**
-     * @var Parser
-     */
-    private $parser;
+    private Parser $parser;
 
-    /**
-     * @var NodeTraverser
-     */
-    private $resolver;
+    private NodeTraverser $resolver;
 
     /**
      * @param Parser|null $parser
@@ -134,22 +134,22 @@ final class AttributeParser
     {
         return static function (Expr $expr) use ($file, $context) {
             switch (\get_class($expr)) {
-                case Scalar\MagicConst\File::class:
+                case File::class:
                     return $file;
 
-                case Scalar\MagicConst\Dir::class:
+                case Dir::class:
                     return \dirname($file);
 
-                case Scalar\MagicConst\Line::class:
+                case Line::class:
                     return $expr->getStartLine();
 
-                case Scalar\MagicConst\Method::class:
+                case Method::class:
                     $namespace = $context[self::CTX_NAMESPACE] ?? '';
                     $function = $context[self::CTX_FUNCTION] ?? '';
 
                     return \ltrim($namespace . '\\' . $function, '\\');
 
-                case Expr\ClassConstFetch::class:
+                case ClassConstFetch::class:
                     $constant = $expr->name->toString();
                     $class = $expr->class->toString();
 
@@ -167,7 +167,7 @@ final class AttributeParser
                     return \constant($definition);
             }
 
-            if ($expr instanceof Scalar\MagicConst) {
+            if ($expr instanceof MagicConst) {
                 return $context[$expr->getName()] ?? '';
             }
 

--- a/src/Attributes/src/Internal/Instantiator/Facade.php
+++ b/src/Attributes/src/Internal/Instantiator/Facade.php
@@ -19,20 +19,11 @@ use Spiral\Attributes\ReaderInterface;
 
 final class Facade implements InstantiatorInterface
 {
-    /**
-     * @var DoctrineInstantiator
-     */
-    private $doctrine;
+    private DoctrineInstantiator $doctrine;
 
-    /**
-     * @var NamedArgumentsInstantiator
-     */
-    private $named;
+    private NamedArgumentsInstantiator $named;
 
-    /**
-     * @var ReaderInterface
-     */
-    private $reader;
+    private ReaderInterface $reader;
 
     /**
      * @param ReaderInterface|null $reader

--- a/src/Attributes/src/Internal/Key/ConcatKeyGenerator.php
+++ b/src/Attributes/src/Internal/Key/ConcatKeyGenerator.php
@@ -32,12 +32,9 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
     /**
      * @var array<KeyGeneratorInterface>
      */
-    private $generators;
+    private array $generators;
 
-    /**
-     * @var string
-     */
-    private $join;
+    private string $join;
 
     /**
      * @param array<KeyGeneratorInterface> $generators
@@ -53,9 +50,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forClass(\ReflectionClass $class): string
     {
-        return $this->joinBy(static function (KeyGeneratorInterface $generator) use ($class): string {
-            return $generator->forClass($class);
-        });
+        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forClass($class));
     }
 
     /**
@@ -63,9 +58,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forProperty(\ReflectionProperty $prop): string
     {
-        return $this->joinBy(static function (KeyGeneratorInterface $generator) use ($prop): string {
-            return $generator->forProperty($prop);
-        });
+        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forProperty($prop));
     }
 
     /**
@@ -73,9 +66,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forConstant(\ReflectionClassConstant $const): string
     {
-        return $this->joinBy(static function (KeyGeneratorInterface $generator) use ($const): string {
-            return $generator->forConstant($const);
-        });
+        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forConstant($const));
     }
 
     /**
@@ -83,9 +74,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forFunction(\ReflectionFunctionAbstract $fn): string
     {
-        return $this->joinBy(static function (KeyGeneratorInterface $generator) use ($fn): string {
-            return $generator->forFunction($fn);
-        });
+        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forFunction($fn));
     }
 
     /**
@@ -93,9 +82,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forParameter(\ReflectionParameter $param): string
     {
-        return $this->joinBy(static function (KeyGeneratorInterface $generator) use ($param): string {
-            return $generator->forParameter($param);
-        });
+        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forParameter($param));
     }
 
     /**

--- a/src/Attributes/src/Internal/Key/ConcatKeyGenerator.php
+++ b/src/Attributes/src/Internal/Key/ConcatKeyGenerator.php
@@ -50,7 +50,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forClass(\ReflectionClass $class): string
     {
-        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forClass($class));
+        return $this->joinBy(static fn (KeyGeneratorInterface $generator): string => $generator->forClass($class));
     }
 
     /**
@@ -58,7 +58,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forProperty(\ReflectionProperty $prop): string
     {
-        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forProperty($prop));
+        return $this->joinBy(static fn (KeyGeneratorInterface $generator): string => $generator->forProperty($prop));
     }
 
     /**
@@ -66,7 +66,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forConstant(\ReflectionClassConstant $const): string
     {
-        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forConstant($const));
+        return $this->joinBy(static fn (KeyGeneratorInterface $generator): string => $generator->forConstant($const));
     }
 
     /**
@@ -74,7 +74,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forFunction(\ReflectionFunctionAbstract $fn): string
     {
-        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forFunction($fn));
+        return $this->joinBy(static fn (KeyGeneratorInterface $generator): string => $generator->forFunction($fn));
     }
 
     /**
@@ -82,7 +82,7 @@ final class ConcatKeyGenerator implements KeyGeneratorInterface
      */
     public function forParameter(\ReflectionParameter $param): string
     {
-        return $this->joinBy(static fn(KeyGeneratorInterface $generator): string => $generator->forParameter($param));
+        return $this->joinBy(static fn (KeyGeneratorInterface $generator): string => $generator->forParameter($param));
     }
 
     /**

--- a/src/Attributes/src/Internal/Key/HashKeyGenerator.php
+++ b/src/Attributes/src/Internal/Key/HashKeyGenerator.php
@@ -32,15 +32,9 @@ final class HashKeyGenerator implements KeyGeneratorInterface
      */
     private const DEFAULT_HASH_ALGO = 'md5';
 
-    /**
-     * @var KeyGeneratorInterface
-     */
-    private $generator;
+    private KeyGeneratorInterface $generator;
 
-    /**
-     * @var string
-     */
-    private $algo;
+    private string $algo;
 
     /**
      * @param KeyGeneratorInterface|null $base

--- a/src/Attributes/src/Psr16CachedReader.php
+++ b/src/Attributes/src/Psr16CachedReader.php
@@ -18,10 +18,7 @@ use Spiral\Attributes\Internal\Key\KeyGeneratorInterface;
 
 final class Psr16CachedReader extends CachedReader
 {
-    /**
-     * @var CacheInterface
-     */
-    private $cache;
+    private CacheInterface $cache;
 
     /**
      * @param KeyGeneratorInterface|null $generator

--- a/src/Attributes/src/Psr6CachedReader.php
+++ b/src/Attributes/src/Psr6CachedReader.php
@@ -18,10 +18,7 @@ use Spiral\Attributes\Internal\Key\KeyGeneratorInterface;
 
 final class Psr6CachedReader extends CachedReader
 {
-    /**
-     * @var CacheItemPoolInterface
-     */
-    private $cache;
+    private CacheItemPoolInterface $cache;
 
     /**
      * @param KeyGeneratorInterface|null $generator

--- a/src/Auth/src/AuthContext.php
+++ b/src/Auth/src/AuthContext.php
@@ -13,20 +13,15 @@ namespace Spiral\Auth;
 
 final class AuthContext implements AuthContextInterface
 {
-    /** @var ActorProviderInterface */
-    private $actorProvider;
+    private ActorProviderInterface $actorProvider;
 
-    /** @var TokenInterface|null */
-    private $token;
+    private ?TokenInterface $token = null;
 
-    /** @var object|null */
-    private $actor;
+    private ?object $actor = null;
 
-    /** @var string|null */
-    private $transport;
+    private ?string $transport = null;
 
-    /** @var bool */
-    private $closed = false;
+    private bool $closed = false;
 
     public function __construct(ActorProviderInterface $actorProvider)
     {

--- a/src/AuthHttp/src/Middleware/AuthMiddleware.php
+++ b/src/AuthHttp/src/Middleware/AuthMiddleware.php
@@ -31,17 +31,13 @@ final class AuthMiddleware implements MiddlewareInterface
 {
     public const ATTRIBUTE = 'authContext';
 
-    /** @var ScopeInterface */
-    private $scope;
+    private ScopeInterface $scope;
 
-    /** @var ActorProviderInterface */
-    private $actorProvider;
+    private ActorProviderInterface $actorProvider;
 
-    /** @var TokenStorageInterface */
-    private $tokenStorage;
+    private TokenStorageInterface $tokenStorage;
 
-    /** @var TransportRegistry */
-    private $transportRegistry;
+    private TransportRegistry $transportRegistry;
 
     public function __construct(
         ScopeInterface $scope,
@@ -65,9 +61,7 @@ final class AuthMiddleware implements MiddlewareInterface
 
         $response = $this->scope->runScope(
             [AuthContextInterface::class => $authContext],
-            static function () use ($request, $handler, $authContext) {
-                return $handler->handle($request->withAttribute(self::ATTRIBUTE, $authContext));
-            }
+            static fn() => $handler->handle($request->withAttribute(self::ATTRIBUTE, $authContext))
         );
 
         return $this->closeContext($request, $response, $authContext);

--- a/src/AuthHttp/src/Middleware/AuthMiddleware.php
+++ b/src/AuthHttp/src/Middleware/AuthMiddleware.php
@@ -61,7 +61,7 @@ final class AuthMiddleware implements MiddlewareInterface
 
         $response = $this->scope->runScope(
             [AuthContextInterface::class => $authContext],
-            static fn() => $handler->handle($request->withAttribute(self::ATTRIBUTE, $authContext))
+            static fn () => $handler->handle($request->withAttribute(self::ATTRIBUTE, $authContext))
         );
 
         return $this->closeContext($request, $response, $authContext);

--- a/src/AuthHttp/src/Middleware/Firewall/ExceptionFirewall.php
+++ b/src/AuthHttp/src/Middleware/Firewall/ExceptionFirewall.php
@@ -20,8 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class ExceptionFirewall extends AbstractFirewall
 {
-    /** @var \Throwable */
-    private $e;
+    private \Throwable $e;
 
     public function __construct(\Throwable $e)
     {

--- a/src/AuthHttp/src/Middleware/Firewall/OverwriteFirewall.php
+++ b/src/AuthHttp/src/Middleware/Firewall/OverwriteFirewall.php
@@ -21,11 +21,9 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class OverwriteFirewall extends AbstractFirewall
 {
-    /** @var UriInterface */
-    private $uri;
+    private UriInterface $uri;
 
-    /** @var int */
-    private $status;
+    private int $status;
 
     public function __construct(UriInterface $uri, int $status = 401)
     {

--- a/src/AuthHttp/src/Transport/CookieTransport.php
+++ b/src/AuthHttp/src/Transport/CookieTransport.php
@@ -23,23 +23,17 @@ use Spiral\Cookies\CookieQueue;
  */
 final class CookieTransport implements HttpTransportInterface
 {
-    /** @var string */
-    private $cookie;
+    private string $cookie;
 
-    /** @var string */
-    private $basePath;
+    private string $basePath;
 
-    /** @var string|null */
-    private $domain;
+    private ?string $domain;
 
-    /** @var bool */
-    private $secure;
+    private bool $secure;
 
-    /** @var bool */
-    private $httpOnly;
+    private bool $httpOnly;
 
-    /** @var string|null */
-    private $sameSite;
+    private ?string $sameSite;
 
     public function __construct(
         string $cookie,

--- a/src/AuthHttp/src/Transport/HeaderTransport.php
+++ b/src/AuthHttp/src/Transport/HeaderTransport.php
@@ -20,11 +20,9 @@ use Spiral\Auth\HttpTransportInterface;
  */
 final class HeaderTransport implements HttpTransportInterface
 {
-    /** @var string */
-    private $header;
+    private string $header;
 
-    /** @var string */
-    private $valueFormat;
+    private string $valueFormat;
 
     public function __construct(string $header = 'X-Auth-Token', string $valueFormat = '%s')
     {

--- a/src/AuthHttp/src/TransportRegistry.php
+++ b/src/AuthHttp/src/TransportRegistry.php
@@ -19,10 +19,9 @@ use Spiral\Auth\Exception\TransportException;
 final class TransportRegistry
 {
     /** @var HttpTransportInterface[] */
-    private $transports = [];
+    private array $transports = [];
 
-    /** @var string */
-    private $default;
+    private ?string $default = null;
 
     public function setDefaultTransport(string $name): void
     {
@@ -39,7 +38,7 @@ final class TransportRegistry
      */
     public function getTransport(string $name = null): HttpTransportInterface
     {
-        $name = $name ?? $this->default;
+        $name ??= $this->default;
 
         if (!isset($this->transports[$name])) {
             throw new TransportException("Undefined auth transport {$name}");

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -44,10 +44,10 @@ abstract class AbstractKernel implements KernelInterface
     protected $dispatchers = [];
 
     /** @var array<Closure> */
-    private $startingCallbacks = [];
+    private array $startingCallbacks = [];
 
     /** @var array<Closure> */
-    private $startedCallbacks = [];
+    private array $startedCallbacks = [];
 
     /**
      * @throws \Throwable
@@ -133,7 +133,7 @@ abstract class AbstractKernel implements KernelInterface
      */
     public function run(?EnvironmentInterface $environment = null): ?self
     {
-        $environment = $environment ?? new Environment();
+        $environment ??= new Environment();
         $this->container->bindSingleton(EnvironmentInterface::class, $environment);
 
         try {

--- a/src/Boot/src/BootloadManager.php
+++ b/src/Boot/src/BootloadManager.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Boot;
 
+use Spiral\Core\Container\SingletonInterface;
 use Closure;
 use Spiral\Boot\Bootloader\BootloaderInterface;
 use Spiral\Boot\Bootloader\DependedInterface;
@@ -20,13 +21,13 @@ use Spiral\Core\Container;
 /**
  * Provides ability to bootload ServiceProviders.
  */
-final class BootloadManager implements Container\SingletonInterface
+final class BootloadManager implements SingletonInterface
 {
     /* @var Container @internal */
     protected $container;
 
     /** @var array<class-string> */
-    private $classes = [];
+    private array $classes = [];
 
     public function __construct(Container $container)
     {

--- a/src/Boot/src/Bootloader/ConfigurationBootloader.php
+++ b/src/Boot/src/Bootloader/ConfigurationBootloader.php
@@ -33,17 +33,14 @@ final class ConfigurationBootloader extends Bootloader
         ConfigManager::class         => [self::class, 'configManager'],
     ];
 
-    /** @var ConfiguratorInterface */
-    private $configurator;
+    private ConfiguratorInterface $configurator;
 
     /** @var FileLoaderInterface[] */
-    private $loaders;
+    private array $loaders;
 
-    /** @var DirectoriesInterface */
-    private $directories;
+    private DirectoriesInterface $directories;
 
-    /** @var Container */
-    private $container;
+    private Container $container;
 
     public function __construct(DirectoriesInterface $directories, Container $container)
     {

--- a/src/Boot/src/Bootloader/CoreBootloader.php
+++ b/src/Boot/src/Bootloader/CoreBootloader.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Spiral\Boot\Bootloader;
 
+use Spiral\Logger\ListenerRegistryInterface;
+use Spiral\Logger\ListenerRegistry;
+use Spiral\Logger\LogsInterface;
+use Spiral\Logger\LogFactory;
 use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\Memory;
 use Spiral\Boot\MemoryInterface;
@@ -35,8 +39,8 @@ final class CoreBootloader extends Bootloader
 
         // debug and logging services
         Dumper::class                           => Dumper::class,
-        Logger\ListenerRegistryInterface::class => Logger\ListenerRegistry::class,
-        Logger\LogsInterface::class             => Logger\LogFactory::class,
+        ListenerRegistryInterface::class => ListenerRegistry::class,
+        LogsInterface::class             => LogFactory::class,
     ];
 
     private function memory(

--- a/src/Boot/src/Directories.php
+++ b/src/Boot/src/Directories.php
@@ -18,8 +18,7 @@ use Spiral\Boot\Exception\DirectoryException;
  */
 final class Directories implements DirectoriesInterface
 {
-    /** @var array */
-    private $directories = [];
+    private array $directories = [];
 
     public function __construct(array $directories)
     {

--- a/src/Boot/src/Finalizer.php
+++ b/src/Boot/src/Finalizer.php
@@ -14,7 +14,7 @@ namespace Spiral\Boot;
 final class Finalizer implements FinalizerInterface
 {
     /** @var callable[] */
-    private $finalizers = [];
+    private array $finalizers = [];
 
     /**
      * @inheritdoc

--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -21,11 +21,9 @@ final class Memory implements MemoryInterface
     // data file extension
     private const EXTENSION = 'php';
 
-    /** @var string */
-    private $directory;
+    private string $directory;
 
-    /** @var FilesInterface */
-    private $files;
+    private FilesInterface $files;
 
     public function __construct(string $directory, FilesInterface $files)
     {

--- a/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
+++ b/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
@@ -24,9 +24,11 @@ final class WebsocketsBootloader extends Bootloader implements SingletonInterfac
     {
         $container->bindSingleton(
             AuthorizationMiddleware::class,
-            static fn (BroadcastInterface $broadcast,
+            static fn (
+                BroadcastInterface $broadcast,
                 ResponseFactoryInterface $responseFactory,
-                BroadcastConfig $config): AuthorizationMiddleware =>
+                BroadcastConfig $config
+            ): AuthorizationMiddleware =>
                     new AuthorizationMiddleware(
                         $broadcast,
                         $responseFactory,

--- a/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
+++ b/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
@@ -22,17 +22,11 @@ final class WebsocketsBootloader extends Bootloader implements SingletonInterfac
 
     public function start(Container $container, HttpBootloader $http, BroadcastConfig $config): void
     {
-        $container->bindSingleton(AuthorizationMiddleware::class, static function (
-            BroadcastInterface $broadcast,
-            ResponseFactoryInterface $responseFactory,
-            BroadcastConfig $config
-        ): AuthorizationMiddleware {
-            return new AuthorizationMiddleware(
-                $broadcast,
-                $responseFactory,
-                $config->getAuthorizationPath()
-            );
-        });
+        $container->bindSingleton(AuthorizationMiddleware::class, static fn(BroadcastInterface $broadcast, ResponseFactoryInterface $responseFactory, BroadcastConfig $config): AuthorizationMiddleware => new AuthorizationMiddleware(
+            $broadcast,
+            $responseFactory,
+            $config->getAuthorizationPath()
+        ));
 
 
         if ($config->getAuthorizationPath() !== null) {

--- a/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
+++ b/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
@@ -22,11 +22,17 @@ final class WebsocketsBootloader extends Bootloader implements SingletonInterfac
 
     public function start(Container $container, HttpBootloader $http, BroadcastConfig $config): void
     {
-        $container->bindSingleton(AuthorizationMiddleware::class, static fn(BroadcastInterface $broadcast, ResponseFactoryInterface $responseFactory, BroadcastConfig $config): AuthorizationMiddleware => new AuthorizationMiddleware(
-            $broadcast,
-            $responseFactory,
-            $config->getAuthorizationPath()
-        ));
+        $container->bindSingleton(
+            AuthorizationMiddleware::class,
+            static fn (BroadcastInterface $broadcast,
+                ResponseFactoryInterface $responseFactory,
+                BroadcastConfig $config): AuthorizationMiddleware =>
+                    new AuthorizationMiddleware(
+                        $broadcast,
+                        $responseFactory,
+                        $config->getAuthorizationPath()
+                    )
+        );
 
 
         if ($config->getAuthorizationPath() !== null) {

--- a/src/Broadcasting/src/Driver/AbstractBroadcast.php
+++ b/src/Broadcasting/src/Driver/AbstractBroadcast.php
@@ -16,7 +16,7 @@ abstract class AbstractBroadcast implements BroadcastInterface
      */
     protected function formatTopics(array $topics): array
     {
-        return array_map(fn($topic) => (string)$topic, $topics);
+        return array_map(fn ($topic) => (string)$topic, $topics);
     }
 
     /**

--- a/src/Broadcasting/src/Driver/AbstractBroadcast.php
+++ b/src/Broadcasting/src/Driver/AbstractBroadcast.php
@@ -16,9 +16,7 @@ abstract class AbstractBroadcast implements BroadcastInterface
      */
     protected function formatTopics(array $topics): array
     {
-        return array_map(function ($topic) {
-            return (string)$topic;
-        }, $topics);
+        return array_map(fn($topic) => (string)$topic, $topics);
     }
 
     /**

--- a/src/Cache/src/Bootloader/CacheBootloader.php
+++ b/src/Cache/src/Bootloader/CacheBootloader.php
@@ -55,9 +55,7 @@ final class CacheBootloader extends Bootloader
         $manager = new CacheManager($config, $container);
 
         foreach ($config->getAliases() as $alias => $storageName) {
-            $container->bind($alias, static function (CacheManager $manager) use ($storageName) {
-                return $manager->storage($storageName);
-            });
+            $container->bind($alias, static fn(CacheManager $manager) => $manager->storage($storageName));
         }
 
         return $manager;

--- a/src/Cache/src/Bootloader/CacheBootloader.php
+++ b/src/Cache/src/Bootloader/CacheBootloader.php
@@ -55,7 +55,7 @@ final class CacheBootloader extends Bootloader
         $manager = new CacheManager($config, $container);
 
         foreach ($config->getAliases() as $alias => $storageName) {
-            $container->bind($alias, static fn(CacheManager $manager) => $manager->storage($storageName));
+            $container->bind($alias, static fn (CacheManager $manager) => $manager->storage($storageName));
         }
 
         return $manager;

--- a/src/Cache/src/CacheManager.php
+++ b/src/Cache/src/CacheManager.php
@@ -11,14 +11,12 @@ use Spiral\Core\FactoryInterface;
 
 class CacheManager implements CacheStorageProviderInterface, SingletonInterface
 {
-    /** @var CacheConfig */
-    private $config;
+    private CacheConfig $config;
 
     /** @var CacheInterface[] */
-    private $storages = [];
+    private array $storages = [];
 
-    /** @var FactoryInterface */
-    private $factory;
+    private FactoryInterface $factory;
 
     public function __construct(CacheConfig $config, FactoryInterface $factory)
     {

--- a/src/Cache/src/Storage/ArrayStorage.php
+++ b/src/Cache/src/Storage/ArrayStorage.php
@@ -20,7 +20,7 @@ class ArrayStorage implements CacheInterface
     /** @var int */
     private $ttl;
 
-    public function __construct(int $ttl = 2592000)
+    public function __construct(int $ttl = 2_592_000)
     {
         $this->ttl = $ttl;
     }

--- a/src/Cache/src/Storage/FileStorage.php
+++ b/src/Cache/src/Storage/FileStorage.php
@@ -12,16 +12,14 @@ final class FileStorage implements CacheInterface
 {
     use InteractsWithTime;
 
-    /** @var string */
-    private $path;
+    private string $path;
 
-    /** @var FilesInterface */
-    private $files;
+    private FilesInterface $files;
 
     /** @var int */
     private $ttl;
 
-    public function __construct(FilesInterface $files, string $path, int $ttl = 2592000)
+    public function __construct(FilesInterface $files, string $path, int $ttl = 2_592_000)
     {
         $this->path = $path;
         $this->files = $files;

--- a/src/Config/src/ConfigManager.php
+++ b/src/Config/src/ConfigManager.php
@@ -22,20 +22,15 @@ use Spiral\Core\Exception\ConfiguratorException;
  */
 final class ConfigManager implements ConfiguratorInterface, SingletonInterface
 {
-    /** @var LoaderInterface */
-    private $loader;
+    private LoaderInterface $loader;
 
-    /** @var bool */
-    private $strict;
+    private bool $strict;
 
-    /** @var array */
-    private $data = [];
+    private array $data = [];
 
-    /** @var array */
-    private $defaults = [];
+    private array $defaults = [];
 
-    /** @var array */
-    private $instances = [];
+    private array $instances = [];
 
     public function __construct(LoaderInterface $loader, bool $strict = true)
     {

--- a/src/Config/src/Loader/DirectoryLoader.php
+++ b/src/Config/src/Loader/DirectoryLoader.php
@@ -16,11 +16,10 @@ use Spiral\Config\LoaderInterface;
 
 final class DirectoryLoader implements LoaderInterface
 {
-    /** @var string */
-    private $directory;
+    private string $directory;
 
     /** @var FileLoaderInterface[] */
-    private $loaders;
+    private array $loaders;
 
     public function __construct(string $directory, array $loaders = [])
     {

--- a/src/Config/src/Loader/PhpLoader.php
+++ b/src/Config/src/Loader/PhpLoader.php
@@ -20,8 +20,7 @@ use Spiral\Core\ContainerScope;
  */
 final class PhpLoader implements FileLoaderInterface
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
     {
@@ -34,9 +33,7 @@ final class PhpLoader implements FileLoaderInterface
     public function loadFile(string $section, string $filename): array
     {
         try {
-            return ContainerScope::runScope($this->container, function () use ($filename) {
-                return (require $filename);
-            });
+            return ContainerScope::runScope($this->container, fn() => require $filename);
         } catch (\Throwable $e) {
             throw new LoaderException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Config/src/Loader/PhpLoader.php
+++ b/src/Config/src/Loader/PhpLoader.php
@@ -33,7 +33,7 @@ final class PhpLoader implements FileLoaderInterface
     public function loadFile(string $section, string $filename): array
     {
         try {
-            return ContainerScope::runScope($this->container, fn() => require $filename);
+            return ContainerScope::runScope($this->container, fn () => require $filename);
         } catch (\Throwable $e) {
             throw new LoaderException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Config/src/Patch/Append.php
+++ b/src/Config/src/Patch/Append.php
@@ -20,11 +20,9 @@ final class Append implements PatchInterface
 {
     use DotTrait;
 
-    /** @var string */
-    private $position;
+    private string $position;
 
-    /** @var null|string */
-    private $key;
+    private ?string $key;
 
     /** @var mixed */
     private $value;

--- a/src/Config/src/Patch/Delete.php
+++ b/src/Config/src/Patch/Delete.php
@@ -19,11 +19,9 @@ final class Delete implements PatchInterface
 {
     use DotTrait;
 
-    /** @var string */
-    private $position;
+    private string $position;
 
-    /** @var null|string */
-    private $key;
+    private ?string $key;
 
     /** @var mixed */
     private $value;

--- a/src/Config/src/Patch/Group.php
+++ b/src/Config/src/Patch/Group.php
@@ -16,7 +16,7 @@ use Spiral\Config\PatchInterface;
 final class Group implements PatchInterface
 {
     /** @var array|PatchInterface[] */
-    private $patches = [];
+    private array $patches = [];
 
     public function __construct(PatchInterface ...$patch)
     {

--- a/src/Config/src/Patch/Prepend.php
+++ b/src/Config/src/Patch/Prepend.php
@@ -20,11 +20,9 @@ final class Prepend implements PatchInterface
 {
     use DotTrait;
 
-    /** @var string */
-    private $position;
+    private string $position;
 
-    /** @var null|string */
-    private $key;
+    private ?string $key;
 
     /** @var mixed */
     private $value;

--- a/src/Config/src/Patch/Set.php
+++ b/src/Config/src/Patch/Set.php
@@ -23,8 +23,7 @@ final class Set implements PatchInterface
 {
     use DotTrait;
 
-    /** @var string */
-    private $key;
+    private string $key;
 
     /** @var mixed */
     private $value;

--- a/src/Console/src/Bootloader/ConsoleBootloader.php
+++ b/src/Console/src/Bootloader/ConsoleBootloader.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Console\Bootloader;
 
+use Symfony\Component\Console\Command\Command;
 use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Command\CleanCommand;
@@ -42,8 +43,7 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
         LocatorInterface::class => CommandLocator::class,
     ];
 
-    /** @var ConfiguratorInterface */
-    private $config;
+    private ConfiguratorInterface $config;
 
     public function __construct(ConfiguratorInterface $config)
     {
@@ -71,7 +71,7 @@ final class ConsoleBootloader extends Bootloader implements SingletonInterface
     }
 
     /**
-     * @param class-string<\Symfony\Component\Console\Command\Command> $command
+     * @param class-string<Command> $command
      * @param bool $lowPriority A low priority command will be overwritten in a name conflict case.
      *        The parameter might be removed in the next major update.
      */

--- a/src/Console/src/CommandOutput.php
+++ b/src/Console/src/CommandOutput.php
@@ -16,8 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class CommandOutput
 {
-    /** @var int */
-    private $code = 0;
+    private int $code = 0;
 
     /** @var OutputInterface */
     private $output = '';

--- a/src/Console/src/Config/ConsoleConfig.php
+++ b/src/Console/src/Config/ConsoleConfig.php
@@ -120,7 +120,7 @@ final class ConsoleConfig extends InjectableConfig
 
         throw new ConfigException(sprintf(
             'Unable to parse sequence `%s`.',
-            json_encode($item)
+            json_encode($item, JSON_THROW_ON_ERROR)
         ));
     }
 }

--- a/src/Console/src/Console.php
+++ b/src/Console/src/Console.php
@@ -62,7 +62,7 @@ final class Console
         $input ??= new ArgvInput();
         $output ??= new ConsoleOutput();
 
-        return ContainerScope::runScope($this->container, fn() => $this->run(
+        return ContainerScope::runScope($this->container, fn () => $this->run(
             $input->getFirstArgument() ?? 'list',
             $input,
             $output
@@ -93,7 +93,7 @@ final class Console
             $input = new InputProxy($input, ['firstArgument' => $command]);
         }
 
-        $code = ContainerScope::runScope($this->container, fn() => $this->getApplication()->doRun($input, $output));
+        $code = ContainerScope::runScope($this->container, fn () => $this->getApplication()->doRun($input, $output));
 
         return new CommandOutput($code ?? self::CODE_NONE, $output);
     }

--- a/src/Console/src/Console.php
+++ b/src/Console/src/Console.php
@@ -31,17 +31,13 @@ final class Console
     // Undefined response code for command (errors). See below.
     public const CODE_NONE = 102;
 
-    /** @var ConsoleConfig */
-    private $config;
+    private ConsoleConfig $config;
 
-    /** @var LocatorInterface|null */
-    private $locator;
+    private ?LocatorInterface $locator;
 
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
-    /** @var Application|null */
-    private $application;
+    private ?Application $application = null;
 
     public function __construct(
         ConsoleConfig $config,
@@ -63,16 +59,14 @@ final class Console
      */
     public function start(InputInterface $input = null, OutputInterface $output = null): int
     {
-        $input = $input ?? new ArgvInput();
-        $output = $output ?? new ConsoleOutput();
+        $input ??= new ArgvInput();
+        $output ??= new ConsoleOutput();
 
-        return ContainerScope::runScope($this->container, function () use ($input, $output) {
-            return $this->run(
-                $input->getFirstArgument() ?? 'list',
-                $input,
-                $output
-            )->getCode();
-        });
+        return ContainerScope::runScope($this->container, fn() => $this->run(
+            $input->getFirstArgument() ?? 'list',
+            $input,
+            $output
+        )->getCode());
     }
 
     /**
@@ -91,7 +85,7 @@ final class Console
         OutputInterface $output = null
     ): CommandOutput {
         $input = is_array($input) ? new ArrayInput($input) : $input;
-        $output = $output ?? new BufferedOutput();
+        $output ??= new BufferedOutput();
 
         $this->configureIO($input, $output);
 
@@ -99,9 +93,7 @@ final class Console
             $input = new InputProxy($input, ['firstArgument' => $command]);
         }
 
-        $code = ContainerScope::runScope($this->container, function () use ($input, $output) {
-            return $this->getApplication()->doRun($input, $output);
-        });
+        $code = ContainerScope::runScope($this->container, fn() => $this->getApplication()->doRun($input, $output));
 
         return new CommandOutput($code ?? self::CODE_NONE, $output);
     }

--- a/src/Console/src/InputProxy.php
+++ b/src/Console/src/InputProxy.php
@@ -19,11 +19,9 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 final class InputProxy implements InputInterface
 {
-    /** @var InputInterface */
-    private $input;
+    private InputInterface $input;
 
-    /** @var array */
-    private $overwrite;
+    private array $overwrite;
 
     public function __construct(InputInterface $input, array $overwrite)
     {

--- a/src/Console/src/Sequence/AbstractSequence.php
+++ b/src/Console/src/Sequence/AbstractSequence.php
@@ -16,11 +16,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractSequence implements SequenceInterface
 {
-    /** @var string */
-    private $header;
+    private string $header;
 
-    /** @var string */
-    private $footer;
+    private string $footer;
 
     public function __construct(string $header, string $footer)
     {

--- a/src/Console/src/Sequence/CallableSequence.php
+++ b/src/Console/src/Sequence/CallableSequence.php
@@ -20,7 +20,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CallableSequence extends AbstractSequence
 {
-    private string $function;
+    /**
+     * @var array|string
+     */
+    private $function;
 
     /**
      * @param callable $function

--- a/src/Console/src/Sequence/CallableSequence.php
+++ b/src/Console/src/Sequence/CallableSequence.php
@@ -20,8 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CallableSequence extends AbstractSequence
 {
-    /** @var string */
-    private $function;
+    private string $function;
 
     /**
      * @param callable $function

--- a/src/Console/src/Sequence/CommandSequence.php
+++ b/src/Console/src/Sequence/CommandSequence.php
@@ -20,11 +20,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CommandSequence extends AbstractSequence
 {
-    /** @var string */
-    private $command;
+    private string $command;
 
-    /** @var array */
-    private $options = [];
+    private array $options = [];
 
     public function __construct(
         string $command,

--- a/src/Console/src/StaticLocator.php
+++ b/src/Console/src/StaticLocator.php
@@ -20,7 +20,7 @@ final class StaticLocator implements LocatorInterface
     use LazyTrait;
 
     /** @var string[] */
-    private $commands;
+    private array $commands;
 
     /** @var ContainerInterface */
     private $container;

--- a/src/Cookies/src/Cookie.php
+++ b/src/Cookies/src/Cookie.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Spiral\Cookies;
 
 use Spiral\Cookies\Cookie\SameSite;
+
 /**
  * Represent singular cookie header value with packing abilities.
  */

--- a/src/Cookies/src/Cookie.php
+++ b/src/Cookies/src/Cookie.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Cookies;
 
+use Spiral\Cookies\Cookie\SameSite;
 /**
  * Represent singular cookie header value with packing abilities.
  */
@@ -18,73 +19,57 @@ final class Cookie
 {
     /**
      * The name of the cookie.
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * The value of the cookie. This value is stored on the clients computer; do not store sensitive information.
-     *
-     * @var string|null
      */
-    private $value;
+    private ?string $value;
 
     /**
      * Cookie lifetime. This value specified in seconds and declares period of time in which cookie will expire
      * relatively to current time() value.
-     *
-     * @var int|null
      */
-    private $lifetime;
+    private ?int $lifetime;
 
     /**
      * The path on the server in which the cookie will be available on.
      * If set to '/', the cookie will be available within the entire domain. If set to '/foo/', the cookie will only be
      * available within the /foo/ directory and all sub-directories such as /foo/bar/ of domain. The default value is
      * the current directory that the cookie is being set in.
-     *
-     * @var string|null
      */
-    private $path;
+    private ?string $path;
 
     /**
      * The domain that the cookie is available. To make the cookie available on all subdomains ofexample.com then you'd
      * set it to '.example.com'. The . is not required but makes itcompatible with more browsers. Setting it to
      * www.example.com will make the cookie onlyavailable in the www subdomain. Refer to tail matching in the spec for
      * details.
-     *
-     * @var string|null
      */
-    private $domain;
+    private ?string $domain;
 
     /**
      * Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client. When set to
      * true, the cookie will only be set if a secure connection exists. On the server-side, it's on the programmer to
      * send this kind of cookie only on secure connection (e.g. with respect to $_SERVER["HTTPS"]).
-     *
-     * @var bool
      */
-    private $secure;
+    private bool $secure;
 
     /**
      * When true the cookie will be made accessible only through the HTTP protocol. This means that the cookie won't be
      * accessible by scripting languages, such as JavaScript. This setting can effectively help to reduce identity
      * theft through XSS attacks (although it is not supported by all browsers).
-     *
-     * @var bool
      */
-    private $httpOnly;
+    private bool $httpOnly;
 
     /**
      * The value of the samesite element should be either None, Lax or Strict. If any of the allowed options are not
      * given, their default values are the same as the default values of the explicit parameters. If the samesite
      * element is omitted, no SameSite cookie attribute is set. When Same-Site attribute is set to "None" it is
      * required to have "Secure" attribute enable. Otherwise it will be converted to "Lax".
-     *
-     * @var Cookie\SameSite
      */
-    private $sameSite;
+    private SameSite $sameSite;
 
     /**
      * New Cookie instance, cookies used to schedule cookie set while dispatching Response.
@@ -137,7 +122,7 @@ final class Cookie
         $this->domain = $domain;
         $this->secure = $secure;
         $this->httpOnly = $httpOnly;
-        $this->sameSite = new Cookie\SameSite($sameSite, $secure);
+        $this->sameSite = new SameSite($sameSite, $secure);
     }
 
     public function __toString(): string

--- a/src/Cookies/src/Cookie/SameSite.php
+++ b/src/Cookies/src/Cookie/SameSite.php
@@ -13,8 +13,7 @@ class SameSite
     private const VALUES  = [self::STRICT, self::LAX, self::NONE];
     private const DEFAULT = self::LAX;
 
-    /** @var string|null */
-    private $sameSite;
+    private ?string $sameSite;
 
     public function __construct(?string $sameSite = null, bool $secure = false)
     {

--- a/src/Cookies/src/CookieQueue.php
+++ b/src/Cookies/src/CookieQueue.php
@@ -16,13 +16,11 @@ final class CookieQueue
     public const ATTRIBUTE = 'cookieQueue';
 
     /** @var Cookie[] */
-    private $scheduled = [];
+    private array $scheduled = [];
 
-    /** @var string|null */
-    private $domain;
+    private ?string $domain;
 
-    /** @var bool */
-    private $secure;
+    private bool $secure;
 
     public function __construct(?string $domain = null, bool $secure = false)
     {

--- a/src/Cookies/src/Middleware/CookiesMiddleware.php
+++ b/src/Cookies/src/Middleware/CookiesMiddleware.php
@@ -29,11 +29,9 @@ use Spiral\Encrypter\Exception\EncryptException;
  */
 final class CookiesMiddleware implements MiddlewareInterface
 {
-    /** @var CookiesConfig */
-    private $config;
+    private CookiesConfig $config;
 
-    /** @var EncryptionInterface */
-    private $encryption;
+    private EncryptionInterface $encryption;
 
     public function __construct(CookiesConfig $config, EncryptionInterface $encryption)
     {

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -50,10 +50,7 @@ final class Container implements
     InvokerInterface,
     ScopeInterface
 {
-    /**
-     * @var array
-     */
-    private $bindings = [
+    private array $bindings = [
         ContainerInterface::class => self::class,
         BinderInterface::class    => self::class,
         FactoryInterface::class   => self::class,
@@ -65,10 +62,8 @@ final class Container implements
     /**
      * List of classes responsible for handling specific instance or interface. Provides ability to
      * delegate container functionality.
-     *
-     * @var array
      */
-    private $injectors = [];
+    private array $injectors = [];
 
     /**
      * Container constructor.

--- a/src/Core/src/Container/Autowire.php
+++ b/src/Core/src/Container/Autowire.php
@@ -20,14 +20,12 @@ use Spiral\Core\FactoryInterface;
  */
 final class Autowire
 {
-    /** @var object|null */
-    private $target;
+    private ?object $target = null;
 
     /** @var mixed */
     private $alias;
 
-    /** @var array */
-    private $parameters;
+    private array $parameters;
 
     /**
      * Autowire constructor.

--- a/src/Core/src/ContainerScope.php
+++ b/src/Core/src/ContainerScope.php
@@ -21,8 +21,7 @@ use Throwable;
  */
 final class ContainerScope
 {
-    /** @var ContainerInterface */
-    private static $container;
+    private static ?ContainerInterface $container = null;
 
     /**
      * Returns currently active container scope if any.

--- a/src/Csrf/src/Middleware/CsrfFirewall.php
+++ b/src/Csrf/src/Middleware/CsrfFirewall.php
@@ -38,11 +38,9 @@ final class CsrfFirewall implements MiddlewareInterface
      */
     public const ALLOW_METHODS = ['GET', 'HEAD', 'OPTIONS'];
 
-    /** @var ResponseFactoryInterface */
-    private $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
-    /** @var array */
-    private $allowMethods;
+    private array $allowMethods;
 
     public function __construct(ResponseFactoryInterface $responseFactory, array $allowMethods = self::ALLOW_METHODS)
     {

--- a/src/Csrf/src/Middleware/CsrfMiddleware.php
+++ b/src/Csrf/src/Middleware/CsrfMiddleware.php
@@ -30,8 +30,7 @@ final class CsrfMiddleware implements MiddlewareInterface
 {
     public const ATTRIBUTE = 'csrfToken';
 
-    /** @var CsrfConfig */
-    protected $config;
+    protected CsrfConfig $config;
 
     public function __construct(CsrfConfig $config)
     {

--- a/src/Csrf/src/Middleware/StrictCsrfFirewall.php
+++ b/src/Csrf/src/Middleware/StrictCsrfFirewall.php
@@ -22,8 +22,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class StrictCsrfFirewall implements MiddlewareInterface
 {
-    /** @var CsrfFirewall */
-    private $csrfFirewall;
+    private CsrfFirewall $csrfFirewall;
 
     public function __construct(ResponseFactoryInterface $responseFactory)
     {

--- a/src/DataGrid/src/Compiler.php
+++ b/src/DataGrid/src/Compiler.php
@@ -21,7 +21,7 @@ use Spiral\DataGrid\Specification\SequenceInterface;
 final class Compiler
 {
     /** @var WriterInterface[] */
-    private $writers = [];
+    private array $writers = [];
 
     public function addWriter(WriterInterface $writer): void
     {

--- a/src/DataGrid/src/Grid.php
+++ b/src/DataGrid/src/Grid.php
@@ -20,11 +20,9 @@ use Spiral\DataGrid\Exception\GridViewException;
  */
 class Grid implements GridInterface
 {
-    /** @var array */
-    private $options = [];
+    private array $options = [];
 
-    /** @var iterable */
-    private $source;
+    private ?iterable $source = null;
 
     /** @var callable */
     private $mapper;

--- a/src/DataGrid/src/GridFactory.php
+++ b/src/DataGrid/src/GridFactory.php
@@ -31,17 +31,13 @@ class GridFactory implements GridFactoryInterface
     /** @var callable */
     private $count = 'count';
 
-    /** @var Compiler */
-    private $compiler;
+    private Compiler $compiler;
 
-    /** @var InputInterface */
-    private $input;
+    private InputInterface $input;
 
-    /** @var InputInterface */
-    private $defaults;
+    private InputInterface $defaults;
 
-    /** @var GridInterface */
-    private $view;
+    private GridInterface $view;
 
     /**
      * @param InputInterface|null $input

--- a/src/DataGrid/src/GridSchema.php
+++ b/src/DataGrid/src/GridSchema.php
@@ -23,13 +23,12 @@ use Spiral\DataGrid\Specification\SorterInterface;
 class GridSchema
 {
     /** @var FilterInterface[] */
-    private $filters = [];
+    private array $filters = [];
 
     /** @var SorterInterface[] */
-    private $sorters = [];
+    private array $sorters = [];
 
-    /** @var FilterInterface|null */
-    private $paginator;
+    private ?FilterInterface $paginator = null;
 
     /**
      * Define new data filter.

--- a/src/DataGrid/src/Input/ArrayInput.php
+++ b/src/DataGrid/src/Input/ArrayInput.php
@@ -19,8 +19,7 @@ use function Spiral\DataGrid\hasKey;
 
 final class ArrayInput implements InputInterface
 {
-    /** @var array */
-    private $data;
+    private array $data;
 
     public function __construct(array $data)
     {

--- a/src/DataGrid/src/Specification/Filter/Between.php
+++ b/src/DataGrid/src/Specification/Filter/Between.php
@@ -17,17 +17,14 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class Between implements FilterInterface
 {
-    /** @var string */
-    private $expression;
+    private string $expression;
 
     /** @var ValueInterface|array */
     private $value;
 
-    /** @var bool */
-    private $includeFrom;
+    private bool $includeFrom;
 
-    /** @var bool */
-    private $includeTo;
+    private bool $includeTo;
 
     /**
      * @param ValueInterface|array $value

--- a/src/DataGrid/src/Specification/Filter/Like.php
+++ b/src/DataGrid/src/Specification/Filter/Like.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\Specification\Value\StringValue;
 
 class Like extends Expression
 {
-    /** @var string */
-    private $pattern;
+    private string $pattern;
 
     /**
      * @param mixed|null $value

--- a/src/DataGrid/src/Specification/Filter/Postgres/ILike.php
+++ b/src/DataGrid/src/Specification/Filter/Postgres/ILike.php
@@ -10,8 +10,7 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class ILike implements FilterInterface
 {
-    /** @var Like */
-    private $like;
+    private Like $like;
 
     public function __construct(string $expression, $value = null, string $pattern = '%%%s%%')
     {

--- a/src/DataGrid/src/Specification/Filter/SortedFilter.php
+++ b/src/DataGrid/src/Specification/Filter/SortedFilter.php
@@ -13,7 +13,7 @@ class SortedFilter implements SequenceInterface, FilterInterface
     private $value;
 
     /** @var SpecificationInterface[] */
-    private $specifications;
+    private array $specifications;
 
     public function __construct(string $value, SpecificationInterface ...$specifications)
     {

--- a/src/DataGrid/src/Specification/Filter/ValueBetween.php
+++ b/src/DataGrid/src/Specification/Filter/ValueBetween.php
@@ -21,13 +21,11 @@ final class ValueBetween implements FilterInterface
     private $expression;
 
     /** @var string[] */
-    private $value;
+    private array $value;
 
-    /** @var bool */
-    private $includeFrom;
+    private bool $includeFrom;
 
-    /** @var bool */
-    private $includeTo;
+    private bool $includeTo;
 
     /**
      * @param ValueInterface|mixed $expression

--- a/src/DataGrid/src/Specification/Pagination/Limit.php
+++ b/src/DataGrid/src/Specification/Pagination/Limit.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class Limit implements SpecificationInterface
 {
-    /** @var int */
-    private $value;
+    private int $value;
 
     public function __construct(int $value)
     {

--- a/src/DataGrid/src/Specification/Pagination/Offset.php
+++ b/src/DataGrid/src/Specification/Pagination/Offset.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class Offset implements SpecificationInterface
 {
-    /** @var int */
-    private $value;
+    private int $value;
 
     public function __construct(int $value)
     {

--- a/src/DataGrid/src/Specification/Pagination/PagePaginator.php
+++ b/src/DataGrid/src/Specification/Pagination/PagePaginator.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Spiral\DataGrid\Specification\Pagination;
 
+use Spiral\DataGrid\Specification\Value\EnumValue;
+use Spiral\DataGrid\Specification\Value\IntValue;
 use Spiral\DataGrid\Specification\FilterInterface;
 use Spiral\DataGrid\Specification\SequenceInterface;
 use Spiral\DataGrid\Specification\Value;
@@ -19,14 +21,11 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class PagePaginator implements SequenceInterface, FilterInterface
 {
-    /** @var Value\EnumValue */
-    private $limitValue;
+    private EnumValue $limitValue;
 
-    /** @var int */
-    private $limit;
+    private int $limit;
 
-    /** @var int */
-    private $page;
+    private int $page;
 
     public function __construct(int $defaultLimit, array $allowedLimits = [])
     {
@@ -37,7 +36,7 @@ final class PagePaginator implements SequenceInterface, FilterInterface
 
         sort($allowedLimits);
 
-        $this->limitValue = new Value\EnumValue(new Value\IntValue(), ...$allowedLimits);
+        $this->limitValue = new EnumValue(new IntValue(), ...$allowedLimits);
     }
 
     /**

--- a/src/DataGrid/src/Specification/Sorter/AbstractSorter.php
+++ b/src/DataGrid/src/Specification/Sorter/AbstractSorter.php
@@ -17,8 +17,7 @@ use Spiral\DataGrid\SpecificationInterface;
 
 abstract class AbstractSorter implements SorterInterface
 {
-    /** @var array */
-    private $expressions;
+    private array $expressions;
 
     public function __construct(string ...$expressions)
     {

--- a/src/DataGrid/src/Specification/Sorter/DirectionalSorter.php
+++ b/src/DataGrid/src/Specification/Sorter/DirectionalSorter.php
@@ -17,17 +17,13 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class DirectionalSorter implements SorterInterface
 {
-    /** @var SorterInterface */
-    private $asc;
+    private SorterInterface $asc;
 
-    /** @var SorterInterface */
-    private $desc;
+    private SorterInterface $desc;
 
-    /** @var SorterInterface */
-    private $sorter;
+    private ?SorterInterface $sorter = null;
 
-    /** @var string|null */
-    private $direction;
+    private ?string $direction = null;
 
     public function __construct(SorterInterface $asc, SorterInterface $desc)
     {

--- a/src/DataGrid/src/Specification/Sorter/FilteredSorter.php
+++ b/src/DataGrid/src/Specification/Sorter/FilteredSorter.php
@@ -13,7 +13,7 @@ class FilteredSorter implements SequenceInterface, SorterInterface
     private $value;
 
     /** @var SpecificationInterface[] */
-    private $specifications;
+    private array $specifications;
 
     public function __construct(string $value, SpecificationInterface ...$specifications)
     {

--- a/src/DataGrid/src/Specification/Sorter/Sorter.php
+++ b/src/DataGrid/src/Specification/Sorter/Sorter.php
@@ -17,8 +17,7 @@ use Spiral\DataGrid\SpecificationInterface;
 
 final class Sorter implements SorterInterface
 {
-    /** @var DirectionalSorter */
-    private $sorter;
+    private DirectionalSorter $sorter;
 
     public function __construct(string ...$expressions)
     {

--- a/src/DataGrid/src/Specification/Sorter/SorterSet.php
+++ b/src/DataGrid/src/Specification/Sorter/SorterSet.php
@@ -18,7 +18,7 @@ use Spiral\DataGrid\SpecificationInterface;
 final class SorterSet implements SorterInterface
 {
     /** @var SorterInterface[] */
-    private $sorters;
+    private array $sorters;
 
     public function __construct(SorterInterface ...$sorters)
     {

--- a/src/DataGrid/src/Specification/Value/Accessor/Split.php
+++ b/src/DataGrid/src/Specification/Value/Accessor/Split.php
@@ -8,8 +8,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 class Split extends Accessor
 {
-    /** @var string */
-    private $char;
+    private string $char;
 
     public function __construct(ValueInterface $next, string $char = ',')
     {

--- a/src/DataGrid/src/Specification/Value/ArrayValue.php
+++ b/src/DataGrid/src/Specification/Value/ArrayValue.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class ArrayValue implements ValueInterface
 {
-    /** @var ValueInterface */
-    private $base;
+    private ValueInterface $base;
 
     public function __construct(ValueInterface $base)
     {

--- a/src/DataGrid/src/Specification/Value/CompareValue.php
+++ b/src/DataGrid/src/Specification/Value/CompareValue.php
@@ -15,8 +15,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 abstract class CompareValue implements ValueInterface
 {
-    /** @var ValueInterface */
-    private $base;
+    private ValueInterface $base;
 
     public function __construct(ValueInterface $base)
     {

--- a/src/DataGrid/src/Specification/Value/DatetimeFormatValue.php
+++ b/src/DataGrid/src/Specification/Value/DatetimeFormatValue.php
@@ -18,11 +18,9 @@ use Throwable;
 
 final class DatetimeFormatValue implements ValueInterface
 {
-    /** @var string */
-    private $readFrom;
+    private string $readFrom;
 
-    /** @var string|null */
-    private $convertInto;
+    private ?string $convertInto;
 
     public function __construct(string $readFrom, ?string $convertInto = null)
     {

--- a/src/DataGrid/src/Specification/Value/EnumValue.php
+++ b/src/DataGrid/src/Specification/Value/EnumValue.php
@@ -17,11 +17,10 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class EnumValue implements ValueInterface
 {
-    /** @var ValueInterface */
-    private $base;
+    private ValueInterface $base;
 
     /** @var array|mixed[] */
-    private $values;
+    private array $values;
 
     /**
      * @param mixed          ...$values

--- a/src/DataGrid/src/Specification/Value/IntersectValue.php
+++ b/src/DataGrid/src/Specification/Value/IntersectValue.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class IntersectValue implements ValueInterface
 {
-    /** @var ValueInterface */
-    private $enum;
+    private ValueInterface $enum;
 
     /**
      * @param mixed          ...$values

--- a/src/DataGrid/src/Specification/Value/NotEmpty.php
+++ b/src/DataGrid/src/Specification/Value/NotEmpty.php
@@ -14,8 +14,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class NotEmpty implements ValueInterface
 {
-    /** @var ValueInterface|null */
-    private $value;
+    private ?ValueInterface $value;
 
     public function __construct(?ValueInterface $value = null)
     {

--- a/src/DataGrid/src/Specification/Value/RangeValue.php
+++ b/src/DataGrid/src/Specification/Value/RangeValue.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Spiral\DataGrid\Specification\Value;
 
+use Spiral\DataGrid\Specification\Value\RangeValue\Boundary;
 use Spiral\DataGrid\Exception\ValueException;
 use Spiral\DataGrid\Specification\ValueInterface;
 
@@ -19,24 +20,21 @@ use Spiral\DataGrid\Specification\ValueInterface;
  */
 final class RangeValue implements ValueInterface
 {
-    /** @var ValueInterface */
-    private $base;
+    private ValueInterface $base;
 
-    /** @var RangeValue\Boundary */
-    private $from;
+    private Boundary $from;
 
-    /** @var RangeValue\Boundary */
-    private $to;
+    private Boundary $to;
 
     /**
      * @param RangeValue\Boundary|null $from
      * @param RangeValue\Boundary|null $to
      */
-    public function __construct(ValueInterface $base, RangeValue\Boundary $from = null, RangeValue\Boundary $to = null)
+    public function __construct(ValueInterface $base, Boundary $from = null, Boundary $to = null)
     {
         $this->base = $base;
-        $from = $from ?? RangeValue\Boundary::empty();
-        $to = $to ?? RangeValue\Boundary::empty();
+        $from ??= Boundary::empty();
+        $to ??= Boundary::empty();
 
         $this->validateBoundaries($from, $to);
         $this->setBoundaries($from, $to);
@@ -58,7 +56,7 @@ final class RangeValue implements ValueInterface
         return $this->base->convert($value);
     }
 
-    private function validateBoundaries(RangeValue\Boundary $from, RangeValue\Boundary $to): void
+    private function validateBoundaries(Boundary $from, Boundary $to): void
     {
         if (!$this->acceptsBoundary($from) || !$this->acceptsBoundary($to)) {
             throw new ValueException('Range boundaries should be applicable via passed type.');
@@ -69,7 +67,7 @@ final class RangeValue implements ValueInterface
         }
     }
 
-    private function acceptsBoundary(RangeValue\Boundary $boundary): bool
+    private function acceptsBoundary(Boundary $boundary): bool
     {
         return $boundary->empty || $this->base->accepts($boundary->value);
     }
@@ -77,7 +75,7 @@ final class RangeValue implements ValueInterface
     /**
      * @return mixed|null
      */
-    private function convertBoundaryValue(RangeValue\Boundary $boundary)
+    private function convertBoundaryValue(Boundary $boundary)
     {
         return $boundary->empty ? null : $this->base->convert($boundary->value);
     }
@@ -110,7 +108,7 @@ final class RangeValue implements ValueInterface
         return $this->to->include ? ($value <= $to) : ($value < $to);
     }
 
-    private function setBoundaries(RangeValue\Boundary $from, RangeValue\Boundary $to): void
+    private function setBoundaries(Boundary $from, Boundary $to): void
     {
         //Swap if from < to and both not empty
         if (!$from->empty && !$to->empty && $from->value > $to->value) {

--- a/src/DataGrid/src/Specification/Value/RegexValue.php
+++ b/src/DataGrid/src/Specification/Value/RegexValue.php
@@ -14,8 +14,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 class RegexValue implements ValueInterface
 {
-    /** @var string */
-    private $pattern;
+    private string $pattern;
 
     public function __construct(string $pattern)
     {

--- a/src/DataGrid/src/Specification/Value/ScalarValue.php
+++ b/src/DataGrid/src/Specification/Value/ScalarValue.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class ScalarValue implements ValueInterface
 {
-    /** @var bool */
-    private $allowEmpty;
+    private bool $allowEmpty;
 
     public function __construct(bool $allowEmpty = false)
     {

--- a/src/DataGrid/src/Specification/Value/StringValue.php
+++ b/src/DataGrid/src/Specification/Value/StringValue.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class StringValue implements ValueInterface
 {
-    /** @var bool */
-    private $allowEmpty;
+    private bool $allowEmpty;
 
     public function __construct(bool $allowEmpty = false)
     {

--- a/src/DataGrid/src/Specification/Value/SubsetValue.php
+++ b/src/DataGrid/src/Specification/Value/SubsetValue.php
@@ -16,8 +16,7 @@ use Spiral\DataGrid\Specification\ValueInterface;
 
 final class SubsetValue implements ValueInterface
 {
-    /** @var ValueInterface */
-    private $enum;
+    private ValueInterface $enum;
 
     /**
      * @param mixed          ...$values

--- a/src/DataGrid/src/Specification/Value/UuidValue.php
+++ b/src/DataGrid/src/Specification/Value/UuidValue.php
@@ -48,11 +48,9 @@ final class UuidValue implements ValueInterface
      */
     private const NIL_VALUE = '00000000-0000-0000-0000-000000000000';
 
-    /** @var string */
-    private $mask;
+    private string $mask;
 
-    /** @var RegexValue */
-    private $regex;
+    private RegexValue $regex;
 
     public function __construct(string $mask = self::VALID)
     {

--- a/src/Debug/src/State.php
+++ b/src/Debug/src/State.php
@@ -19,14 +19,11 @@ use Spiral\Logger\Event\LogEvent;
  */
 final class State implements StateInterface
 {
-    /** @var array */
-    private $tags = [];
+    private array $tags = [];
 
-    /** @var array */
-    private $extras = [];
+    private array $extras = [];
 
-    /** @var array */
-    private $logEvents = [];
+    private array $logEvents = [];
 
     public function setTags(array $tags): void
     {

--- a/src/Distribution/src/Internal/DateTimeFactory.php
+++ b/src/Distribution/src/Internal/DateTimeFactory.php
@@ -27,10 +27,7 @@ final class DateTimeFactory implements DateTimeFactoryInterface
      */
     private const DATE_NOW = 'now';
 
-    /**
-     * @var string
-     */
-    private $timezone;
+    private string $timezone;
 
     public function __construct(string $timezone = self::DEFAULT_TIMEZONE)
     {

--- a/src/Distribution/src/Manager.php
+++ b/src/Distribution/src/Manager.php
@@ -31,12 +31,9 @@ final class Manager implements MutableDistributionInterface
     /**
      * @var array<string, UriResolverInterface>
      */
-    private $resolvers = [];
+    private array $resolvers = [];
 
-    /**
-     * @var string
-     */
-    private $default;
+    private string $default;
 
     public function __construct(string $name = self::DEFAULT_RESOLVER)
     {
@@ -59,7 +56,7 @@ final class Manager implements MutableDistributionInterface
      */
     public function resolver(string $name = null): UriResolverInterface
     {
-        $name = $name ?? $this->default;
+        $name ??= $this->default;
 
         if (!isset($this->resolvers[$name])) {
             throw new \InvalidArgumentException(\sprintf(self::ERROR_NOT_FOUND, $name));

--- a/src/Distribution/src/Resolver/CloudFrontResolver.php
+++ b/src/Distribution/src/Resolver/CloudFrontResolver.php
@@ -24,25 +24,13 @@ use Spiral\Distribution\Internal\DateTimeIntervalFactoryInterface;
  */
 class CloudFrontResolver extends ExpirationAwareResolver
 {
-    /**
-     * @var string
-     */
-    private $domain;
+    private string $domain;
 
-    /**
-     * @var UrlSigner
-     */
-    private $signer;
+    private UrlSigner $signer;
 
-    /**
-     * @var AmazonUriFactory
-     */
-    private $factory;
+    private AmazonUriFactory $factory;
 
-    /**
-     * @var string|null
-     */
-    private $prefix;
+    private ?string $prefix;
 
     /**
      * @param string|null $prefix

--- a/src/Distribution/src/Resolver/S3SignedResolver.php
+++ b/src/Distribution/src/Resolver/S3SignedResolver.php
@@ -22,20 +22,11 @@ use Spiral\Distribution\Internal\DateTimeIntervalFactoryInterface;
  */
 class S3SignedResolver extends ExpirationAwareResolver
 {
-    /**
-     * @var S3ClientInterface
-     */
-    private $client;
+    private S3ClientInterface $client;
 
-    /**
-     * @var string
-     */
-    private $bucket;
+    private string $bucket;
 
-    /**
-     * @var string|null
-     */
-    private $prefix;
+    private ?string $prefix;
 
     /**
      * @param string|null $prefix

--- a/src/Distribution/src/Resolver/StaticResolver.php
+++ b/src/Distribution/src/Resolver/StaticResolver.php
@@ -22,10 +22,7 @@ class StaticResolver extends UriResolver
      */
     private const URI_PATH_DELIMITER = '/';
 
-    /**
-     * @var UriInterface
-     */
-    private $host;
+    private UriInterface $host;
 
     public function __construct(UriInterface $host)
     {

--- a/src/Dumper/src/Dumper.php
+++ b/src/Dumper/src/Dumper.php
@@ -39,15 +39,14 @@ class Dumper implements LoggerAwareInterface
     public const OUTPUT_CLI_COLORS = 5;
     public const ROADRUNNER        = 6;
 
-    /** @var int */
-    private $maxLevel = 12;
+    private int $maxLevel = 12;
 
     /**
      * Default render associations.
      *
      * @var array|RendererInterface[]
      */
-    private $targets = [
+    private array $targets = [
         self::OUTPUT            => HtmlRenderer::class,
         self::OUTPUT_CLI        => PlainRenderer::class,
         self::OUTPUT_CLI_COLORS => ConsoleRenderer::class,

--- a/src/Dumper/src/Renderer/ConsoleRenderer.php
+++ b/src/Dumper/src/Renderer/ConsoleRenderer.php
@@ -22,17 +22,13 @@ final class ConsoleRenderer extends AbstractRenderer
 {
     /**
      * Every dumped element is wrapped using this pattern.
-     *
-     * @var string
      */
-    protected $element = '%s%s' . Color::RESET;
+    protected string $element = '%s%s' . Color::RESET;
 
     /**
      * Set of styles associated with different dumping properties.
-     *
-     * @var array
      */
-    protected $styles = [
+    protected array $styles = [
         'common'   => Color::BOLD_WHITE,
         'name'     => Color::LIGHT_WHITE,
         'dynamic'  => Color::PURPLE,

--- a/src/Dumper/src/Renderer/HtmlRenderer.php
+++ b/src/Dumper/src/Renderer/HtmlRenderer.php
@@ -100,10 +100,8 @@ final class HtmlRenderer implements RendererInterface
 
     /**
      * Set of styles associated with different dumping properties.
-     *
-     * @var array
      */
-    protected $style = self::DEFAULT;
+    protected array $style = self::DEFAULT;
 
     public function __construct(array $style = self::DEFAULT)
     {

--- a/src/Dumper/src/Renderer/PlainRenderer.php
+++ b/src/Dumper/src/Renderer/PlainRenderer.php
@@ -18,8 +18,7 @@ namespace Spiral\Debug\Renderer;
  */
 final class PlainRenderer extends AbstractRenderer
 {
-    /** @var bool */
-    private $escapeStrings = false;
+    private bool $escapeStrings = false;
 
     public function __construct(bool $escapeStrings = true)
     {

--- a/src/Dumper/src/helpers.php
+++ b/src/Dumper/src/helpers.php
@@ -8,8 +8,8 @@
  */
 
 declare(strict_types=1);
-use Spiral\Core\ContainerScope;
 
+use Spiral\Core\ContainerScope;
 use Spiral\Debug\Dumper;
 
 if (!function_exists('dump')) {

--- a/src/Dumper/src/helpers.php
+++ b/src/Dumper/src/helpers.php
@@ -8,6 +8,7 @@
  */
 
 declare(strict_types=1);
+use Spiral\Core\ContainerScope;
 
 use Spiral\Debug\Dumper;
 
@@ -22,11 +23,11 @@ if (!function_exists('dump')) {
      */
     function dump($value, int $output = Dumper::OUTPUT): ?string
     {
-        if (!class_exists(\Spiral\Core\ContainerScope::class)) {
+        if (!class_exists(ContainerScope::class)) {
             return (new Dumper())->dump($value, $output);
         }
 
-        $container = \Spiral\Core\ContainerScope::getContainer();
+        $container = ContainerScope::getContainer();
         if (is_null($container) || !$container->has(Dumper::class)) {
             $dumper = new Dumper();
 

--- a/src/Encrypter/src/Encrypter.php
+++ b/src/Encrypter/src/Encrypter.php
@@ -29,8 +29,7 @@ final class Encrypter implements EncrypterInterface, InjectableInterface
 {
     public const INJECTOR = EncrypterFactory::class;
 
-    /** @var Key */
-    private $key;
+    private ?Key $key = null;
 
     /**
      * @param string $key Loads a Key from its encoded form (ANSI).
@@ -78,7 +77,7 @@ final class Encrypter implements EncrypterInterface, InjectableInterface
      */
     public function encrypt($data): string
     {
-        $packed = json_encode($data);
+        $packed = json_encode($data, JSON_THROW_ON_ERROR);
 
         try {
             return base64_encode(Crypto::Encrypt($packed, $this->key));
@@ -100,7 +99,7 @@ final class Encrypter implements EncrypterInterface, InjectableInterface
                 $this->key
             );
 
-            return json_decode($result, true);
+            return json_decode($result, true, 512, JSON_THROW_ON_ERROR);
         } catch (\Throwable $e) {
             throw new DecryptException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Encrypter/src/EncrypterFactory.php
+++ b/src/Encrypter/src/EncrypterFactory.php
@@ -23,8 +23,7 @@ use Spiral\Encrypter\Exception\EncrypterException;
  */
 final class EncrypterFactory implements InjectorInterface, EncryptionInterface, SingletonInterface
 {
-    /** @var EncrypterConfig */
-    protected $config;
+    protected EncrypterConfig $config;
 
     public function __construct(EncrypterConfig $config)
     {

--- a/src/Exceptions/src/ConsoleHandler.php
+++ b/src/Exceptions/src/ConsoleHandler.php
@@ -41,8 +41,7 @@ class ConsoleHandler extends AbstractHandler
         'reset'      => Color::RESET,
     ];
 
-    /** @var StyleInterface */
-    private $colorsSupport;
+    private StyleInterface $colorsSupport;
 
     /**
      * @param bool|resource $stream

--- a/src/Exceptions/src/ConsoleHandler.php
+++ b/src/Exceptions/src/ConsoleHandler.php
@@ -41,7 +41,7 @@ class ConsoleHandler extends AbstractHandler
         'reset'      => Color::RESET,
     ];
 
-    private StyleInterface $colorsSupport;
+    private bool $colorsSupport;
 
     /**
      * @param bool|resource $stream

--- a/src/Exceptions/src/Highlighter.php
+++ b/src/Exceptions/src/Highlighter.php
@@ -16,8 +16,7 @@ namespace Spiral\Exceptions;
  */
 class Highlighter
 {
-    /** @var StyleInterface */
-    private $r;
+    private StyleInterface $r;
 
     public function __construct(StyleInterface $renderer)
     {

--- a/src/Exceptions/src/JsonHandler.php
+++ b/src/Exceptions/src/JsonHandler.php
@@ -24,7 +24,7 @@ final class JsonHandler extends AbstractHandler
                 $e->getLine()
             ),
             'stacktrace' => iterator_to_array($this->renderTrace($e->getTrace(), $verbosity)),
-        ]);
+        ], JSON_THROW_ON_ERROR);
     }
 
     private function renderTrace(array $trace, int $verbosity): \Generator

--- a/src/Exceptions/src/ValueWrapper.php
+++ b/src/Exceptions/src/ValueWrapper.php
@@ -21,21 +21,16 @@ use Spiral\Debug\RendererInterface;
  */
 class ValueWrapper
 {
-    /** @var RendererInterface */
-    private $r;
+    private RendererInterface $r;
 
-    /** @var Dumper */
-    private $dumper;
+    private Dumper $dumper;
 
-    /** @var int */
-    private $verbosity;
+    private int $verbosity;
 
     /**
      * Aggregated list of value dumps, only for DEBUG mode.
-     *
-     * @var array
      */
-    private $values = [];
+    private array $values = [];
 
     public function __construct(Dumper $dumper, RendererInterface $renderer, int $verbosity)
     {
@@ -71,7 +66,7 @@ class ValueWrapper
             if ($this->verbosity < HandlerInterface::VERBOSITY_DEBUG) {
                 $result[] = sprintf('<span>%s</span>', $type);
             } else {
-                $hash = is_object($arg) ? spl_object_hash($arg) : md5(json_encode($arg));
+                $hash = is_object($arg) ? spl_object_hash($arg) : md5(json_encode($arg, JSON_THROW_ON_ERROR));
 
                 if (!isset($this->values[$hash])) {
                     $this->values[$hash] = $this->dumper->dump($arg, Dumper::RETURN);

--- a/src/Files/src/Files.php
+++ b/src/Files/src/Files.php
@@ -27,10 +27,8 @@ final class Files implements FilesInterface
 
     /**
      * Files to be removed when component destructed.
-     *
-     * @var array
      */
-    private $destructFiles = [];
+    private array $destructFiles = [];
 
     /**
      * FileManager constructor.
@@ -117,7 +115,7 @@ final class Files implements FilesInterface
         bool $ensureDirectory = false,
         bool $append = false
     ): bool {
-        $mode = $mode ?? self::DEFAULT_FILE_MODE;
+        $mode ??= self::DEFAULT_FILE_MODE;
 
         try {
             if ($ensureDirectory) {
@@ -427,7 +425,7 @@ final class Files implements FilesInterface
      */
     private function filesIterator(string $location, string $pattern = null): \GlobIterator
     {
-        $pattern = $pattern ?? '*';
+        $pattern ??= '*';
         $regexp = rtrim($location, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($pattern, DIRECTORY_SEPARATOR);
 
         return new \GlobIterator($regexp);

--- a/src/Files/src/FilesInterface.php
+++ b/src/Files/src/FilesInterface.php
@@ -29,8 +29,8 @@ interface FilesInterface
      * Few size constants for better size manipulations.
      */
     public const KB = 1024;
-    public const MB = 1048576;
-    public const GB = 1073741824;
+    public const MB = 1_048_576;
+    public const GB = 1_073_741_824;
 
     /**
      * Default location (directory) separator.

--- a/src/Filters/src/ArrayInput.php
+++ b/src/Filters/src/ArrayInput.php
@@ -18,11 +18,9 @@ use Spiral\Filters\Exception\DotNotFoundException;
  */
 final class ArrayInput implements InputInterface
 {
-    /** @var array */
-    private $data;
+    private array $data;
 
-    /** @var string */
-    private $prefix = '';
+    private string $prefix = '';
 
     public function __construct(array $data = [])
     {

--- a/src/Filters/src/ErrorMapper.php
+++ b/src/Filters/src/ErrorMapper.php
@@ -18,8 +18,7 @@ use Spiral\Filters\Exception\SchemaException;
  */
 final class ErrorMapper
 {
-    /** @var array */
-    private $schema;
+    private array $schema;
 
     public function __construct(array $schema)
     {

--- a/src/Filters/src/Filter.php
+++ b/src/Filters/src/Filter.php
@@ -65,17 +65,15 @@ abstract class Filter extends SchematicEntity implements FilterInterface
     protected const SETTERS   = [];
     protected const GETTERS   = [];
 
-    /** @var ErrorMapper */
-    private $errorMapper;
+    private ErrorMapper $errorMapper;
 
     /** @var array|null */
     private $errors;
 
-    /** @var array */
-    private $mappings;
+    private array $mappings;
 
     /** @var ValidatorInterface @internal */
-    private $validator;
+    private ValidatorInterface $validator;
 
     /**
      * Filter constructor.

--- a/src/Filters/src/FilterProvider.php
+++ b/src/Filters/src/FilterProvider.php
@@ -38,20 +38,17 @@ final class FilterProvider implements FilterProviderInterface
     public const ITERATE_SOURCE = 'iterate_source';
     public const ITERATE_ORIGIN = 'iterate_origin';
 
-    /** @var array */
-    private $cache;
+    private array $cache;
 
     /** @var ErrorMapper[] */
-    private $errorMappers = [];
+    private array $errorMappers = [];
 
     /** @var ValidatorInterface[] */
-    private $validators = [];
+    private array $validators = [];
 
-    /** @var ValidationInterface */
-    private $validation;
+    private ValidationInterface $validation;
 
-    /** @var FactoryInterface */
-    private $factory;
+    private FactoryInterface $factory;
 
     /**
      * @param FactoryInterface|null $factory

--- a/src/Filters/src/SchemaBuilder.php
+++ b/src/Filters/src/SchemaBuilder.php
@@ -23,8 +23,7 @@ final class SchemaBuilder
     protected const ITERATE  = 2;
     protected const OPTIONAL = 'optional';
 
-    /** @var ReflectionEntity */
-    private $entity;
+    private ReflectionEntity $entity;
 
     public function __construct(ReflectionEntity $entity)
     {

--- a/src/Hmvc/src/AbstractCore.php
+++ b/src/Hmvc/src/AbstractCore.php
@@ -75,8 +75,6 @@ abstract class AbstractCore implements CoreInterface
             );
         }
 
-        return ContainerScope::runScope($this->container, function () use ($controller, $method, $args) {
-            return $method->invokeArgs($this->container->get($controller), $args);
-        });
+        return ContainerScope::runScope($this->container, fn() => $method->invokeArgs($this->container->get($controller), $args));
     }
 }

--- a/src/Hmvc/src/AbstractCore.php
+++ b/src/Hmvc/src/AbstractCore.php
@@ -75,6 +75,7 @@ abstract class AbstractCore implements CoreInterface
             );
         }
 
-        return ContainerScope::runScope($this->container, fn () => $method->invokeArgs($this->container->get($controller), $args));
+        return ContainerScope::runScope($this->container, fn () =>
+            $method->invokeArgs($this->container->get($controller), $args));
     }
 }

--- a/src/Hmvc/src/AbstractCore.php
+++ b/src/Hmvc/src/AbstractCore.php
@@ -75,6 +75,6 @@ abstract class AbstractCore implements CoreInterface
             );
         }
 
-        return ContainerScope::runScope($this->container, fn() => $method->invokeArgs($this->container->get($controller), $args));
+        return ContainerScope::runScope($this->container, fn () => $method->invokeArgs($this->container->get($controller), $args));
     }
 }

--- a/src/Hmvc/src/InterceptableCore.php
+++ b/src/Hmvc/src/InterceptableCore.php
@@ -16,11 +16,9 @@ namespace Spiral\Core;
  */
 final class InterceptableCore implements CoreInterface
 {
-    /** @var InterceptorPipeline */
-    private $pipeline;
+    private InterceptorPipeline $pipeline;
 
-    /** @var CoreInterface */
-    private $core;
+    private CoreInterface $core;
 
     public function __construct(CoreInterface $core)
     {

--- a/src/Hmvc/src/InterceptorPipeline.php
+++ b/src/Hmvc/src/InterceptorPipeline.php
@@ -18,14 +18,12 @@ use Spiral\Core\Exception\InterceptorException;
  */
 final class InterceptorPipeline implements CoreInterface
 {
-    /** @var CoreInterface */
-    private $core;
+    private ?CoreInterface $core = null;
 
     /** @var CoreInterceptorInterface[] */
-    private $interceptors = [];
+    private array $interceptors = [];
 
-    /** @var int */
-    private $position = 0;
+    private int $position = 0;
 
     public function addInterceptor(CoreInterceptorInterface $interceptor): void
     {

--- a/src/Http/src/CallableHandler.php
+++ b/src/Http/src/CallableHandler.php
@@ -27,8 +27,7 @@ final class CallableHandler implements RequestHandlerInterface
     /** @var callable */
     private $callable;
 
-    /** @var ResponseFactoryInterface */
-    private $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
     public function __construct(callable $callable, ResponseFactoryInterface $responseFactory)
     {

--- a/src/Http/src/Header/AcceptHeader.php
+++ b/src/Http/src/Header/AcceptHeader.php
@@ -25,10 +25,9 @@ use Spiral\Http\Exception\AcceptHeaderException;
 final class AcceptHeader
 {
     /** @var array|AcceptHeaderItem[] */
-    private $items = [];
+    private array $items = [];
 
-    /** @var bool */
-    private $sorted = false;
+    private bool $sorted = false;
 
     /**
      * AcceptHeader constructor.
@@ -91,9 +90,7 @@ final class AcceptHeader
             /**
              * Sort item in descending order.
              */
-            uasort($this->items, static function (AcceptHeaderItem $a, AcceptHeaderItem $b) {
-                return self::compare($a, $b) * -1;
-            });
+            uasort($this->items, static fn(AcceptHeaderItem $a, AcceptHeaderItem $b) => self::compare($a, $b) * -1);
 
             $this->sorted = true;
         }

--- a/src/Http/src/Header/AcceptHeader.php
+++ b/src/Http/src/Header/AcceptHeader.php
@@ -90,7 +90,7 @@ final class AcceptHeader
             /**
              * Sort item in descending order.
              */
-            uasort($this->items, static fn(AcceptHeaderItem $a, AcceptHeaderItem $b) => self::compare($a, $b) * -1);
+            uasort($this->items, static fn (AcceptHeaderItem $a, AcceptHeaderItem $b) => self::compare($a, $b) * -1);
 
             $this->sorted = true;
         }

--- a/src/Http/src/Header/AcceptHeaderItem.php
+++ b/src/Http/src/Header/AcceptHeaderItem.php
@@ -18,14 +18,11 @@ namespace Spiral\Http\Header;
  */
 final class AcceptHeaderItem
 {
-    /** @var string|null */
-    private $value;
+    private ?string $value;
 
-    /** @var float */
-    private $quality;
+    private float $quality;
 
-    /** @var array */
-    private $params = [];
+    private array $params = [];
 
     /**
      * AcceptHeaderItem constructor.

--- a/src/Http/src/Http.php
+++ b/src/Http/src/Http.php
@@ -21,17 +21,13 @@ use Spiral\Http\Exception\HttpException;
 
 final class Http implements RequestHandlerInterface
 {
-    /** @var HttpConfig */
-    protected $config;
+    protected HttpConfig $config;
 
-    /** @var Pipeline */
-    protected $pipeline;
+    protected Pipeline $pipeline;
 
-    /** @var ResponseFactoryInterface */
-    protected $responseFactory;
+    protected ResponseFactoryInterface $responseFactory;
 
-    /** @var ContainerInterface */
-    protected $container;
+    protected ContainerInterface $container;
 
     /** @var RequestHandlerInterface */
     protected $handler;

--- a/src/Http/src/Pipeline.php
+++ b/src/Http/src/Pipeline.php
@@ -74,6 +74,6 @@ final class Pipeline implements RequestHandlerInterface, MiddlewareInterface
             return $this->middleware[$position]->process($request, $this);
         }
 
-        return $this->scope->runScope([Request::class => $request], fn() => $this->handler->handle($request));
+        return $this->scope->runScope([Request::class => $request], fn () => $this->handler->handle($request));
     }
 }

--- a/src/Http/src/Pipeline.php
+++ b/src/Http/src/Pipeline.php
@@ -26,14 +26,11 @@ final class Pipeline implements RequestHandlerInterface, MiddlewareInterface
 {
     use MiddlewareTrait;
 
-    /** @var ScopeInterface */
-    private $scope;
+    private ScopeInterface $scope;
 
-    /** @var int */
-    private $position = 0;
+    private int $position = 0;
 
-    /** @var RequestHandlerInterface */
-    private $handler;
+    private ?RequestHandlerInterface $handler = null;
 
     public function __construct(ScopeInterface $scope)
     {
@@ -77,8 +74,6 @@ final class Pipeline implements RequestHandlerInterface, MiddlewareInterface
             return $this->middleware[$position]->process($request, $this);
         }
 
-        return $this->scope->runScope([Request::class => $request], function () use ($request) {
-            return $this->handler->handle($request);
-        });
+        return $this->scope->runScope([Request::class => $request], fn() => $this->handler->handle($request));
     }
 }

--- a/src/Http/src/Request/InputBag.php
+++ b/src/Http/src/Request/InputBag.php
@@ -20,11 +20,9 @@ use Spiral\Http\Exception\InputException;
  */
 class InputBag implements \Countable, \IteratorAggregate, \ArrayAccess
 {
-    /** @var array */
-    private $data = [];
+    private array $data = [];
 
-    /** @var string */
-    private $prefix = '';
+    private string $prefix = '';
 
     public function __construct(array $data, string $prefix = '')
     {

--- a/src/Http/src/Request/InputManager.php
+++ b/src/Http/src/Request/InputManager.php
@@ -44,9 +44,8 @@ final class InputManager implements SingletonInterface
      * Associations between bags and representing class/request method.
      *
      * @invisible
-     * @var array
      */
-    protected $bagAssociations = [
+    protected array $bagAssociations = [
         'headers'    => [
             'class'  => HeadersBag::class,
             'source' => 'getHeaders',
@@ -84,26 +83,23 @@ final class InputManager implements SingletonInterface
 
     /**
      * @invisible
-     * @var ContainerInterface
      */
-    protected $container;
+    protected ContainerInterface $container;
 
     /** @var InputBag[] */
-    private $bags = [];
+    private array $bags = [];
 
     /**
      * Prefix to add for each input request.
      *
      * @see self::withPrefix();
-     * @var string
      */
-    private $prefix = '';
+    private string $prefix = '';
 
     /**
      * List of content types that must be considered as JSON.
-     * @var array
      */
-    private $jsonTypes = [
+    private array $jsonTypes = [
         'application/json',
     ];
 

--- a/src/Http/src/ResponseWrapper.php
+++ b/src/Http/src/ResponseWrapper.php
@@ -28,14 +28,11 @@ final class ResponseWrapper
 {
     use JsonTrait;
 
-    /** @var ResponseFactoryInterface */
-    private $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
-    /** @var StreamFactoryInterface */
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
-    /** @var FilesInterface */
-    private $files;
+    private FilesInterface $files;
 
     public function __construct(
         ResponseFactoryInterface $responseFactory,

--- a/src/Http/src/SapiRequestFactory.php
+++ b/src/Http/src/SapiRequestFactory.php
@@ -56,17 +56,13 @@ use Psr\Http\Message\UriInterface;
  */
 final class SapiRequestFactory
 {
-    /** @var ServerRequestFactoryInterface */
-    private $requestFactory;
+    private ServerRequestFactoryInterface $requestFactory;
 
-    /** @var UriFactoryInterface */
-    private $uriFactory;
+    private UriFactoryInterface $uriFactory;
 
-    /** @var StreamFactoryInterface */
-    private $streamFactory;
+    private StreamFactoryInterface $streamFactory;
 
-    /** @var UploadedFileFactoryInterface */
-    private $uploadedFileFactory;
+    private UploadedFileFactoryInterface $uploadedFileFactory;
 
     public function __construct(
         ServerRequestFactoryInterface $requestFactory,

--- a/src/Http/src/Traits/JsonTrait.php
+++ b/src/Http/src/Traits/JsonTrait.php
@@ -34,7 +34,7 @@ trait JsonTrait
             $code = $payload['status'];
         }
 
-        $response->getBody()->write(json_encode($payload));
+        $response->getBody()->write(json_encode($payload, JSON_THROW_ON_ERROR));
 
         return $response->withStatus($code)->withHeader('Content-Type', 'application/json');
     }

--- a/src/Logger/src/Event/LogEvent.php
+++ b/src/Logger/src/Event/LogEvent.php
@@ -13,20 +13,15 @@ namespace Spiral\Logger\Event;
 
 final class LogEvent
 {
-    /** @var \DateTimeInterface */
-    private $time;
+    private \DateTimeInterface $time;
 
-    /** @var string */
-    private $channel;
+    private string $channel;
 
-    /** @var string */
-    private $level;
+    private string $level;
 
-    /** @var string */
-    private $message;
+    private string $message;
 
-    /** @var array */
-    private $context;
+    private array $context;
 
     public function __construct(
         \DateTimeInterface $time,

--- a/src/Logger/src/ListenerRegistry.php
+++ b/src/Logger/src/ListenerRegistry.php
@@ -17,7 +17,7 @@ namespace Spiral\Logger;
 final class ListenerRegistry implements ListenerRegistryInterface
 {
     /** @var callable[] */
-    private $listeners = [];
+    private array $listeners = [];
 
     public function addListener(callable $listener): void
     {

--- a/src/Logger/src/LogFactory.php
+++ b/src/Logger/src/LogFactory.php
@@ -19,8 +19,7 @@ use Spiral\Logger\Event\LogEvent;
  */
 final class LogFactory implements LogsInterface
 {
-    /** @var ListenerRegistryInterface */
-    private $listenedRegistry;
+    private ListenerRegistryInterface $listenedRegistry;
 
     public function __construct(ListenerRegistryInterface $listenedRegistry)
     {

--- a/src/Logger/src/NullLogger.php
+++ b/src/Logger/src/NullLogger.php
@@ -24,8 +24,7 @@ final class NullLogger implements LoggerInterface
     /** @var callable */
     private $receptor;
 
-    /** @var string */
-    private $channel;
+    private string $channel;
 
     public function __construct(callable $receptor, string $channel)
     {

--- a/src/Mailer/src/Message.php
+++ b/src/Mailer/src/Message.php
@@ -13,29 +13,21 @@ namespace Spiral\Mailer;
 
 class Message implements MessageInterface
 {
-    /** @var string */
-    private $subject;
+    private string $subject;
 
-    /** @var array */
-    private $data;
+    private array $data;
 
-    /** @var array */
-    private $to = [];
+    private array $to = [];
 
-    /** @var array */
-    private $cc = [];
+    private array $cc = [];
 
-    /** @var array */
-    private $bcc = [];
+    private array $bcc = [];
 
-    /** @var string|null */
-    private $from;
+    private ?string $from = null;
 
-    /** @var string|null */
-    private $replyTo;
+    private ?string $replyTo = null;
 
-    /** @var array */
-    private $options = [];
+    private array $options = [];
 
     /**
      * @param string|string[] $to

--- a/src/Models/src/AbstractEntity.php
+++ b/src/Models/src/AbstractEntity.php
@@ -20,8 +20,7 @@ use Spiral\Models\Exception\EntityException;
  */
 abstract class AbstractEntity implements EntityInterface, ValueInterface, \IteratorAggregate
 {
-    /** @var array */
-    private $fields;
+    private array $fields;
 
     public function __construct(array $data = [])
     {

--- a/src/Models/src/Reflection/ReflectionEntity.php
+++ b/src/Models/src/Reflection/ReflectionEntity.php
@@ -42,10 +42,9 @@ class ReflectionEntity
     private const MUTATOR_ACCESSOR = 'accessor';
 
     /** @var array @internal */
-    private $propertyCache = [];
+    private array $propertyCache = [];
 
-    /** @var \ReflectionClass */
-    private $reflection;
+    private ?\ReflectionClass $reflection;
 
     /**
      * Only support SchematicEntity classes!

--- a/src/Models/src/SchematicEntity.php
+++ b/src/Models/src/SchematicEntity.php
@@ -16,8 +16,7 @@ namespace Spiral\Models;
  */
 class SchematicEntity extends AbstractEntity
 {
-    /** @var array */
-    private $schema = [];
+    private array $schema = [];
 
     public function __construct(array $data, array $schema)
     {

--- a/src/Pagination/src/Paginator.php
+++ b/src/Pagination/src/Paginator.php
@@ -16,20 +16,15 @@ namespace Spiral\Pagination;
  */
 final class Paginator implements PaginatorInterface, \Countable
 {
-    /** @var int */
-    private $pageNumber = 1;
+    private int $pageNumber = 1;
 
-    /** @var int */
-    private $countPages = 1;
+    private int $countPages = 1;
 
-    /** @var int */
-    private $limit = 25;
+    private int $limit = 25;
 
-    /** @var int */
-    private $count = 0;
+    private int $count = 0;
 
-    /** @var string|null */
-    private $parameter;
+    private ?string $parameter;
 
     /**
      * @param string|null $parameter

--- a/src/Prototype/src/ClassNode.php
+++ b/src/Prototype/src/ClassNode.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype;
 
+use Spiral\Prototype\ClassNode\ClassStmt;
 use Spiral\Prototype\ClassNode\ConstructorParam;
 
 /**
@@ -37,7 +38,7 @@ final class ClassNode
     public $dependencies = [];
 
     /** @var ClassNode\ClassStmt[] */
-    private $stmts = [];
+    private array $stmts = [];
 
     /**
      * ClassNode constructor.
@@ -65,7 +66,7 @@ final class ClassNode
 
     public function addImportUsage(string $name, ?string $alias): void
     {
-        $this->addStmt(ClassNode\ClassStmt::create($name, $alias));
+        $this->addStmt(ClassStmt::create($name, $alias));
     }
 
     /**
@@ -84,7 +85,7 @@ final class ClassNode
         $this->constructorParams[$parameter->name] = ConstructorParam::createFromReflection($parameter);
     }
 
-    private function addStmt(ClassNode\ClassStmt $stmt): void
+    private function addStmt(ClassStmt $stmt): void
     {
         $this->stmts[(string)$stmt] = $stmt;
     }

--- a/src/Prototype/src/ClassNode/ConflictResolver/Names.php
+++ b/src/Prototype/src/ClassNode/ConflictResolver/Names.php
@@ -16,8 +16,7 @@ use Spiral\Prototype\Utils;
 
 final class Names
 {
-    /** @var Sequences */
-    private $sequences;
+    private Sequences $sequences;
 
     public function __construct(Sequences $sequences)
     {

--- a/src/Prototype/src/ClassNode/ConflictResolver/NamespaceEntity.php
+++ b/src/Prototype/src/ClassNode/ConflictResolver/NamespaceEntity.php
@@ -13,8 +13,7 @@ namespace Spiral\Prototype\ClassNode\ConflictResolver;
 
 final class NamespaceEntity extends AbstractEntity
 {
-    /** @var string */
-    private $fullName;
+    private ?string $fullName = null;
 
     public static function createWithSequence(string $name, string $fullName, int $sequence): NamespaceEntity
     {

--- a/src/Prototype/src/ClassNode/ConflictResolver/Namespaces.php
+++ b/src/Prototype/src/ClassNode/ConflictResolver/Namespaces.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\ClassNode\ConflictResolver;
 
+use Spiral\Prototype\ClassNode\Type;
 use Spiral\Prototype\ClassNode;
 use Spiral\Prototype\Utils;
 
 final class Namespaces
 {
-    /** @var Sequences */
-    private $sequences;
+    private Sequences $sequences;
 
     public function __construct(Sequences $sequences)
     {
@@ -149,7 +149,7 @@ final class Namespaces
         return null;
     }
 
-    private function parseNamespaceFromType(ClassNode\Type $type): NamespaceEntity
+    private function parseNamespaceFromType(Type $type): NamespaceEntity
     {
         return $this->parseNamespace($type->shortName, $type->name());
     }

--- a/src/Prototype/src/ClassNode/ConstructorParam.php
+++ b/src/Prototype/src/ClassNode/ConstructorParam.php
@@ -34,8 +34,7 @@ final class ConstructorParam
     /** @var bool */
     public $isVariadic = false;
 
-    /** @var bool */
-    private $builtIn;
+    private ?bool $builtIn = null;
 
     /**
      * ConstructorParam constructor.

--- a/src/Prototype/src/Command/AbstractCommand.php
+++ b/src/Prototype/src/Command/AbstractCommand.php
@@ -30,8 +30,7 @@ abstract class AbstractCommand extends Command
     /** @var PrototypeRegistry */
     protected $registry;
 
-    /** @var array */
-    private $cache = [];
+    private array $cache = [];
 
     public function __construct(PrototypeLocator $locator, NodeExtractor $extractor, PrototypeRegistry $registry)
     {

--- a/src/Prototype/src/Command/DumpCommand.php
+++ b/src/Prototype/src/Command/DumpCommand.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\Command;
 
+use Spiral\Prototype\Annotation\Parser;
+use Spiral\Prototype\Annotation\Line;
 use Spiral\Prototype\Annotation;
 use Spiral\Prototype\Bootloader\PrototypeBootloader;
 use Spiral\Prototype\Traits\PrototypeTrait;
@@ -77,14 +79,14 @@ final class DumpCommand extends AbstractCommand
 
     private function buildAnnotation(array $dependencies): string
     {
-        $an = new Annotation\Parser('');
-        $an->lines[] = new Annotation\Line(
+        $an = new Parser('');
+        $an->lines[] = new Line(
             'This DocComment is auto-generated, do not edit or commit this file to repository.'
         );
-        $an->lines[] = new Annotation\Line('');
+        $an->lines[] = new Line('');
 
         foreach ($dependencies as $dependency) {
-            $an->lines[] = new Annotation\Line(
+            $an->lines[] = new Line(
                 sprintf('\\%s $%s', $dependency->type->fullName, $dependency->var),
                 'property'
             );

--- a/src/Prototype/src/Command/InjectCommand.php
+++ b/src/Prototype/src/Command/InjectCommand.php
@@ -33,8 +33,7 @@ final class InjectCommand extends AbstractCommand
         ],
     ];
 
-    /** @var Injector */
-    private $injector;
+    private Injector $injector;
 
     public function __construct(PrototypeLocator $locator, NodeExtractor $extractor, PrototypeRegistry $registry)
     {

--- a/src/Prototype/src/Injector.php
+++ b/src/Prototype/src/Injector.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype;
 
+use PhpParser\Lexer\Emulative;
+use PhpParser\Parser\Php7;
 use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
@@ -29,17 +31,14 @@ use Spiral\Prototype\NodeVisitors\UpdateConstructor;
  */
 final class Injector
 {
-    /** @var Parser */
-    private $parser;
+    private Parser $parser;
 
-    /** @var Lexer */
-    private $lexer;
+    private Lexer $lexer;
 
     /** @var null|Standard|PrettyPrinterAbstract */
     private $printer;
 
-    /** @var NodeTraverser */
-    private $cloner;
+    private NodeTraverser $cloner;
 
     /**
      * @param Lexer|null                 $lexer
@@ -48,7 +47,7 @@ final class Injector
     public function __construct(Lexer $lexer = null, PrettyPrinterAbstract $printer = null)
     {
         if ($lexer === null) {
-            $lexer = new Lexer\Emulative([
+            $lexer = new Emulative([
                 'usedAttributes' => [
                     'comments',
                     'startLine',
@@ -60,7 +59,7 @@ final class Injector
         }
 
         $this->lexer = $lexer;
-        $this->parser = new Parser\Php7($this->lexer);
+        $this->parser = new Php7($this->lexer);
 
         $this->cloner = new NodeTraverser();
         $this->cloner->addVisitor(new CloningVisitor());

--- a/src/Prototype/src/NodeExtractor.php
+++ b/src/Prototype/src/NodeExtractor.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype;
 
+use Spiral\Prototype\ClassNode\ConflictResolver\Names;
+use Spiral\Prototype\ClassNode\ConflictResolver\Namespaces;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\Parser;
@@ -26,18 +28,15 @@ use Spiral\Prototype\NodeVisitors\ClassNode\LocateVariables;
  */
 final class NodeExtractor
 {
-    /** @var Parser */
-    private $parser;
+    private Parser $parser;
 
-    /** @var ConflictResolver\Names */
-    private $namesResolver;
+    private Names $namesResolver;
 
-    /** @var ConflictResolver\Namespaces */
-    private $namespacesResolver;
+    private Namespaces $namespacesResolver;
 
     public function __construct(
-        ConflictResolver\Names $namesResolver,
-        ConflictResolver\Namespaces $namespacesResolver,
+        Names $namesResolver,
+        Namespaces $namespacesResolver,
         Parser $parser = null
     ) {
         $this->namesResolver = $namesResolver;

--- a/src/Prototype/src/NodeVisitors/AddProperty.php
+++ b/src/Prototype/src/NodeVisitors/AddProperty.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Builder\Property;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
@@ -21,12 +23,9 @@ use Spiral\Prototype\Utils;
 
 final class AddProperty extends NodeVisitorAbstract
 {
-    /** @var ClassNode */
-    private $definition;
-    /** @var bool */
-    private $useTypedProperties;
-    /** @var bool */
-    private $noPhpDoc;
+    private ClassNode $definition;
+    private bool $useTypedProperties;
+    private bool $noPhpDoc;
 
     public function __construct(ClassNode $definition, bool $useTypedProperties = false, bool $noPhpDoc = false)
     {
@@ -40,7 +39,7 @@ final class AddProperty extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if (!$node instanceof Node\Stmt\Class_) {
+        if (!$node instanceof Class_) {
             return null;
         }
 
@@ -55,10 +54,10 @@ final class AddProperty extends NodeVisitorAbstract
         return $node;
     }
 
-    private function definePlacementID(Node\Stmt\Class_ $node): int
+    private function definePlacementID(Class_ $node): int
     {
         foreach ($node->stmts as $index => $child) {
-            if ($child instanceof Node\Stmt\ClassMethod || $child instanceof Node\Stmt\Property) {
+            if ($child instanceof ClassMethod || $child instanceof Node\Stmt\Property) {
                 return $index;
             }
         }

--- a/src/Prototype/src/NodeVisitors/AddUse.php
+++ b/src/Prototype/src/NodeVisitors/AddUse.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Name;
 use PhpParser\Builder\Use_;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -22,11 +25,10 @@ use Spiral\Prototype\Utils;
  */
 final class AddUse extends NodeVisitorAbstract
 {
-    /** @var ClassNode */
-    private $node;
+    private ClassNode $node;
 
     /** @var Node\Stmt\Use_[] */
-    private $nodes = [];
+    private array $nodes = [];
 
     public function __construct(ClassNode $node)
     {
@@ -38,7 +40,7 @@ final class AddUse extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if (!$node instanceof Node\Stmt\Namespace_) {
+        if (!$node instanceof Namespace_) {
             return null;
         }
 
@@ -80,10 +82,10 @@ final class AddUse extends NodeVisitorAbstract
         return $node;
     }
 
-    private function definePlacementID(Node\Stmt\Namespace_ $node): int
+    private function definePlacementID(Namespace_ $node): int
     {
         foreach ($node->stmts as $index => $child) {
-            if ($child instanceof Node\Stmt\Class_) {
+            if ($child instanceof Class_) {
                 return $index;
             }
         }
@@ -140,7 +142,7 @@ final class AddUse extends NodeVisitorAbstract
 
     private function buildUse(string $type, ?string $alias = null): Node\Stmt\Use_
     {
-        $b = new Use_(new Node\Name($type), Node\Stmt\Use_::TYPE_NORMAL);
+        $b = new Use_(new Name($type), Node\Stmt\Use_::TYPE_NORMAL);
         if (!empty($alias)) {
             $b->as($alias);
         }

--- a/src/Prototype/src/NodeVisitors/ClassNode/DeclareClass.php
+++ b/src/Prototype/src/NodeVisitors/ClassNode/DeclareClass.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors\ClassNode;
 
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -25,11 +27,11 @@ final class DeclareClass extends NodeVisitorAbstract
      */
     public function enterNode(Node $node)
     {
-        if ($node instanceof Node\Stmt\Namespace_) {
+        if ($node instanceof Namespace_) {
             $this->namespace = implode('\\', $node->name->parts);
         }
 
-        if ($node instanceof Node\Stmt\Class_) {
+        if ($node instanceof Class_) {
             $this->class = $node->name->name;
 
             return NodeTraverser::STOP_TRAVERSAL;

--- a/src/Prototype/src/NodeVisitors/ClassNode/LocateStatements.php
+++ b/src/Prototype/src/NodeVisitors/ClassNode/LocateStatements.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors\ClassNode;
 
+use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
@@ -19,15 +20,14 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class LocateStatements extends NodeVisitorAbstract
 {
-    /** @var array */
-    private $imports = [];
+    private array $imports = [];
 
     /**
      * @inheritDoc
      */
     public function enterNode(Node $node)
     {
-        if ($node instanceof Node\Stmt\Use_) {
+        if ($node instanceof Use_) {
             foreach ($node->uses as $use) {
                 $this->imports[] = [
                     'name'  => implode('\\', $use->name->parts),

--- a/src/Prototype/src/NodeVisitors/ClassNode/LocateVariables.php
+++ b/src/Prototype/src/NodeVisitors/ClassNode/LocateVariables.php
@@ -11,30 +11,32 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors\ClassNode;
 
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
 final class LocateVariables extends NodeVisitorAbstract
 {
-    /** @var array */
-    private $vars = [];
+    private array $vars = [];
 
     /**
      * @inheritDoc
      */
     public function enterNode(Node $node)
     {
-        if ($node instanceof Node\Stmt\Class_) {
+        if ($node instanceof Class_) {
             foreach ($node->stmts as $stmt) {
-                if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name === '__construct') {
+                if ($stmt instanceof ClassMethod && $stmt->name === '__construct') {
                     return $stmt;
                 }
             }
             return NodeTraverser::DONT_TRAVERSE_CHILDREN;
         }
 
-        if ($node instanceof Node\Expr\Variable) {
+        if ($node instanceof Variable) {
             $this->vars[] = $node->name;
         }
 

--- a/src/Prototype/src/NodeVisitors/DefineConstructor.php
+++ b/src/Prototype/src/NodeVisitors/DefineConstructor.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -26,14 +28,14 @@ final class DefineConstructor extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if (!$node instanceof Node\Stmt\Class_) {
+        if (!$node instanceof Class_) {
             return null;
         }
 
         $placementID = 0;
         foreach ($node->stmts as $index => $child) {
             $placementID = $index;
-            if ($child instanceof Node\Stmt\ClassMethod) {
+            if ($child instanceof ClassMethod) {
                 if ($child->name->name === '__construct') {
                     $node->setAttribute('constructor', $child);
 
@@ -51,12 +53,12 @@ final class DefineConstructor extends NodeVisitorAbstract
         return $node;
     }
 
-    private function buildConstructor(): Node\Stmt\ClassMethod
+    private function buildConstructor(): ClassMethod
     {
-        $constructor = new Node\Stmt\ClassMethod('__construct');
+        $constructor = new ClassMethod('__construct');
         $constructor->flags = BuilderHelpers::addModifier(
             $constructor->flags,
-            Node\Stmt\Class_::MODIFIER_PUBLIC
+            Class_::MODIFIER_PUBLIC
         );
 
         return $constructor;

--- a/src/Prototype/src/NodeVisitors/LocateProperties.php
+++ b/src/Prototype/src/NodeVisitors/LocateProperties.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
@@ -19,11 +23,9 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class LocateProperties extends NodeVisitorAbstract
 {
-    /** @var array */
-    private $properties = [];
+    private array $properties = [];
 
-    /** @var array */
-    private $requested = [];
+    private array $requested = [];
 
     /**
      * Get names of all virtual properties.
@@ -44,16 +46,16 @@ final class LocateProperties extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if (
-            $node instanceof Node\Expr\PropertyFetch &&
-            $node->var instanceof Node\Expr\Variable &&
+            $node instanceof PropertyFetch &&
+            $node->var instanceof Variable &&
             $node->var->name === 'this'
         ) {
             $this->requested[$node->name->name] = $node->name->name;
         }
 
-        if ($node instanceof Node\Stmt\Property) {
+        if ($node instanceof Property) {
             foreach ($node->props as $prop) {
-                if ($prop instanceof Node\Stmt\PropertyProperty) {
+                if ($prop instanceof PropertyProperty) {
                     $this->properties[$prop->name->name] = $prop->name->name;
                 }
             }

--- a/src/Prototype/src/NodeVisitors/RemoveTrait.php
+++ b/src/Prototype/src/NodeVisitors/RemoveTrait.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -27,12 +29,12 @@ final class RemoveTrait extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if (!$node instanceof Node\Stmt\TraitUse) {
+        if (!$node instanceof TraitUse) {
             return null;
         }
 
         foreach ($node->traits as $index => $use) {
-            if ($use instanceof Node\Name) {
+            if ($use instanceof Name) {
                 $name = $this->trimSlashes(implode('\\', $use->parts));
                 if (
                     in_array($name, [

--- a/src/Prototype/src/NodeVisitors/RemoveUse.php
+++ b/src/Prototype/src/NodeVisitors/RemoveUse.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -26,7 +27,7 @@ final class RemoveUse extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if (!$node instanceof Node\Stmt\Use_) {
+        if (!$node instanceof Use_) {
             return null;
         }
 

--- a/src/Prototype/src/NodeVisitors/UpdateConstructor.php
+++ b/src/Prototype/src/NodeVisitors/UpdateConstructor.php
@@ -11,6 +11,18 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\NodeVisitors;
 
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
+use Spiral\Prototype\Annotation\Parser;
+use Spiral\Prototype\Annotation\Line;
+use Spiral\Prototype\ClassNode\ConstructorParam;
 use PhpParser\Builder\Param;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
@@ -25,8 +37,7 @@ use Spiral\Prototype\Utils;
  */
 final class UpdateConstructor extends NodeVisitorAbstract
 {
-    /** @var ClassNode */
-    private $definition;
+    private ClassNode $definition;
 
     public function __construct(ClassNode $definition)
     {
@@ -38,7 +49,7 @@ final class UpdateConstructor extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if (!$node instanceof Node\Stmt\Class_) {
+        if (!$node instanceof Class_) {
             return null;
         }
 
@@ -58,16 +69,16 @@ final class UpdateConstructor extends NodeVisitorAbstract
     /**
      * Add dependencies to constructor method.
      */
-    private function addDependencies(Node\Stmt\ClassMethod $constructor): void
+    private function addDependencies(ClassMethod $constructor): void
     {
         foreach ($this->definition->dependencies as $dependency) {
             array_unshift($constructor->params, $this->buildConstructorParam($dependency));
             array_unshift(
                 $constructor->stmts,
-                new Node\Stmt\Expression(
-                    new Node\Expr\Assign(
-                        new Node\Expr\PropertyFetch(new Node\Expr\Variable('this'), $dependency->property),
-                        new Node\Expr\Variable($dependency->var)
+                new Expression(
+                    new Assign(
+                        new PropertyFetch(new Variable('this'), $dependency->property),
+                        new Variable($dependency->var)
                     )
                 )
             );
@@ -77,14 +88,14 @@ final class UpdateConstructor extends NodeVisitorAbstract
     private function buildConstructorParam(Dependency $dependency): Node
     {
         $param = new Param($dependency->var);
-        return $param->setType(new Node\Name($this->getPropertyType($dependency)))->getNode();
+        return $param->setType(new Name($this->getPropertyType($dependency)))->getNode();
     }
 
-    private function addParentConstructorCall(Node\Stmt\ClassMethod $constructor): void
+    private function addParentConstructorCall(ClassMethod $constructor): void
     {
         $parentConstructorDependencies = [];
         foreach ($this->definition->constructorParams as $param) {
-            $parentConstructorDependencies[] = new Node\Arg(new Node\Expr\Variable($param->name));
+            $parentConstructorDependencies[] = new Arg(new Variable($param->name));
 
             $cp = new Param($param->name);
             if (!empty($param->type)) {
@@ -93,7 +104,7 @@ final class UpdateConstructor extends NodeVisitorAbstract
                     $type = "?$type";
                 }
 
-                $cp->setType(new Node\Name($type));
+                $cp->setType(new Name($type));
             }
 
             if ($param->byRef) {
@@ -113,9 +124,9 @@ final class UpdateConstructor extends NodeVisitorAbstract
         if ($parentConstructorDependencies) {
             array_unshift(
                 $constructor->stmts,
-                new Node\Stmt\Expression(
-                    new Node\Expr\StaticCall(
-                        new Node\Name('parent'),
+                new Expression(
+                    new StaticCall(
+                        new Name('parent'),
                         '__construct',
                         $parentConstructorDependencies
                     )
@@ -124,7 +135,7 @@ final class UpdateConstructor extends NodeVisitorAbstract
         }
     }
 
-    private function getConstructorAttribute(Node\Stmt\Class_ $node): Node\Stmt\ClassMethod
+    private function getConstructorAttribute(Class_ $node): ClassMethod
     {
         return $node->getAttribute('constructor');
     }
@@ -136,12 +147,12 @@ final class UpdateConstructor extends NodeVisitorAbstract
      */
     private function addComments(Doc $doc = null): Doc
     {
-        $an = new Annotation\Parser($doc ? $doc->getText() : '');
+        $an = new Parser($doc ? $doc->getText() : '');
 
         $params = [];
 
         foreach ($this->definition->dependencies as $dependency) {
-            $params[] = new Annotation\Line(
+            $params[] = new Line(
                 sprintf('%s $%s', $this->getPropertyType($dependency), $dependency->var),
                 'param'
             );
@@ -155,12 +166,12 @@ final class UpdateConstructor extends NodeVisitorAbstract
                         $type = "$type|null";
                     }
 
-                    $params[] = new Annotation\Line(
+                    $params[] = new Line(
                         sprintf($param->isVariadic ? '%s ...$%s' : '%s $%s', $type, $param->name),
                         'param'
                     );
                 } else {
-                    $params[] = new Annotation\Line(
+                    $params[] = new Line(
                         sprintf('$%s', $param->name),
                         'param'
                     );
@@ -206,7 +217,7 @@ final class UpdateConstructor extends NodeVisitorAbstract
         return $dependency->type->getAliasOrShortName();
     }
 
-    private function getParamType(ClassNode\ConstructorParam $param): string
+    private function getParamType(ConstructorParam $param): string
     {
         foreach ($this->definition->getStmts() as $stmt) {
             if ($stmt->name === $param->type->fullName) {

--- a/src/Prototype/src/PropertyExtractor.php
+++ b/src/Prototype/src/PropertyExtractor.php
@@ -21,8 +21,7 @@ use Spiral\Prototype\NodeVisitors\LocateProperties;
  */
 final class PropertyExtractor
 {
-    /** @var Parser */
-    private $parser;
+    private Parser $parser;
 
     /**
      * @param Parser|null $parser

--- a/src/Prototype/src/PrototypeRegistry.php
+++ b/src/Prototype/src/PrototypeRegistry.php
@@ -21,10 +21,9 @@ use Spiral\Core\Exception\Container\ContainerException;
 final class PrototypeRegistry
 {
     /** @var Dependency[] */
-    private $dependencies = [];
+    private array $dependencies = [];
 
-    /** @var \Spiral\Core\Container */
-    private $container;
+    private Container $container;
 
     /**
      * PrototypeRegistry constructor.

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -83,14 +83,14 @@ final class QueueBootloader extends Bootloader
 
     private function registerJobsSerializer(Container $container): void
     {
-        $container->bindSingleton(SerializerInterface::class, static fn() => new DefaultSerializer());
+        $container->bindSingleton(SerializerInterface::class, static fn () => new DefaultSerializer());
     }
 
     private function registerQueue(Container $container): void
     {
         $container->bindSingleton(
             QueueInterface::class,
-            static fn(QueueManager $manager): QueueInterface => $manager->getConnection()
+            static fn (QueueManager $manager): QueueInterface => $manager->getConnection()
         );
     }
 

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -37,8 +37,7 @@ final class QueueBootloader extends Bootloader
         QueueRegistry::class => [self::class, 'initRegistry'],
     ];
 
-    /** @var ConfiguratorInterface */
-    private $config;
+    private ConfiguratorInterface $config;
 
     public function __construct(ConfiguratorInterface $config)
     {
@@ -84,18 +83,14 @@ final class QueueBootloader extends Bootloader
 
     private function registerJobsSerializer(Container $container): void
     {
-        $container->bindSingleton(SerializerInterface::class, static function () {
-            return new DefaultSerializer();
-        });
+        $container->bindSingleton(SerializerInterface::class, static fn() => new DefaultSerializer());
     }
 
     private function registerQueue(Container $container): void
     {
         $container->bindSingleton(
             QueueInterface::class,
-            static function (QueueManager $manager): QueueInterface {
-                return $manager->getConnection();
-            }
+            static fn(QueueManager $manager): QueueInterface => $manager->getConnection()
         );
     }
 

--- a/src/Queue/src/ContainerRegistry.php
+++ b/src/Queue/src/ContainerRegistry.php
@@ -39,7 +39,7 @@ final class ContainerRegistry implements HandlerRegistryInterface
     private function className(string $jobType): string
     {
         $names = explode('.', $jobType);
-        $names = array_map(fn(string $value) => $this->inflector->classify($value), $names);
+        $names = array_map(fn (string $value) => $this->inflector->classify($value), $names);
 
         return implode('\\', $names);
     }

--- a/src/Queue/src/ContainerRegistry.php
+++ b/src/Queue/src/ContainerRegistry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Queue;
 
+use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\Rules\English\InflectorFactory;
 use Psr\Container\ContainerInterface;
 use Spiral\Core\Exception\Container\ContainerException;
@@ -11,10 +12,8 @@ use Spiral\Queue\Exception\JobException;
 
 final class ContainerRegistry implements HandlerRegistryInterface
 {
-    /** @var ContainerInterface  */
-    private $container;
-    /** @var \Doctrine\Inflector\Inflector */
-    private $inflector;
+    private ContainerInterface $container;
+    private Inflector $inflector;
 
     public function __construct(ContainerInterface $container)
     {
@@ -40,9 +39,7 @@ final class ContainerRegistry implements HandlerRegistryInterface
     private function className(string $jobType): string
     {
         $names = explode('.', $jobType);
-        $names = array_map(function (string $value) {
-            return $this->inflector->classify($value);
-        }, $names);
+        $names = array_map(fn(string $value) => $this->inflector->classify($value), $names);
 
         return implode('\\', $names);
     }

--- a/src/Queue/src/DefaultSerializer.php
+++ b/src/Queue/src/DefaultSerializer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Queue;
 
+use function Opis\Closure\serialize;
+use function Opis\Closure\unserialize;
 use Spiral\Queue\Exception\SerializationException;
 
 /**
@@ -17,7 +19,7 @@ final class DefaultSerializer implements SerializerInterface
     public function serialize(array $payload): string
     {
         try {
-            return \Opis\Closure\serialize($payload);
+            return serialize($payload);
         } catch (\Throwable $e) {
             throw new SerializationException($e->getMessage(), (int)$e->getCode(), $e);
         }
@@ -29,7 +31,7 @@ final class DefaultSerializer implements SerializerInterface
     public function deserialize(string $payload): array
     {
         try {
-            return (array)\Opis\Closure\unserialize($payload);
+            return (array)unserialize($payload);
         } catch (\Throwable $e) {
             throw new SerializationException($e->getMessage(), (int)$e->getCode(), $e);
         }

--- a/src/Queue/src/DefaultSerializer.php
+++ b/src/Queue/src/DefaultSerializer.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Queue;
 
+use Spiral\Queue\Exception\SerializationException;
+
 use function Opis\Closure\serialize;
 use function Opis\Closure\unserialize;
-use Spiral\Queue\Exception\SerializationException;
 
 /**
  * @internal

--- a/src/Queue/src/Driver/SyncDriver.php
+++ b/src/Queue/src/Driver/SyncDriver.php
@@ -18,10 +18,8 @@ final class SyncDriver implements QueueInterface
 {
     use QueueTrait;
 
-    /** @var HandlerRegistryInterface */
-    private $registry;
-    /** @var FailedJobHandlerInterface */
-    private $failedJobHandler;
+    private HandlerRegistryInterface $registry;
+    private FailedJobHandlerInterface $failedJobHandler;
 
     public function __construct(
         HandlerRegistryInterface $registry,

--- a/src/Queue/src/Failed/LogFailedJobHandler.php
+++ b/src/Queue/src/Failed/LogFailedJobHandler.php
@@ -8,8 +8,7 @@ use Spiral\Snapshots\SnapshotterInterface;
 
 final class LogFailedJobHandler implements FailedJobHandlerInterface
 {
-    /** @var SnapshotterInterface */
-    private $snapshotter;
+    private SnapshotterInterface $snapshotter;
 
     public function __construct(SnapshotterInterface $snapshotter)
     {

--- a/src/Queue/src/Job/CallableJob.php
+++ b/src/Queue/src/Job/CallableJob.php
@@ -10,8 +10,7 @@ use Spiral\Queue\HandlerInterface;
 
 final class CallableJob implements HandlerInterface
 {
-    /** @var InvokerInterface */
-    private $invoker;
+    private InvokerInterface $invoker;
 
     public function __construct(InvokerInterface $invoker)
     {

--- a/src/Queue/src/Job/ObjectJob.php
+++ b/src/Queue/src/Job/ObjectJob.php
@@ -10,8 +10,7 @@ use Spiral\Queue\HandlerInterface;
 
 final class ObjectJob implements HandlerInterface
 {
-    /** @var InvokerInterface */
-    private $invoker;
+    private InvokerInterface $invoker;
 
     public function __construct(InvokerInterface $invoker)
     {

--- a/src/Queue/src/Options.php
+++ b/src/Queue/src/Options.php
@@ -6,11 +6,9 @@ namespace Spiral\Queue;
 
 final class Options implements OptionsInterface, \JsonSerializable
 {
-    /** @var int|null */
-    private $delay;
+    private ?int $delay = null;
 
-    /** @var string|null */
-    private $queue;
+    private ?string $queue = null;
 
     public function withQueue(?string $queue): self
     {

--- a/src/Queue/src/QueueManager.php
+++ b/src/Queue/src/QueueManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Queue;
 
+use Spiral\Queue\Exception\NotSupportedDriverException;
 use Spiral\Core\Exception\Container\ContainerException;
 use Spiral\Core\FactoryInterface;
 use Spiral\Queue\Config\QueueConfig;
@@ -11,11 +12,9 @@ use Spiral\Queue\Config\QueueConfig;
 final class QueueManager implements QueueConnectionProviderInterface
 {
     /** @var QueueInterface[] */
-    private $pipelines = [];
-    /** @var QueueConfig */
-    private $config;
-    /** @var FactoryInterface */
-    private $factory;
+    private array $pipelines = [];
+    private QueueConfig $config;
+    private FactoryInterface $factory;
 
     public function __construct(QueueConfig $config, FactoryInterface $factory)
     {
@@ -47,7 +46,7 @@ final class QueueManager implements QueueConnectionProviderInterface
         try {
             return $this->factory->make($config['driver'], $config);
         } catch (ContainerException $e) {
-            throw new Exception\NotSupportedDriverException(
+            throw new NotSupportedDriverException(
                 \sprintf(
                     'Driver `%s` is not supported. Connection `%s` cannot be created. Reason: `%s`',
                     $config['driver'],

--- a/src/Queue/src/QueueRegistry.php
+++ b/src/Queue/src/QueueRegistry.php
@@ -9,11 +9,9 @@ use Psr\Container\ContainerInterface;
 final class QueueRegistry implements HandlerRegistryInterface
 {
     /** @var array<string, class-string>  */
-    private $handlers = [];
-    /** @var ContainerInterface */
-    private $container;
-    /** @var HandlerRegistryInterface  */
-    private $fallbackHandlers;
+    private array $handlers = [];
+    private ContainerInterface $container;
+    private HandlerRegistryInterface $fallbackHandlers;
 
     public function __construct(
         ContainerInterface $container,

--- a/src/Reactor/src/Aggregator.php
+++ b/src/Reactor/src/Aggregator.php
@@ -28,15 +28,12 @@ class Aggregator extends AbstractDeclaration implements
     Countable,
     ReplaceableInterface
 {
-    /**
-     * @var array
-     */
-    private $allowed;
+    private array $allowed;
 
     /**
      * @var DeclarationInterface[]
      */
-    private $elements;
+    private array $elements;
 
     public function __construct(array $allowed, array $elements = [])
     {

--- a/src/Reactor/src/ClassDeclaration.php
+++ b/src/Reactor/src/ClassDeclaration.php
@@ -30,23 +30,17 @@ class ClassDeclaration extends AbstractDeclaration implements ReplaceableInterfa
     use NamedTrait;
     use CommentTrait;
 
-    /** @var string */
-    private $extends = '';
+    private string $extends = '';
 
-    /** @var array */
-    private $interfaces = [];
+    private array $interfaces = [];
 
-    /** @var array */
-    private $traits = [];
+    private array $traits = [];
 
-    /** @var Constants */
-    private $constants;
+    private Constants $constants;
 
-    /** @var Properties */
-    private $properties;
+    private Properties $properties;
 
-    /** @var Methods */
-    private $methods;
+    private Methods $methods;
 
     /**
      *

--- a/src/Reactor/src/FileDeclaration.php
+++ b/src/Reactor/src/FileDeclaration.php
@@ -27,18 +27,12 @@ class FileDeclaration extends AbstractDeclaration implements ReplaceableInterfac
 
     /**
      * File namespace.
-     *
-     * @var string
      */
-    private $namespace;
+    private string $namespace;
 
-    /** @var Directives|null */
-    private $directives;
+    private ?Directives $directives = null;
 
-    /**
-     * @var Aggregator
-     */
-    private $elements;
+    private Aggregator $elements;
 
     public function __construct(string $namespace = '', string $comment = '')
     {
@@ -131,9 +125,8 @@ class FileDeclaration extends AbstractDeclaration implements ReplaceableInterfac
         }
 
         $result .= $this->elements->render($indentLevel);
-        $result .= "\n";
 
-        return $result;
+        return $result . "\n";
     }
 
     /**

--- a/src/Reactor/src/NamespaceDeclaration.php
+++ b/src/Reactor/src/NamespaceDeclaration.php
@@ -26,10 +26,7 @@ class NamespaceDeclaration extends AbstractDeclaration implements ReplaceableInt
     use UsesTrait;
     use CommentTrait;
 
-    /**
-     * @var Aggregator
-     */
-    private $elements;
+    private Aggregator $elements;
 
     public function __construct(string $name = '', string $comment = '')
     {

--- a/src/Reactor/src/Partial/Directives.php
+++ b/src/Reactor/src/Partial/Directives.php
@@ -16,7 +16,7 @@ use Spiral\Reactor\DeclarationInterface;
 class Directives implements DeclarationInterface
 {
     /** @var string[] */
-    private $directives;
+    private array $directives;
 
     public function __construct(string ...$directives)
     {

--- a/src/Reactor/src/Partial/Method.php
+++ b/src/Reactor/src/Partial/Method.php
@@ -28,17 +28,13 @@ class Method extends AbstractDeclaration implements ReplaceableInterface, NamedI
     use CommentTrait;
     use AccessTrait;
 
-    /** @var bool */
-    private $static = false;
+    private bool $static = false;
 
-    /** @var string */
-    private $return;
+    private ?string $return = null;
 
-    /** @var Parameters */
-    private $parameters;
+    private Parameters $parameters;
 
-    /** @var Source */
-    private $source;
+    private ?Source $source = null;
 
     /**
      * @param string|array $source

--- a/src/Reactor/src/Partial/Parameter.php
+++ b/src/Reactor/src/Partial/Parameter.php
@@ -26,17 +26,14 @@ class Parameter extends AbstractDeclaration implements NamedInterface
     use NamedTrait;
     use SerializerTrait;
 
-    /** @var string */
-    private $type = '';
+    private string $type = '';
 
-    /** @var bool */
-    private $isOptional = false;
+    private bool $isOptional = false;
 
     /** @var mixed */
     private $defaultValue;
 
-    /** @var bool */
-    private $pdb = false;
+    private bool $pdb = false;
 
     public function __construct(string $name)
     {

--- a/src/Reactor/src/Partial/Property.php
+++ b/src/Reactor/src/Partial/Property.php
@@ -30,10 +30,7 @@ class Property extends AbstractDeclaration implements ReplaceableInterface, Name
     use SerializerTrait;
     use AccessTrait;
 
-    /**
-     * @var bool
-     */
-    private $hasDefault = false;
+    private bool $hasDefault = false;
 
     /**
      * @var mixed

--- a/src/Reactor/src/Partial/Source.php
+++ b/src/Reactor/src/Partial/Source.php
@@ -19,10 +19,7 @@ use Spiral\Reactor\Exception\MultilineException;
  */
 class Source extends AbstractDeclaration
 {
-    /**
-     * @var array
-     */
-    private $lines;
+    private array $lines;
 
     public function __construct(array $lines = [])
     {
@@ -191,9 +188,7 @@ class Source extends AbstractDeclaration
         $lines = explode("\n", self::normalizeEndings($string, false));
 
         //Pre-processing
-        return array_filter(array_map([$this, 'prepareLine'], $lines), static function ($line): bool {
-            return $line !== null;
-        });
+        return array_filter(array_map([$this, 'prepareLine'], $lines), static fn($line): bool => $line !== null);
     }
 
     /**

--- a/src/Reactor/src/Partial/Source.php
+++ b/src/Reactor/src/Partial/Source.php
@@ -188,7 +188,7 @@ class Source extends AbstractDeclaration
         $lines = explode("\n", self::normalizeEndings($string, false));
 
         //Pre-processing
-        return array_filter(array_map([$this, 'prepareLine'], $lines), static fn($line): bool => $line !== null);
+        return array_filter(array_map([$this, 'prepareLine'], $lines), static fn ($line): bool => $line !== null);
     }
 
     /**

--- a/src/Router/src/Autofill.php
+++ b/src/Router/src/Autofill.php
@@ -13,10 +13,7 @@ namespace Spiral\Router;
 
 final class Autofill
 {
-    /**
-     * @var string
-     */
-    private $value;
+    private string $value;
 
     public function __construct(string $value)
     {

--- a/src/Router/src/CoreHandler.php
+++ b/src/Router/src/CoreHandler.php
@@ -104,7 +104,7 @@ final class CoreHandler implements RequestHandlerInterface
                     Request::class  => $request,
                     Response::class => $response,
                 ],
-                fn() => $this->core->callAction(
+                fn () => $this->core->callAction(
                     $this->controller,
                     $this->getAction($request),
                     $this->parameters

--- a/src/Router/src/CoreHandler.php
+++ b/src/Router/src/CoreHandler.php
@@ -31,26 +31,19 @@ final class CoreHandler implements RequestHandlerInterface
 {
     use JsonTrait;
 
-    /** @var CoreInterface */
-    private $core;
+    private CoreInterface $core;
 
-    /** @var ScopeInterface */
-    private $scope;
+    private ScopeInterface $scope;
 
-    /** @var string|null */
-    private $controller;
+    private ?string $controller = null;
 
-    /** @var string|null */
-    private $action;
+    private ?string $action = null;
 
-    /** @var bool */
-    private $verbActions;
+    private ?bool $verbActions = null;
 
-    /** @var array|null */
-    private $parameters;
+    private ?array $parameters = null;
 
-    /** @var ResponseFactoryInterface */
-    private $responseFactory;
+    private ResponseFactoryInterface $responseFactory;
 
     public function __construct(
         CoreInterface $core,
@@ -111,13 +104,11 @@ final class CoreHandler implements RequestHandlerInterface
                     Request::class  => $request,
                     Response::class => $response,
                 ],
-                function () use ($request) {
-                    return $this->core->callAction(
-                        $this->controller,
-                        $this->getAction($request),
-                        $this->parameters
-                    );
-                }
+                fn() => $this->core->callAction(
+                    $this->controller,
+                    $this->getAction($request),
+                    $this->parameters
+                )
             );
         } catch (ControllerException $e) {
             ob_get_clean();

--- a/src/Router/src/Exception/RouteNotFoundException.php
+++ b/src/Router/src/Exception/RouteNotFoundException.php
@@ -15,10 +15,7 @@ use Psr\Http\Message\UriInterface;
 
 class RouteNotFoundException extends UndefinedRouteException
 {
-    /**
-     * @var UriInterface
-     */
-    private $uri;
+    private UriInterface $uri;
 
     /**
      * @param \Throwable|null $previous

--- a/src/Router/src/GroupRegistry.php
+++ b/src/Router/src/GroupRegistry.php
@@ -19,11 +19,10 @@ use Spiral\Core\FactoryInterface;
  */
 final class GroupRegistry implements \IteratorAggregate
 {
-    /** @var ContainerInterface */
-    private $factory;
+    private ContainerInterface $factory;
 
     /** @var RouteGroup[] */
-    private $groups = [];
+    private array $groups = [];
 
     public function __construct(FactoryInterface $factory)
     {

--- a/src/Router/src/Route.php
+++ b/src/Router/src/Route.php
@@ -49,8 +49,7 @@ final class Route extends AbstractRoute implements ContainerizedInterface
     /** @var string|callable|RequestHandlerInterface|TargetInterface */
     private $target;
 
-    /** @var RequestHandlerInterface */
-    private $requestHandler;
+    private ?RequestHandlerInterface $requestHandler = null;
 
     /**
      * @param string                                                  $pattern  Uri pattern.

--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -23,23 +23,17 @@ use Spiral\Router\Target\Action;
  */
 final class RouteGroup
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
-    /** @var string */
-    private $prefix = '';
+    private string $prefix = '';
 
-    /** @var Pipeline */
-    private $pipeline;
+    private Pipeline $pipeline;
 
-    /** @var Router */
-    private $router;
+    private Router $router;
 
-    /** @var array */
-    private $routes = [];
+    private array $routes = [];
 
-    /** @var CoreInterface */
-    private $core;
+    private ?CoreInterface $core = null;
 
     public function __construct(
         ContainerInterface $container,

--- a/src/Router/src/Router.php
+++ b/src/Router/src/Router.php
@@ -34,20 +34,16 @@ final class Router implements RouterInterface
     // attribute to store active route in request
     public const ROUTE_MATCHES = 'matches';
 
-    /** @var string */
-    private $basePath = '/';
+    private string $basePath = '/';
 
     /** @var RouteInterface[] */
-    private $routes = [];
+    private array $routes = [];
 
-    /** @var RouteInterface */
-    private $default;
+    private ?RouteInterface $default = null;
 
-    /** @var UriHandler */
-    private $uriHandler;
+    private UriHandler $uriHandler;
 
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(string $basePath, UriHandler $uriHandler, ContainerInterface $container)
     {

--- a/src/Router/src/Target/AbstractTarget.php
+++ b/src/Router/src/Target/AbstractTarget.php
@@ -26,23 +26,17 @@ abstract class AbstractTarget implements TargetInterface
     // Automatically prepend HTTP verb to all action names.
     public const RESTFUL = 1;
 
-    /** @var array */
-    private $defaults = [];
+    private array $defaults = [];
 
-    /** @var array */
-    private $constrains = [];
+    private array $constrains = [];
 
-    /** @var CoreInterface */
-    private $core;
+    private ?CoreInterface $core = null;
 
-    /** @var CoreHandler */
-    private $handler;
+    private ?CoreHandler $handler = null;
 
-    /** @var bool */
-    private $verbActions;
+    private bool $verbActions;
 
-    /** @var string */
-    private $defaultAction;
+    private string $defaultAction;
 
     public function __construct(array $defaults, array $constrains, int $options = 0, string $defaultAction = 'index')
     {

--- a/src/Router/src/Target/Action.php
+++ b/src/Router/src/Target/Action.php
@@ -24,8 +24,7 @@ use Spiral\Router\Exception\InvalidArgumentException;
  */
 final class Action extends AbstractTarget
 {
-    /** @var string */
-    private $controller;
+    private string $controller;
 
     /** @var array|string */
     private $action;

--- a/src/Router/src/Target/Controller.php
+++ b/src/Router/src/Target/Controller.php
@@ -18,8 +18,7 @@ namespace Spiral\Router\Target;
  */
 final class Controller extends AbstractTarget
 {
-    /** @var string */
-    private $controller;
+    private string $controller;
 
     public function __construct(string $controller, int $options = 0, string $defaultAction = 'index')
     {

--- a/src/Router/src/Target/Group.php
+++ b/src/Router/src/Target/Group.php
@@ -18,8 +18,7 @@ namespace Spiral\Router\Target;
  */
 final class Group extends AbstractTarget
 {
-    /** @var array */
-    private $controllers;
+    private array $controllers;
 
     public function __construct(array $controllers, int $options = 0, string $defaultAction = 'index')
     {

--- a/src/Router/src/Target/Namespaced.php
+++ b/src/Router/src/Target/Namespaced.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Router\Target;
 
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\Rules\English\InflectorFactory;
 use Spiral\Router\Exception\TargetException;
 
 /**
@@ -20,14 +22,11 @@ use Spiral\Router\Exception\TargetException;
  */
 final class Namespaced extends AbstractTarget
 {
-    /** @var string */
-    private $namespace;
+    private string $namespace;
 
-    /** @var string */
-    private $postfix;
+    private string $postfix;
 
-    /** @var \Doctrine\Inflector\Inflector */
-    private $inflector;
+    private Inflector $inflector;
 
     public function __construct(
         string $namespace,
@@ -43,7 +42,7 @@ final class Namespaced extends AbstractTarget
             $options
         );
 
-        $this->inflector = (new \Doctrine\Inflector\Rules\English\InflectorFactory())->build();
+        $this->inflector = (new InflectorFactory())->build();
     }
 
     /**

--- a/src/Router/src/TargetInterface.php
+++ b/src/Router/src/TargetInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Router;
 
+use Spiral\Router\Exception\TargetException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
 
@@ -37,7 +38,7 @@ interface TargetInterface
      * Generates target handler.
      *
      *
-     * @throws \Spiral\Router\Exception\TargetException
+     * @throws TargetException
      */
     public function getHandler(ContainerInterface $container, array $matches): Handler;
 }

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -41,35 +41,26 @@ final class UriHandler
         '//'  => '/',
     ];
 
-    /** @var UriFactoryInterface */
-    private $uriFactory;
+    private UriFactoryInterface $uriFactory;
 
-    /** @var string */
-    private $pattern;
+    private ?string $pattern = null;
 
     /** @var SlugifyInterface @internal */
-    private $slugify;
+    private SlugifyInterface $slugify;
 
-    /** @var array */
-    private $constrains = [];
+    private array $constrains = [];
 
-    /** @var array */
-    private $defaults = [];
+    private array $defaults = [];
 
-    /** @var bool */
-    private $matchHost = false;
+    private bool $matchHost = false;
 
-    /** @var string */
-    private $prefix = '';
+    private string $prefix = '';
 
-    /** @var string|null */
-    private $compiled;
+    private ?string $compiled = null;
 
-    /** @var string|null */
-    private $template;
+    private ?string $template = null;
 
-    /** @var array */
-    private $options = [];
+    private array $options = [];
 
     /**
      * @param SlugifyInterface|null $slugify

--- a/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php
+++ b/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php
@@ -11,6 +11,26 @@ declare(strict_types=1);
 
 namespace Spiral\Scaffolder\Bootloader;
 
+use Spiral\Scaffolder\Command\Database\EntityCommand;
+use Spiral\Scaffolder\Command\Database\RepositoryCommand;
+use Spiral\Scaffolder\Command\BootloaderCommand;
+use Spiral\Scaffolder\Command\CommandCommand;
+use Spiral\Scaffolder\Command\ConfigCommand;
+use Spiral\Scaffolder\Command\ControllerCommand;
+use Spiral\Scaffolder\Command\FilterCommand;
+use Spiral\Scaffolder\Command\JobHandlerCommand;
+use Spiral\Scaffolder\Command\MiddlewareCommand;
+use Spiral\Scaffolder\Command\MigrationCommand;
+use Spiral\Scaffolder\Declaration\BootloaderDeclaration;
+use Spiral\Scaffolder\Declaration\ConfigDeclaration;
+use Spiral\Scaffolder\Declaration\ControllerDeclaration;
+use Spiral\Scaffolder\Declaration\MiddlewareDeclaration;
+use Spiral\Scaffolder\Declaration\CommandDeclaration;
+use Spiral\Scaffolder\Declaration\JobHandlerDeclaration;
+use Spiral\Scaffolder\Declaration\MigrationDeclaration;
+use Spiral\Scaffolder\Declaration\FilterDeclaration;
+use Spiral\Scaffolder\Declaration\Database\Entity\AnnotatedDeclaration;
+use Spiral\Scaffolder\Declaration\Database\RepositoryDeclaration;
 use Cocur\Slugify\Slugify;
 use Cocur\Slugify\SlugifyInterface;
 use ReflectionClass;
@@ -30,11 +50,9 @@ class ScaffolderBootloader extends Bootloader
         SlugifyInterface::class => Slugify::class,
     ];
 
-    /** @var ConfiguratorInterface */
-    private $config;
+    private ConfiguratorInterface $config;
 
-    /** @var KernelInterface */
-    private $kernel;
+    private KernelInterface $kernel;
 
     /**
      * ScaffolderBootloader constructor.
@@ -47,16 +65,16 @@ class ScaffolderBootloader extends Bootloader
 
     public function boot(ConsoleBootloader $console): void
     {
-        $console->addCommand(Command\Database\EntityCommand::class, true);
-        $console->addCommand(Command\Database\RepositoryCommand::class, true);
-        $console->addCommand(Command\BootloaderCommand::class);
-        $console->addCommand(Command\CommandCommand::class);
-        $console->addCommand(Command\ConfigCommand::class);
-        $console->addCommand(Command\ControllerCommand::class);
-        $console->addCommand(Command\FilterCommand::class);
-        $console->addCommand(Command\JobHandlerCommand::class);
-        $console->addCommand(Command\MiddlewareCommand::class);
-        $console->addCommand(Command\MigrationCommand::class, true);
+        $console->addCommand(EntityCommand::class, true);
+        $console->addCommand(RepositoryCommand::class, true);
+        $console->addCommand(BootloaderCommand::class);
+        $console->addCommand(CommandCommand::class);
+        $console->addCommand(ConfigCommand::class);
+        $console->addCommand(ControllerCommand::class);
+        $console->addCommand(FilterCommand::class);
+        $console->addCommand(JobHandlerCommand::class);
+        $console->addCommand(MiddlewareCommand::class);
+        $console->addCommand(MigrationCommand::class, true);
 
         try {
             $defaultNamespace = (new ReflectionClass($this->kernel))->getNamespaceName();
@@ -96,12 +114,12 @@ class ScaffolderBootloader extends Bootloader
                 'bootloader' => [
                     'namespace' => 'Bootloader',
                     'postfix'   => 'Bootloader',
-                    'class'     => Declaration\BootloaderDeclaration::class,
+                    'class'     => BootloaderDeclaration::class,
                 ],
                 'config'     => [
                     'namespace' => 'Config',
                     'postfix'   => 'Config',
-                    'class'     => Declaration\ConfigDeclaration::class,
+                    'class'     => ConfigDeclaration::class,
                     'options'   => [
                         'directory' => directory('config'),
                     ],
@@ -109,32 +127,32 @@ class ScaffolderBootloader extends Bootloader
                 'controller' => [
                     'namespace' => 'Controller',
                     'postfix'   => 'Controller',
-                    'class'     => Declaration\ControllerDeclaration::class,
+                    'class'     => ControllerDeclaration::class,
                 ],
                 'middleware' => [
                     'namespace' => 'Middleware',
                     'postfix'   => '',
-                    'class'     => Declaration\MiddlewareDeclaration::class,
+                    'class'     => MiddlewareDeclaration::class,
                 ],
                 'command'    => [
                     'namespace' => 'Command',
                     'postfix'   => 'Command',
-                    'class'     => Declaration\CommandDeclaration::class,
+                    'class'     => CommandDeclaration::class,
                 ],
                 'jobHandler' => [
                     'namespace' => 'Job',
                     'postfix'   => 'Job',
-                    'class'     => Declaration\JobHandlerDeclaration::class,
+                    'class'     => JobHandlerDeclaration::class,
                 ],
                 'migration'  => [
                     'namespace' => '',
                     'postfix'   => 'Migration',
-                    'class'     => Declaration\MigrationDeclaration::class,
+                    'class'     => MigrationDeclaration::class,
                 ],
                 'filter'     => [
                     'namespace' => 'Request',
                     'postfix'   => 'Request',
-                    'class'     => Declaration\FilterDeclaration::class,
+                    'class'     => FilterDeclaration::class,
                     'options'   => [
                         //Set of default filters and validate rules for various types
                         'mapping' => [
@@ -198,13 +216,13 @@ class ScaffolderBootloader extends Bootloader
                     'namespace' => 'Database',
                     'postfix'   => '',
                     'options'   => [
-                        'annotated' => Declaration\Database\Entity\AnnotatedDeclaration::class,
+                        'annotated' => AnnotatedDeclaration::class,
                     ],
                 ],
                 'repository' => [
                     'namespace' => 'Repository',
                     'postfix'   => 'Repository',
-                    'class'     => Declaration\Database\RepositoryDeclaration::class,
+                    'class'     => RepositoryDeclaration::class,
                 ],
             ],
         ]);

--- a/src/Scaffolder/src/Command/AbstractCommand.php
+++ b/src/Scaffolder/src/Command/AbstractCommand.php
@@ -37,8 +37,7 @@ abstract class AbstractCommand extends Command
      */
     protected $files;
 
-    /** @var FactoryInterface */
-    private $factory;
+    private FactoryInterface $factory;
 
     public function __construct(
         ScaffolderConfig $config,
@@ -88,7 +87,7 @@ abstract class AbstractCommand extends Command
      */
     protected function writeDeclaration(ClassDeclaration $declaration, string $type = null): void
     {
-        $type = $type ?? static::ELEMENT;
+        $type ??= static::ELEMENT;
 
         $filename = $this->config->classFilename($type, (string)$this->argument('name'));
         $filename = $this->files->normalizePath($filename);

--- a/src/Scaffolder/src/Command/Database/EntityCommand.php
+++ b/src/Scaffolder/src/Command/Database/EntityCommand.php
@@ -126,8 +126,7 @@ class EntityCommand extends AbstractCommand
                 throw new ScaffolderException("Field definition must in 'name:type' or 'name:type' form");
             }
 
-            $parts = explode(':', $field);
-            [$name, $type] = $parts;
+            [$name, $type] = explode(':', $field);
 
             $declaration->addField($name, $accessibility, $type);
         }

--- a/src/Scaffolder/src/Declaration/ConfigDeclaration.php
+++ b/src/Scaffolder/src/Declaration/ConfigDeclaration.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Spiral\Scaffolder\Declaration;
 
+use Spiral\Scaffolder\Declaration\ConfigDeclaration\TypeAnnotations;
+use Spiral\Scaffolder\Declaration\ConfigDeclaration\TypeHints;
+use Spiral\Scaffolder\Declaration\ConfigDeclaration\Defaults;
 use Cocur\Slugify\SlugifyInterface;
 use Doctrine\Inflector\Rules\English\InflectorFactory;
 use Spiral\Core\InjectableConfig;
@@ -28,37 +31,29 @@ use function Spiral\Scaffolder\isAssociativeArray;
 
 class ConfigDeclaration extends ClassDeclaration implements DependedInterface
 {
-    /** @var ScaffolderConfig */
-    private $config;
+    private ScaffolderConfig $config;
 
-    /** @var FilesInterface */
-    private $files;
+    private FilesInterface $files;
 
-    /** @var SlugifyInterface */
-    private $slugify;
+    private SlugifyInterface $slugify;
 
-    /** @var ConfigDeclaration\TypeAnnotations */
-    private $typeAnnotations;
+    private TypeAnnotations $typeAnnotations;
 
-    /** @var ConfigDeclaration\TypeHints */
-    private $typeHints;
+    private TypeHints $typeHints;
 
-    /** @var ConfigDeclaration\Defaults */
-    private $defaultValues;
+    private Defaults $defaultValues;
 
-    /** @var string */
-    private $configName;
+    private string $configName;
 
-    /** @var string */
-    private $directory;
+    private string $directory;
 
     public function __construct(
         ScaffolderConfig $config,
         FilesInterface $files,
         SlugifyInterface $slugify,
-        ConfigDeclaration\TypeAnnotations $typeAnnotations,
-        ConfigDeclaration\TypeHints $typeHints,
-        ConfigDeclaration\Defaults $defaultValues,
+        TypeAnnotations $typeAnnotations,
+        TypeHints $typeHints,
+        Defaults $defaultValues,
         string $configName,
         string $name,
         string $comment = '',

--- a/src/Scaffolder/src/Declaration/ControllerDeclaration.php
+++ b/src/Scaffolder/src/Declaration/ControllerDeclaration.php
@@ -22,8 +22,7 @@ use Spiral\Reactor\Partial\Method;
  */
 class ControllerDeclaration extends ClassDeclaration implements DependedInterface
 {
-    /** @var bool */
-    private $withPrototype = false;
+    private bool $withPrototype = false;
 
     public function __construct(string $name, string $comment = '')
     {

--- a/src/Scaffolder/src/Declaration/FilterDeclaration.php
+++ b/src/Scaffolder/src/Declaration/FilterDeclaration.php
@@ -23,8 +23,7 @@ class FilterDeclaration extends ClassDeclaration implements DependedInterface
      */
     private const DEFAULT_SOURCE = 'data';
 
-    /** @var array */
-    private $mapping;
+    private array $mapping;
 
     public function __construct(string $name, string $comment = '', array $mapping = [])
     {
@@ -61,7 +60,7 @@ class FilterDeclaration extends ClassDeclaration implements DependedInterface
         $definition = $this->mapping[$type];
 
         //Source can depend on type
-        $source = $source ?? $definition['source'];
+        $source ??= $definition['source'];
         $schema[$field] = $source . ':' . ($origin ?: $field);
 
         if (!empty($definition['validates'])) {

--- a/src/Scaffolder/src/helpers.php
+++ b/src/Scaffolder/src/helpers.php
@@ -60,7 +60,7 @@ if (!function_exists('defineArrayType')) {
      */
     function defineArrayType(array $array, string $failureType = null): ?string
     {
-        $types = array_map(static fn($value): string => gettype($value), $array);
+        $types = array_map(static fn ($value): string => gettype($value), $array);
 
         $types = array_unique($types);
 

--- a/src/Scaffolder/src/helpers.php
+++ b/src/Scaffolder/src/helpers.php
@@ -60,9 +60,7 @@ if (!function_exists('defineArrayType')) {
      */
     function defineArrayType(array $array, string $failureType = null): ?string
     {
-        $types = array_map(static function ($value): string {
-            return gettype($value);
-        }, $array);
+        $types = array_map(static fn($value): string => gettype($value), $array);
 
         $types = array_unique($types);
 

--- a/src/Security/src/Actor/Actor.php
+++ b/src/Security/src/Actor/Actor.php
@@ -18,8 +18,7 @@ use Spiral\Security\ActorInterface;
  */
 class Actor implements ActorInterface
 {
-    /** @var array */
-    private $roles = [];
+    private array $roles = [];
 
     public function __construct(array $roles)
     {

--- a/src/Security/src/Guard.php
+++ b/src/Security/src/Guard.php
@@ -18,14 +18,11 @@ use Spiral\Security\Exception\GuardException;
  */
 final class Guard implements GuardInterface
 {
-    /** @var PermissionsInterface */
-    private $permissions;
+    private PermissionsInterface $permissions;
 
-    /** @var ActorInterface|null */
-    private $actor;
+    private ?ActorInterface $actor;
 
-    /** @var array */
-    private $roles = [];
+    private array $roles = [];
 
     /**
      * @param array                $roles Session specific roles.

--- a/src/Security/src/PermissionManager.php
+++ b/src/Security/src/PermissionManager.php
@@ -32,13 +32,10 @@ final class PermissionManager implements PermissionsInterface, SingletonInterfac
 {
     /**
      * Roles associated with their permissions.
-     *
-     * @var array
      */
-    private $permissions = [];
+    private array $permissions = [];
 
-    /** @var Matcher */
-    private $matcher;
+    private Matcher $matcher;
 
     /**@var RulesInterface */
     private $rules;

--- a/src/Security/src/Rule/CompositeRule.php
+++ b/src/Security/src/Rule/CompositeRule.php
@@ -37,8 +37,7 @@ abstract class CompositeRule implements RuleInterface
     /** List of rules to be composited. */
     protected const RULES = [];
 
-    /** @var RulesInterface */
-    private $repository;
+    private RulesInterface $repository;
 
     public function __construct(RulesInterface $repository)
     {

--- a/src/Security/src/RuleManager.php
+++ b/src/Security/src/RuleManager.php
@@ -21,11 +21,9 @@ use Spiral\Security\Rule\CallableRule;
  */
 final class RuleManager implements RulesInterface, SingletonInterface
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
-    /** @var array */
-    private $rules = [];
+    private array $rules = [];
 
     public function __construct(ContainerInterface $container)
     {

--- a/src/Security/src/Traits/GuardedTrait.php
+++ b/src/Security/src/Traits/GuardedTrait.php
@@ -53,7 +53,7 @@ trait GuardedTrait
     {
         if (defined('static::GUARD_NAMESPACE')) {
             // Yay! Isolation
-            $permission = constant(get_called_class() . '::' . 'GUARD_NAMESPACE') . '.' . $permission;
+            $permission = constant(static::class . '::' . 'GUARD_NAMESPACE') . '.' . $permission;
         }
 
         return $permission;

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -90,7 +90,7 @@ class MailerBootloader extends Bootloader
         } else {
             $container->bindSingleton(
                 MailerInterface::class,
-                static fn(MailerConfig $config, QueueConnectionProviderInterface $provider) => new MailQueue(
+                static fn (MailerConfig $config, QueueConnectionProviderInterface $provider) => new MailQueue(
                     $config,
                     $provider->getConnection($config->getQueueConnection())
                 )

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\SendIt\Bootloader;
 
+use Spiral\SendIt\Jobs\MailJobAdapter;
+use Spiral\SendIt\MailJob;
 use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\EnvironmentInterface;
@@ -45,8 +47,7 @@ class MailerBootloader extends Bootloader
         SymfonyMailer::class => [self::class, 'mailer'],
     ];
 
-    /** @var ConfiguratorInterface */
-    private $config;
+    private ConfiguratorInterface $config;
 
     public function __construct(ConfiguratorInterface $config)
     {
@@ -71,7 +72,7 @@ class MailerBootloader extends Bootloader
         if ($container->has(JobRegistry::class)) {
             // Will be removed since v3.0
             $registry = $container->get(JobRegistry::class);
-            $registry->setHandler(MailQueue::JOB_NAME, \Spiral\SendIt\Jobs\MailJobAdapter::class);
+            $registry->setHandler(MailQueue::JOB_NAME, MailJobAdapter::class);
             $registry->setSerializer(MailQueue::JOB_NAME, JsonJobSerializer::class);
 
             $container->bindSingleton(
@@ -89,18 +90,16 @@ class MailerBootloader extends Bootloader
         } else {
             $container->bindSingleton(
                 MailerInterface::class,
-                static function (MailerConfig $config, QueueConnectionProviderInterface $provider) {
-                    return new MailQueue(
-                        $config,
-                        $provider->getConnection($config->getQueueConnection())
-                    );
-                }
+                static fn(MailerConfig $config, QueueConnectionProviderInterface $provider) => new MailQueue(
+                    $config,
+                    $provider->getConnection($config->getQueueConnection())
+                )
             );
         }
 
         if ($container->has(HandlerRegistryInterface::class)) {
             $registry = $container->get(HandlerRegistryInterface::class);
-            $registry->setHandler(MailQueue::JOB_NAME, \Spiral\SendIt\MailJob::class);
+            $registry->setHandler(MailQueue::JOB_NAME, MailJob::class);
         }
     }
 

--- a/src/SendIt/src/JsonJobSerializer.php
+++ b/src/SendIt/src/JsonJobSerializer.php
@@ -10,6 +10,6 @@ final class JsonJobSerializer implements SerializerInterface
 {
     public function serialize(string $jobType, array $payload): string
     {
-        return json_encode($payload);
+        return json_encode($payload, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/SendIt/src/MailJob.php
+++ b/src/SendIt/src/MailJob.php
@@ -18,14 +18,11 @@ final class MailJob implements HandlerInterface, SingletonInterface
 {
     use LoggerTrait;
 
-    /** @var MailerConfig */
-    private $config;
+    private MailerConfig $config;
 
-    /** @var SymfonyMailer */
-    private $mailer;
+    private SymfonyMailer $mailer;
 
-    /**  @var RendererInterface */
-    private $renderer;
+    private RendererInterface $renderer;
 
     public function __construct(MailerConfig $config, SymfonyMailer $mailer, RendererInterface $renderer)
     {
@@ -43,7 +40,7 @@ final class MailJob implements HandlerInterface, SingletonInterface
     public function handle(string $name, string $id, $payload): void
     {
         if (\is_string($payload)) {
-            $payload = json_decode($payload, true);
+            $payload = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
         }
 
         if (!\is_array($payload)) {

--- a/src/SendIt/src/MailQueue.php
+++ b/src/SendIt/src/MailQueue.php
@@ -22,8 +22,7 @@ final class MailQueue implements MailerInterface
 {
     public const JOB_NAME = 'sendit.mail';
 
-    /** @var MailerConfig */
-    private $config;
+    private MailerConfig $config;
 
     /** @var QueueInterface|\Spiral\Queue\QueueInterface */
     private $queue;

--- a/src/SendIt/src/Renderer/ViewRenderer.php
+++ b/src/SendIt/src/Renderer/ViewRenderer.php
@@ -20,8 +20,7 @@ use Symfony\Component\Mime\Email;
 
 final class ViewRenderer implements RendererInterface
 {
-    /** @var ViewsInterface */
-    private $views;
+    private ViewsInterface $views;
 
     public function __construct(ViewsInterface $views)
     {

--- a/src/Session/src/Handler/FileHandler.php
+++ b/src/Session/src/Handler/FileHandler.php
@@ -18,15 +18,9 @@ use Spiral\Files\FilesInterface;
  */
 final class FileHandler implements \SessionHandlerInterface
 {
-    /**
-     * @var FilesInterface
-     */
-    protected $files;
+    protected FilesInterface $files;
 
-    /**
-     * @var string
-     */
-    protected $directory = '';
+    protected string $directory = '';
 
     /**
      * @param int            $lifetime Default session lifetime.

--- a/src/Session/src/Session.php
+++ b/src/Session/src/Session.php
@@ -40,27 +40,20 @@ final class Session implements SessionInterface
 
     /**
      * Unique string to identify client. Signature is stored inside the session.
-     *
-     * @var string
      */
-    private $clientSignature;
+    private string $clientSignature;
 
     /**
      * Session lifetime in seconds.
-     *
-     * @var int
      */
-    private $lifetime;
+    private int $lifetime;
 
     /**
      * @var string
      */
     private $id;
 
-    /**
-     * @var bool
-     */
-    private $started = false;
+    private bool $started = false;
 
     /**
      * @param string|null $id

--- a/src/Session/src/SessionFactory.php
+++ b/src/Session/src/SessionFactory.php
@@ -23,11 +23,9 @@ use Spiral\Session\Exception\SessionException;
  */
 final class SessionFactory implements SessionFactoryInterface, SingletonInterface
 {
-    /** @var SessionConfig */
-    private $config;
+    private SessionConfig $config;
 
-    /** @var FactoryInterface */
-    private $factory;
+    private FactoryInterface $factory;
 
     public function __construct(SessionConfig $config, FactoryInterface $factory)
     {

--- a/src/Session/src/SessionSection.php
+++ b/src/Session/src/SessionSection.php
@@ -18,8 +18,7 @@ use Spiral\Core\Container\InjectableInterface;
  */
 final class SessionSection implements SessionSectionInterface, InjectableInterface
 {
-    /** @var SessionInterface */
-    private $session;
+    private SessionInterface $session;
 
     /**
      * Reference to _SESSION segment.

--- a/src/Snapshots/src/Snapshot.php
+++ b/src/Snapshots/src/Snapshot.php
@@ -16,11 +16,9 @@ namespace Spiral\Snapshots;
  */
 final class Snapshot implements SnapshotInterface
 {
-    /** @var string */
-    private $id;
+    private string $id;
 
-    /** @var \Throwable */
-    private $exception;
+    private \Throwable $exception;
 
     public function __construct(string $id, \Throwable $exception)
     {

--- a/src/Stempler/src/Builder.php
+++ b/src/Stempler/src/Builder.php
@@ -35,17 +35,14 @@ final class Builder
     public const STAGE_FINALIZE  = 2;
     public const STAGE_COMPILE   = 3;
 
-    /** @var LoaderInterface */
-    private $loader;
+    private LoaderInterface $loader;
 
-    /** @var Parser */
-    private $parser;
+    private Parser $parser;
 
-    /** @var Compiler */
-    private $compiler;
+    private Compiler $compiler;
 
     /** @var VisitorInterface[][] */
-    private $visitors = [];
+    private array $visitors = [];
 
     /**
      * @param Parser|null     $parser

--- a/src/Stempler/src/Compiler.php
+++ b/src/Stempler/src/Compiler.php
@@ -22,7 +22,7 @@ use Spiral\Stempler\Node\NodeInterface;
 final class Compiler
 {
     /** @var RendererInterface[] */
-    private $renders = [];
+    private array $renders = [];
 
     public function addRenderer(RendererInterface $renderer): void
     {
@@ -35,7 +35,7 @@ final class Compiler
      */
     public function compile($node, Result $result = null): Result
     {
-        $result = $result ?? new Result();
+        $result ??= new Result();
 
         if (is_array($node)) {
             foreach ($node as $child) {

--- a/src/Stempler/src/Compiler/Renderer/CoreRenderer.php
+++ b/src/Stempler/src/Compiler/Renderer/CoreRenderer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Compiler\Renderer;
 
+use Spiral\Stempler\Compiler\Result;
 use Spiral\Stempler\Compiler;
 use Spiral\Stempler\Compiler\RendererInterface;
 use Spiral\Stempler\Node\Aggregate;
@@ -28,7 +29,7 @@ final class CoreRenderer implements RendererInterface
      */
     public function render(
         Compiler $compiler,
-        Compiler\Result $result,
+        Result $result,
         NodeInterface $node
     ): bool {
         switch (true) {
@@ -38,7 +39,7 @@ final class CoreRenderer implements RendererInterface
             case $node instanceof Template || $node instanceof Block || $node instanceof Aggregate:
                 $result->withinContext(
                     $node->getContext(),
-                    function (Compiler\Result $source) use ($node, $compiler): void {
+                    function (Result $source) use ($node, $compiler): void {
                         foreach ($node->nodes as $child) {
                             $compiler->compile($child, $source);
                         }
@@ -50,7 +51,7 @@ final class CoreRenderer implements RendererInterface
             case $node instanceof Mixin:
                 $result->withinContext(
                     $node->getContext(),
-                    function (Compiler\Result $source) use ($node, $compiler): void {
+                    function (Result $source) use ($node, $compiler): void {
                         foreach ($node->nodes as $child) {
                             if (is_string($child)) {
                                 $source->push($child, null);

--- a/src/Stempler/src/Compiler/Renderer/DynamicRenderer.php
+++ b/src/Stempler/src/Compiler/Renderer/DynamicRenderer.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Compiler\Renderer;
 
+use Spiral\Stempler\Compiler\RendererInterface;
+use Spiral\Stempler\Compiler\Result;
 use Spiral\Stempler\Compiler;
 use Spiral\Stempler\Directive\DirectiveRendererInterface;
 use Spiral\Stempler\Exception\DirectiveException;
@@ -18,16 +20,14 @@ use Spiral\Stempler\Node\Dynamic\Directive;
 use Spiral\Stempler\Node\Dynamic\Output;
 use Spiral\Stempler\Node\NodeInterface;
 
-final class DynamicRenderer implements Compiler\RendererInterface
+final class DynamicRenderer implements RendererInterface
 {
     // default output filter
     public const DEFAULT_FILTER = "htmlspecialchars((string) (%s), ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8')";
 
-    /** @var string */
-    private $defaultFilter = '';
+    private string $defaultFilter = '';
 
-    /** @var DirectiveRendererInterface|null */
-    private $directiveRenderer;
+    private ?DirectiveRendererInterface $directiveRenderer;
 
     public function __construct(
         DirectiveRendererInterface $directiveRenderer = null,
@@ -40,7 +40,7 @@ final class DynamicRenderer implements Compiler\RendererInterface
     /**
      * @inheritDoc
      */
-    public function render(Compiler $compiler, Compiler\Result $result, NodeInterface $node): bool
+    public function render(Compiler $compiler, Result $result, NodeInterface $node): bool
     {
         switch (true) {
             case $node instanceof Output:
@@ -58,7 +58,7 @@ final class DynamicRenderer implements Compiler\RendererInterface
      *
      * @throws DirectiveException
      */
-    private function directive(Compiler\Result $source, Directive $directive): void
+    private function directive(Result $source, Directive $directive): void
     {
         if ($this->directiveRenderer !== null) {
             $result = $this->directiveRenderer->render($directive);
@@ -74,7 +74,7 @@ final class DynamicRenderer implements Compiler\RendererInterface
         );
     }
 
-    private function output(Compiler\Result $source, Output $output): void
+    private function output(Result $source, Output $output): void
     {
         if ($output->rawOutput) {
             $source->push(sprintf('<?php echo %s; ?>', trim($output->body)), $output->getContext());

--- a/src/Stempler/src/Compiler/Renderer/HTMLRenderer.php
+++ b/src/Stempler/src/Compiler/Renderer/HTMLRenderer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Compiler\Renderer;
 
+use Spiral\Stempler\Compiler\Result;
 use PHPUnit\Framework\Constraint\Attribute;
 use Spiral\Stempler\Compiler;
 use Spiral\Stempler\Compiler\RendererInterface;
@@ -25,7 +26,7 @@ final class HTMLRenderer implements RendererInterface
     /**
      * @inheritDoc
      */
-    public function render(Compiler $compiler, Compiler\Result $result, NodeInterface $node): bool
+    public function render(Compiler $compiler, Result $result, NodeInterface $node): bool
     {
         switch (true) {
             case $node instanceof Tag:
@@ -45,7 +46,7 @@ final class HTMLRenderer implements RendererInterface
     /**
      * @psalm-suppress UndefinedClass
      */
-    private function tag(Compiler $compiler, Compiler\Result $result, Tag $node): void
+    private function tag(Compiler $compiler, Result $result, Tag $node): void
     {
         $result->push(sprintf('<%s', $node->name), $node->getContext());
 
@@ -69,7 +70,7 @@ final class HTMLRenderer implements RendererInterface
         }
     }
 
-    private function attribute(Compiler $compiler, Compiler\Result $result, Attr $node): void
+    private function attribute(Compiler $compiler, Result $result, Attr $node): void
     {
         if ($node->name instanceof NodeInterface) {
             $result->push(' ', null);
@@ -92,7 +93,7 @@ final class HTMLRenderer implements RendererInterface
         $result->push(sprintf('=%s', $value), $node->getContext());
     }
 
-    private function verbatim(Compiler $compiler, Compiler\Result $result, Verbatim $node): void
+    private function verbatim(Compiler $compiler, Result $result, Verbatim $node): void
     {
         foreach ($node->nodes as $child) {
             if (is_string($child)) {

--- a/src/Stempler/src/Compiler/Renderer/PHPRenderer.php
+++ b/src/Stempler/src/Compiler/Renderer/PHPRenderer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Compiler\Renderer;
 
+use Spiral\Stempler\Compiler\Result;
 use Spiral\Stempler\Compiler;
 use Spiral\Stempler\Compiler\RendererInterface;
 use Spiral\Stempler\Node\NodeInterface;
@@ -21,7 +22,7 @@ final class PHPRenderer implements RendererInterface
     /**
      * @inheritDoc
      */
-    public function render(Compiler $compiler, Compiler\Result $result, NodeInterface $node): bool
+    public function render(Compiler $compiler, Result $result, NodeInterface $node): bool
     {
         if ($node instanceof PHP) {
             $result->push($node->content, $node->getContext());

--- a/src/Stempler/src/Compiler/Result.php
+++ b/src/Stempler/src/Compiler/Result.php
@@ -22,14 +22,12 @@ use Spiral\Stempler\Parser\Context;
  */
 final class Result
 {
-    /** @var string */
-    private $content = '';
+    private string $content = '';
 
     /** @var Location[] */
-    private $locations = [];
+    private array $locations = [];
 
-    /** @var Location|null */
-    private $parent;
+    private ?Location $parent = null;
 
     public function withinContext(?Context $ctx, callable $body): void
     {

--- a/src/Stempler/src/Compiler/SourceMap.php
+++ b/src/Stempler/src/Compiler/SourceMap.php
@@ -19,14 +19,12 @@ use Spiral\Stempler\Loader\Source;
  */
 final class SourceMap
 {
-    /** @var array */
-    private $paths = [];
+    private array $paths = [];
 
-    /** @var array */
-    private $lines = [];
+    private array $lines = [];
 
     /** @var Source[] */
-    private $sourceCache;
+    private ?array $sourceCache = null;
 
     public function __serialize(): array
     {
@@ -88,7 +86,7 @@ final class SourceMap
      */
     public function serialize()
     {
-        return json_encode($this->__serialize());
+        return json_encode($this->__serialize(), JSON_THROW_ON_ERROR);
     }
 
     /**
@@ -96,7 +94,7 @@ final class SourceMap
      */
     public function unserialize($serialized): void
     {
-        $this->__unserialize(json_decode($serialized, true));
+        $this->__unserialize(json_decode($serialized, true, 512, JSON_THROW_ON_ERROR));
     }
 
     public static function calculate(string $content, array $locations, LoaderInterface $loader): SourceMap

--- a/src/Stempler/src/Directive/AbstractDirective.php
+++ b/src/Stempler/src/Directive/AbstractDirective.php
@@ -19,8 +19,7 @@ use Spiral\Stempler\Node\Dynamic\Directive;
  */
 abstract class AbstractDirective implements DirectiveRendererInterface
 {
-    /** @var ReflectionObject */
-    private $r;
+    private \ReflectionObject $r;
 
     /**
      * AbstractDirective constructor.

--- a/src/Stempler/src/Directive/ConditionalDirective.php
+++ b/src/Stempler/src/Directive/ConditionalDirective.php
@@ -18,8 +18,7 @@ use Spiral\Stempler\Node\Dynamic\Directive;
  */
 final class ConditionalDirective extends AbstractDirective
 {
-    /** @var bool */
-    private $firstSwitchCase = false;
+    private bool $firstSwitchCase = false;
 
     public function renderIf(Directive $directive): string
     {

--- a/src/Stempler/src/Directive/DirectiveGroup.php
+++ b/src/Stempler/src/Directive/DirectiveGroup.php
@@ -16,7 +16,7 @@ use Spiral\Stempler\Node\Dynamic\Directive;
 final class DirectiveGroup implements DirectiveRendererInterface
 {
     /** @var DirectiveRendererInterface[] */
-    private $directives = [];
+    private array $directives = [];
 
     public function __construct(array $directives = [])
     {

--- a/src/Stempler/src/Exception/SyntaxException.php
+++ b/src/Stempler/src/Exception/SyntaxException.php
@@ -19,8 +19,7 @@ use Spiral\Stempler\Lexer\Token;
  */
 class SyntaxException extends \RuntimeException
 {
-    /** @var Token */
-    private $token;
+    private Token $token;
 
     public function __construct(string $message, Token $context)
     {

--- a/src/Stempler/src/Lexer/Buffer.php
+++ b/src/Stempler/src/Lexer/Buffer.php
@@ -17,16 +17,15 @@ namespace Spiral\Stempler\Lexer;
 final class Buffer implements \IteratorAggregate
 {
     /** @var \Generator @internal */
-    private $generator;
+    private \Generator $generator;
 
     /** @var Byte[]|Token[] */
-    private $buffer = [];
+    private array $buffer = [];
 
     /** @var Byte[]|Token[] */
-    private $replay = [];
+    private array $replay = [];
 
-    /** @var int */
-    private $offset = 0;
+    private int $offset = 0;
 
     public function __construct(\Generator $generator, int $offset = 0)
     {

--- a/src/Stempler/src/Lexer/Grammar/Dynamic/BracesGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/Dynamic/BracesGrammar.php
@@ -24,23 +24,17 @@ final class BracesGrammar
 {
     use TokenTrait;
 
-    /** @var bool */
-    private $active;
+    private bool $active;
 
-    /** @var int */
-    private $startToken;
+    private int $startToken;
 
-    /** @var int */
-    private $endToken;
+    private int $endToken;
 
-    /** @var string */
-    private $startSequence;
+    private string $startSequence;
 
-    /** @var string */
-    private $endSequence;
+    private string $endSequence;
 
-    /** @var array */
-    private $body = [];
+    private array $body = [];
 
     public function __construct(string $startSequence, string $endSequence, int $startToken, int $closeToken)
     {

--- a/src/Stempler/src/Lexer/Grammar/Dynamic/DeclareGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/Dynamic/DeclareGrammar.php
@@ -32,8 +32,7 @@ final class DeclareGrammar implements GrammarInterface
     // whitespace
     private const REGEXP_WHITESPACE = '/\s/';
 
-    /** @var array */
-    private $keyword = [];
+    private array $keyword = [];
 
     /**
      * @inheritDoc

--- a/src/Stempler/src/Lexer/Grammar/Dynamic/DirectiveGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/Dynamic/DirectiveGrammar.php
@@ -31,8 +31,7 @@ final class DirectiveGrammar implements \IteratorAggregate
     // Allowed keyword characters.
     private const REGEXP_KEYWORD = '/[a-z0-9_\-:\.]/ui';
 
-    /** @var array */
-    private $name = [];
+    private array $name = [];
 
     /** @var array */
     private $body = [];

--- a/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
@@ -48,14 +48,11 @@ final class DynamicGrammar implements GrammarInterface
     // grammar control directive
     public const DECLARE_DIRECTIVE = 'declare';
 
-    /** @var DirectiveRendererInterface */
-    private $directiveRenderer;
+    private ?DirectiveRendererInterface $directiveRenderer;
 
-    /** @var BracesGrammar */
-    private $echo;
+    private BracesGrammar $echo;
 
-    /** @var BracesGrammar */
-    private $raw;
+    private BracesGrammar $raw;
 
     /**
      * @param DirectiveRendererInterface|null $directiveRenderer

--- a/src/Stempler/src/Lexer/Grammar/HTMLGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/HTMLGrammar.php
@@ -45,14 +45,11 @@ final class HTMLGrammar implements GrammarInterface
     // Allowed keyword characters.
     private const REGEXP_KEYWORD = '/[a-z0-9_\-:\.]/ui';
 
-    /** @var array */
-    private $whitespace = [];
+    private array $whitespace = [];
 
-    /** @var array */
-    private $attribute = [];
+    private array $attribute = [];
 
-    /** @var array */
-    private $keyword = [];
+    private array $keyword = [];
 
     /**
      * @inheritDoc

--- a/src/Stempler/src/Lexer/Grammar/InlineGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/InlineGrammar.php
@@ -38,7 +38,7 @@ final class InlineGrammar implements GrammarInterface
     private const REGEXP_KEYWORD = '/[a-z0-9_\-:\.]/ui';
 
     /** @var Byte[] */
-    private $name = [];
+    private array $name = [];
 
     /** @var Byte[]|null */
     private $default;

--- a/src/Stempler/src/Lexer/Grammar/Traits/TokenTrait.php
+++ b/src/Stempler/src/Lexer/Grammar/Traits/TokenTrait.php
@@ -28,7 +28,7 @@ trait TokenTrait
         $bufferOffset = 0;
 
         foreach ($inner as $n) {
-            $token->offset = $token->offset ?? $n->offset;
+            $token->offset ??= $n->offset;
 
             if ($n instanceof Byte) {
                 if ($buffer === null) {

--- a/src/Stempler/src/Lexer/Lexer.php
+++ b/src/Stempler/src/Lexer/Lexer.php
@@ -20,7 +20,7 @@ use Spiral\Stempler\Lexer\Grammar\RawGrammar;
 final class Lexer
 {
     /** @var GrammarInterface[] */
-    private $grammars = [];
+    private array $grammars = [];
 
     /**
      * Attach grammar layer.

--- a/src/Stempler/src/Lexer/StringStream.php
+++ b/src/Stempler/src/Lexer/StringStream.php
@@ -15,14 +15,11 @@ use Spiral\Stempler\Exception\ScannerException;
 
 final class StringStream implements StreamInterface
 {
-    /** @var string */
-    private $source;
+    private string $source;
 
-    /** @var int */
-    private $length;
+    private int $length;
 
-    /** @var int */
-    private $offset;
+    private int $offset;
 
     public function __construct(string $source)
     {

--- a/src/Stempler/src/Loader/DirectoryLoader.php
+++ b/src/Stempler/src/Loader/DirectoryLoader.php
@@ -18,11 +18,9 @@ use Spiral\Stempler\Exception\LoaderException;
  */
 final class DirectoryLoader implements LoaderInterface
 {
-    /** @var string */
-    private $directory;
+    private string $directory;
 
-    /** @var string */
-    private $extension;
+    private string $extension;
 
     public function __construct(string $directory, string $extension = '.dark.php')
     {

--- a/src/Stempler/src/Loader/Source.php
+++ b/src/Stempler/src/Loader/Source.php
@@ -16,11 +16,9 @@ namespace Spiral\Stempler\Loader;
  */
 final class Source
 {
-    /** @var string|null */
-    private $filename;
+    private ?string $filename;
 
-    /** @var string */
-    private $content;
+    private string $content;
 
     /**
      * @param string|null $filename

--- a/src/Stempler/src/Loader/StringLoader.php
+++ b/src/Stempler/src/Loader/StringLoader.php
@@ -15,8 +15,7 @@ use Spiral\Stempler\Exception\LoaderException;
 
 final class StringLoader implements LoaderInterface
 {
-    /** @var array */
-    private $paths = [];
+    private array $paths = [];
 
     public function set(string $path, string $content): void
     {

--- a/src/Stempler/src/Parser.php
+++ b/src/Stempler/src/Parser.php
@@ -28,14 +28,12 @@ use Spiral\Stempler\Parser\SyntaxInterface;
  */
 final class Parser
 {
-    /** @var Lexer */
-    private $lexer;
+    private Lexer $lexer;
 
-    /** @var string */
-    private $path;
+    private ?string $path = null;
 
     /** @var SyntaxInterface[] */
-    private $syntax = [];
+    private array $syntax = [];
 
     /**
      * Parser constructor.

--- a/src/Stempler/src/Parser/Assembler.php
+++ b/src/Stempler/src/Parser/Assembler.php
@@ -18,14 +18,12 @@ use Spiral\Stempler\Node\NodeInterface;
  */
 final class Assembler
 {
-    /** @var NodeInterface */
-    private $node;
+    private NodeInterface $node;
 
-    /** @var string */
-    private $path;
+    private string $path;
 
     /** @var NodeInterface[] */
-    private $stack = [];
+    private array $stack = [];
 
     public function __construct(NodeInterface $node, string $path)
     {

--- a/src/Stempler/src/Parser/Context.php
+++ b/src/Stempler/src/Parser/Context.php
@@ -19,14 +19,11 @@ use Spiral\Stempler\Lexer\Token;
 final class Context
 {
     public $parent;
-    /** @var Token */
-    private $token;
+    private Token $token;
 
-    /** @var string|null */
-    private $path;
+    private ?string $path;
 
-    /** @var array */
-    private $values = [];
+    private array $values = [];
 
     /**
      * @param string|null $path

--- a/src/Stempler/src/Parser/Syntax/DynamicSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/DynamicSyntax.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Parser\Syntax;
 
+use Spiral\Stempler\Parser\Context;
 use Spiral\Stempler\Lexer\Grammar\DynamicGrammar;
 use Spiral\Stempler\Lexer\StringStream;
 use Spiral\Stempler\Lexer\Token;
@@ -25,11 +26,9 @@ use Spiral\Stempler\Parser\SyntaxInterface;
  */
 final class DynamicSyntax implements SyntaxInterface
 {
-    /** @var Directive|null */
-    private $directive;
+    private ?Directive $directive = null;
 
-    /** @var Output|null */
-    private $output;
+    private ?Output $output = null;
 
     /**
      * @inheritDoc
@@ -38,18 +37,18 @@ final class DynamicSyntax implements SyntaxInterface
     {
         switch ($token->type) {
             case DynamicGrammar::TYPE_DIRECTIVE:
-                $this->directive = new Directive(new Parser\Context($token, $parser->getPath()));
+                $this->directive = new Directive(new Context($token, $parser->getPath()));
                 $asm->push($this->directive);
                 break;
 
             case DynamicGrammar::TYPE_OPEN_TAG:
-                $this->output = new Output(new Parser\Context($token, $parser->getPath()));
+                $this->output = new Output(new Context($token, $parser->getPath()));
 
                 $asm->push($this->output);
                 break;
 
             case DynamicGrammar::TYPE_OPEN_RAW_TAG:
-                $this->output = new Output(new Parser\Context($token, $parser->getPath()));
+                $this->output = new Output(new Context($token, $parser->getPath()));
                 $this->output->rawOutput = true;
 
                 $asm->push($this->output);

--- a/src/Stempler/src/Parser/Syntax/HTMLSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/HTMLSyntax.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Parser\Syntax;
 
+use Spiral\Stempler\Parser\Syntax\Traits\MixinTrait;
+use Spiral\Stempler\Parser\Context;
 use Spiral\Stempler\Exception\SyntaxException;
 use Spiral\Stempler\Lexer\Grammar\HTMLGrammar;
 use Spiral\Stempler\Lexer\Token;
@@ -29,7 +31,7 @@ use Spiral\Stempler\Parser\SyntaxInterface;
  */
 final class HTMLSyntax implements SyntaxInterface
 {
-    use Parser\Syntax\Traits\MixinTrait;
+    use MixinTrait;
 
     // list of tags which are closed automatically (http://xahlee.info/js/html5_non-closing_tag.html)
     private const VOID_TAGS = [
@@ -55,14 +57,11 @@ final class HTMLSyntax implements SyntaxInterface
         'on*',
     ];
 
-    /** @var Tag|null */
-    private $node;
+    private ?Tag $node = null;
 
-    /** @var Token|null */
-    private $token;
+    private ?Token $token = null;
 
-    /** @var Attr|null */
-    private $attr;
+    private ?Attr $attr = null;
 
     /**
      * @inheritDoc
@@ -72,7 +71,7 @@ final class HTMLSyntax implements SyntaxInterface
         switch ($token->type) {
             case HTMLGrammar::TYPE_OPEN:
             case HTMLGrammar::TYPE_OPEN_SHORT:
-                $this->node = new Tag(new Parser\Context($token, $parser->getPath()));
+                $this->node = new Tag(new Context($token, $parser->getPath()));
                 $this->token = $token;
 
                 break;
@@ -92,7 +91,7 @@ final class HTMLSyntax implements SyntaxInterface
                 $this->attr = new Attr(
                     $this->parseToken($parser, $token),
                     new Nil(),
-                    new Parser\Context($token, $parser->getPath())
+                    new Context($token, $parser->getPath())
                 );
 
                 $this->node->attrs[] = $this->attr;
@@ -163,7 +162,7 @@ final class HTMLSyntax implements SyntaxInterface
                 if ($asm->getNode() instanceof Mixin || $asm->getNode() instanceof Verbatim) {
                     $node = $this->parseToken($parser, $token);
                     if (is_string($node)) {
-                        $node = new Raw($node, new Parser\Context($token, $parser->getPath()));
+                        $node = new Raw($node, new Context($token, $parser->getPath()));
                     }
 
                     $asm->push($node);
@@ -183,7 +182,7 @@ final class HTMLSyntax implements SyntaxInterface
 
     private function parseVerbatim(Parser $parser, Token $token): Verbatim
     {
-        $verbatim = new Verbatim(new Parser\Context($token, $parser->getPath()));
+        $verbatim = new Verbatim(new Context($token, $parser->getPath()));
 
         if ($token->tokens === []) {
             if ($token->content) {

--- a/src/Stempler/src/Parser/Syntax/InlineSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/InlineSyntax.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Parser\Syntax;
 
+use Spiral\Stempler\Parser\Syntax\Traits\MixinTrait;
+use Spiral\Stempler\Parser\Context;
 use Spiral\Stempler\Lexer\Grammar\InlineGrammar;
 use Spiral\Stempler\Lexer\Token;
 use Spiral\Stempler\Node\Inline;
@@ -20,10 +22,9 @@ use Spiral\Stempler\Parser\SyntaxInterface;
 
 final class InlineSyntax implements SyntaxInterface
 {
-    use Parser\Syntax\Traits\MixinTrait;
+    use MixinTrait;
 
-    /** @var Inline|null */
-    private $inline;
+    private ?Inline $inline = null;
 
     /**
      * @inheritDoc
@@ -32,7 +33,7 @@ final class InlineSyntax implements SyntaxInterface
     {
         switch ($token->type) {
             case InlineGrammar::TYPE_OPEN_TAG:
-                $this->inline = new Inline(new Parser\Context($token, $parser->getPath()));
+                $this->inline = new Inline(new Context($token, $parser->getPath()));
                 $asm->push($this->inline);
                 break;
 

--- a/src/Stempler/src/Parser/Syntax/PHPSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/PHPSyntax.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Parser\Syntax;
 
+use Spiral\Stempler\Parser\Context;
 use Spiral\Stempler\Lexer\Token;
 use Spiral\Stempler\Node\PHP;
 use Spiral\Stempler\Parser;
@@ -30,7 +31,7 @@ final class PHPSyntax implements SyntaxInterface
         $asm->push(new PHP(
             $token->content,
             $token->tokens,
-            new Parser\Context($token, $parser->getPath())
+            new Context($token, $parser->getPath())
         ));
     }
 }

--- a/src/Stempler/src/Parser/Syntax/RawSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/RawSyntax.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Parser\Syntax;
 
+use Spiral\Stempler\Parser\Context;
 use Spiral\Stempler\Lexer\Token;
 use Spiral\Stempler\Node\Raw;
 use Spiral\Stempler\Parser;
@@ -29,7 +30,7 @@ final class RawSyntax implements SyntaxInterface
     {
         $asm->push(new Raw(
             $token->content,
-            new Parser\Context($token, $parser->getPath())
+            new Context($token, $parser->getPath())
         ));
     }
 }

--- a/src/Stempler/src/Parser/Syntax/Traits/MixinTrait.php
+++ b/src/Stempler/src/Parser/Syntax/Traits/MixinTrait.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Parser\Syntax\Traits;
 
+use Spiral\Stempler\Parser\Context;
 use Spiral\Stempler\Lexer\Token;
 use Spiral\Stempler\Node\Mixin;
 use Spiral\Stempler\Node\Raw;
@@ -32,7 +33,7 @@ trait MixinTrait
             return $token->content;
         }
 
-        $mixin = new Mixin([], new Parser\Context($token, $parser->getPath()));
+        $mixin = new Mixin([], new Context($token, $parser->getPath()));
         $parser->parseTokens(
             new Assembler($mixin, 'nodes'),
             $token->tokens

--- a/src/Stempler/src/Transform/BlockClaims.php
+++ b/src/Stempler/src/Transform/BlockClaims.php
@@ -17,11 +17,10 @@ namespace Spiral\Stempler\Transform;
  */
 final class BlockClaims
 {
-    /** @var array */
-    private $claimed = [];
+    private array $claimed = [];
 
     /** @var array[] */
-    private $blocks = [];
+    private array $blocks = [];
 
     public function __construct(array $blocks)
     {

--- a/src/Stempler/src/Transform/Context/ImportContext.php
+++ b/src/Stempler/src/Transform/Context/ImportContext.php
@@ -23,8 +23,7 @@ use Spiral\Stempler\VisitorContext;
  */
 final class ImportContext
 {
-    /** @var VisitorContext */
-    private $ctx;
+    private VisitorContext $ctx;
 
     private function __construct(VisitorContext $ctx)
     {

--- a/src/Stempler/src/Transform/Context/StackContext.php
+++ b/src/Stempler/src/Transform/Context/StackContext.php
@@ -18,8 +18,7 @@ use Spiral\Stempler\VisitorContext;
 
 final class StackContext
 {
-    /** @var VisitorContext */
-    private $ctx;
+    private VisitorContext $ctx;
 
     private function __construct(VisitorContext $ctx)
     {

--- a/src/Stempler/src/Transform/Finalizer/DynamicToPHP.php
+++ b/src/Stempler/src/Transform/Finalizer/DynamicToPHP.php
@@ -34,14 +34,12 @@ final class DynamicToPHP implements VisitorInterface
     // default output filter
     public const DEFAULT_FILTER = DynamicRenderer::DEFAULT_FILTER;
 
-    /** @var string */
-    private $defaultFilter;
+    private string $defaultFilter;
 
     /** @var DirectiveRendererInterface[] */
-    private $directives;
+    private array $directives;
 
-    /** @var Traverser */
-    private $traverser;
+    private Traverser $traverser;
 
     public function __construct(string $defaultFilter = self::DEFAULT_FILTER, array $directives = [])
     {

--- a/src/Stempler/src/Transform/Finalizer/IsolateBlocks.php
+++ b/src/Stempler/src/Transform/Finalizer/IsolateBlocks.php
@@ -20,8 +20,7 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class IsolateBlocks implements VisitorInterface
 {
-    /** @var string */
-    private $path;
+    private string $path;
 
     public function __construct(string $path)
     {

--- a/src/Stempler/src/Transform/Finalizer/IsolatePHPBlocks.php
+++ b/src/Stempler/src/Transform/Finalizer/IsolatePHPBlocks.php
@@ -24,8 +24,7 @@ final class IsolatePHPBlocks implements VisitorInterface
     // php marcos to inject values into
     private const PHP_MARCO_EXISTS_FUNCTION = 'injected';
 
-    /** @var string */
-    private $path;
+    private string $path;
 
     public function __construct(string $path)
     {

--- a/src/Stempler/src/Transform/Finalizer/StackCollector.php
+++ b/src/Stempler/src/Transform/Finalizer/StackCollector.php
@@ -22,11 +22,9 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class StackCollector implements VisitorInterface
 {
-    /** @var string */
-    private $pushKeyword = 'stack:push';
+    private string $pushKeyword = 'stack:push';
 
-    /** @var string */
-    private $prependKeyword = 'stack:prepend';
+    private string $prependKeyword = 'stack:prepend';
 
     /**
      * @inheritDoc

--- a/src/Stempler/src/Transform/Finalizer/TrimRaw.php
+++ b/src/Stempler/src/Transform/Finalizer/TrimRaw.php
@@ -21,8 +21,7 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class TrimRaw implements VisitorInterface
 {
-    /** @var string */
-    private $trim;
+    private string $trim;
 
     public function __construct(string $charset = " \n\t\r")
     {

--- a/src/Stempler/src/Transform/Import/Bundle.php
+++ b/src/Stempler/src/Transform/Import/Bundle.php
@@ -24,14 +24,11 @@ final class Bundle implements ImportInterface
 {
     use ContextTrait;
 
-    /** @var string */
-    private $path;
+    private string $path;
 
-    /** @var Template */
-    private $template;
+    private ?Template $template = null;
 
-    /** @var string|null */
-    private $prefix;
+    private ?string $prefix;
 
     /**
      * @param Context|null $context

--- a/src/Stempler/src/Transform/Import/Element.php
+++ b/src/Stempler/src/Transform/Import/Element.php
@@ -23,11 +23,9 @@ final class Element implements ImportInterface
 {
     use ContextTrait;
 
-    /** @var string */
-    private $path;
+    private string $path;
 
-    /** @var string */
-    private $alias;
+    private string $alias;
 
     /**
      * @param string|null  $alias

--- a/src/Stempler/src/Transform/Import/Inline.php
+++ b/src/Stempler/src/Transform/Import/Inline.php
@@ -23,11 +23,9 @@ final class Inline implements ImportInterface
 {
     use ContextTrait;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var array */
-    private $nodes;
+    private array $nodes;
 
     /**
      * @param Context|null $context

--- a/src/Stempler/src/Transform/Merge/ExtendsParent.php
+++ b/src/Stempler/src/Transform/Merge/ExtendsParent.php
@@ -27,14 +27,11 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class ExtendsParent implements VisitorInterface
 {
-    /** @var string */
-    private $extendsKeyword = 'extends';
+    private string $extendsKeyword = 'extends';
 
-    /** @var Builder */
-    private $builder;
+    private Builder $builder;
 
-    /** @var Merger */
-    private $merger;
+    private Merger $merger;
 
     public function __construct(Builder $builder, Merger $merger = null)
     {

--- a/src/Stempler/src/Transform/Merge/Inject/InjectAttributes.php
+++ b/src/Stempler/src/Transform/Merge/Inject/InjectAttributes.php
@@ -27,8 +27,7 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class InjectAttributes implements VisitorInterface
 {
-    /** @var BlockClaims */
-    private $blocks;
+    private BlockClaims $blocks;
 
     public function __construct(BlockClaims $blocks)
     {

--- a/src/Stempler/src/Transform/Merge/Inject/InjectBlocks.php
+++ b/src/Stempler/src/Transform/Merge/Inject/InjectBlocks.php
@@ -24,8 +24,7 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class InjectBlocks implements VisitorInterface
 {
-    /** @var BlockClaims */
-    private $blocks;
+    private BlockClaims $blocks;
 
     public function __construct(BlockClaims $blocks)
     {

--- a/src/Stempler/src/Transform/Merge/Inject/InjectPHP.php
+++ b/src/Stempler/src/Transform/Merge/Inject/InjectPHP.php
@@ -33,8 +33,7 @@ final class InjectPHP implements VisitorInterface
 
     private const PHP_MARCO_EXISTS_FUNCTION = 'injected';
 
-    /** @var BlockClaims */
-    private $blocks;
+    private BlockClaims $blocks;
 
     public function __construct(BlockClaims $blocks)
     {

--- a/src/Stempler/src/Transform/Merge/Inject/PHPMixin.php
+++ b/src/Stempler/src/Transform/Merge/Inject/PHPMixin.php
@@ -16,11 +16,9 @@ namespace Spiral\Stempler\Transform\Merge\Inject;
  */
 final class PHPMixin
 {
-    /** @var array */
-    private $tokens = [];
+    private array $tokens = [];
 
-    /** @var array */
-    private $blocks = [];
+    private array $blocks = [];
 
     public function __construct(array $tokens, string $func)
     {

--- a/src/Stempler/src/Transform/Merge/ResolveImports.php
+++ b/src/Stempler/src/Transform/Merge/ResolveImports.php
@@ -29,14 +29,11 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class ResolveImports implements VisitorInterface
 {
-    /** @var string */
-    private $useKeyword = 'use:';
+    private string $useKeyword = 'use:';
 
-    /** @var Builder */
-    private $builder;
+    private Builder $builder;
 
-    /** @var Merger */
-    private $merger;
+    private Merger $merger;
 
     public function __construct(Builder $builder, Merger $merger = null)
     {

--- a/src/Stempler/src/Transform/Merger.php
+++ b/src/Stempler/src/Transform/Merger.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Spiral\Stempler\Transform;
 
+use Spiral\Stempler\Transform\Merge\Inject\InjectBlocks;
+use Spiral\Stempler\Transform\Merge\Inject\InjectPHP;
+use Spiral\Stempler\Transform\Merge\Inject\InjectAttributes;
 use DeepCopy\DeepCopy;
 use Spiral\Stempler\Node\HTML\Tag;
 use Spiral\Stempler\Node\NodeInterface;
@@ -27,11 +30,9 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class Merger
 {
-    /** @var DeepCopy */
-    private $deepCopy;
+    private DeepCopy $deepCopy;
 
-    /** @var BlockFetcher */
-    private $fetcher;
+    private BlockFetcher $fetcher;
 
     /**
      * Merger constructor.
@@ -58,9 +59,9 @@ final class Merger
         $target = $this->deepCopy->copy($target);
         $target->setContext($source->getContext());
 
-        $target->nodes = $this->traverse($target->nodes, new Inject\InjectBlocks($blocks));
-        $target->nodes = $this->traverse($target->nodes, new Inject\InjectPHP($blocks));
-        $target->nodes = $this->traverse($target->nodes, new Inject\InjectAttributes($blocks));
+        $target->nodes = $this->traverse($target->nodes, new InjectBlocks($blocks));
+        $target->nodes = $this->traverse($target->nodes, new InjectPHP($blocks));
+        $target->nodes = $this->traverse($target->nodes, new InjectAttributes($blocks));
 
         return $target;
     }

--- a/src/Stempler/src/Transform/Visitor/DefineBlocks.php
+++ b/src/Stempler/src/Transform/Visitor/DefineBlocks.php
@@ -25,8 +25,7 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class DefineBlocks implements VisitorInterface
 {
-    /** @var array */
-    private $prefix = ['block:', 'define:', 'yield:', 'section:'];
+    private array $prefix = ['block:', 'define:', 'yield:', 'section:'];
 
     /**
      * @inheritDoc
@@ -63,7 +62,7 @@ final class DefineBlocks implements VisitorInterface
     {
         $name = null;
         foreach ($this->prefix as $prefix) {
-            if (strpos($node->name, $prefix) === 0) {
+            if (strpos($node->name, (string) $prefix) === 0) {
                 $name = substr($node->name, strlen($prefix));
                 break;
             }

--- a/src/Stempler/src/Transform/Visitor/DefineHidden.php
+++ b/src/Stempler/src/Transform/Visitor/DefineHidden.php
@@ -18,8 +18,7 @@ use Spiral\Stempler\VisitorInterface;
 
 final class DefineHidden implements VisitorInterface
 {
-    /** @var string */
-    private $hiddenKeyword = 'hidden';
+    private string $hiddenKeyword = 'hidden';
 
     /**
      * @inheritDoc

--- a/src/Stempler/src/Transform/Visitor/DefineStacks.php
+++ b/src/Stempler/src/Transform/Visitor/DefineStacks.php
@@ -22,8 +22,7 @@ use Spiral\Stempler\VisitorInterface;
  */
 final class DefineStacks implements VisitorInterface
 {
-    /** @var string */
-    private $stackKeyword = 'stack:collect';
+    private string $stackKeyword = 'stack:collect';
 
     /**
      * @inheritDoc

--- a/src/Stempler/src/Traverser.php
+++ b/src/Stempler/src/Traverser.php
@@ -21,10 +21,9 @@ use Spiral\Stempler\Node\NodeInterface;
 final class Traverser
 {
     /** @var VisitorInterface[] */
-    private $visitors = [];
+    private array $visitors = [];
 
-    /** @var bool */
-    private $stopTraversal = false;
+    private bool $stopTraversal = false;
 
     public function __construct(array $visitors = [])
     {
@@ -60,7 +59,7 @@ final class Traverser
      */
     public function traverse(array $nodes, VisitorContext $context = null): array
     {
-        $context = $context ?? new VisitorContext();
+        $context ??= new VisitorContext();
 
         $ctx = clone $context;
         foreach ($nodes as $index => $node) {

--- a/src/Stempler/src/VisitorContext.php
+++ b/src/Stempler/src/VisitorContext.php
@@ -19,7 +19,7 @@ use Spiral\Stempler\Node\NodeInterface;
 final class VisitorContext
 {
     /** @var NodeInterface[] */
-    private $scope = [];
+    private array $scope = [];
 
     public function withNode(NodeInterface $node): self
     {

--- a/src/Storage/src/File.php
+++ b/src/Storage/src/File.php
@@ -22,20 +22,11 @@ final class File implements FileInterface
     use ReadableTrait;
     use WritableTrait;
 
-    /**
-     * @var BucketInterface
-     */
-    private $storage;
+    private BucketInterface $storage;
 
-    /**
-     * @var string
-     */
-    private $pathname;
+    private string $pathname;
 
-    /**
-     * @var UriResolverInterface|null
-     */
-    private $resolver;
+    private ?UriResolverInterface $resolver;
 
     /**
      * @param UriResolverInterface|null $resolver

--- a/src/Storage/src/Storage.php
+++ b/src/Storage/src/Storage.php
@@ -43,12 +43,9 @@ final class Storage implements MutableStorageInterface
     /**
      * @var array<string, BucketInterface>
      */
-    private $buckets = [];
+    private array $buckets = [];
 
-    /**
-     * @var string
-     */
-    private $default;
+    private string $default;
 
     public function __construct(string $name = self::DEFAULT_STORAGE)
     {
@@ -71,7 +68,7 @@ final class Storage implements MutableStorageInterface
      */
     public function bucket(string $name = null): BucketInterface
     {
-        $name = $name ?? $this->default;
+        $name ??= $this->default;
 
         if (!isset($this->buckets[$name])) {
             throw new InvalidArgumentException(\sprintf(self::ERROR_NOT_FOUND, $name));

--- a/src/Streams/src/StreamWrapper.php
+++ b/src/Streams/src/StreamWrapper.php
@@ -26,18 +26,14 @@ final class StreamWrapper
      */
     public $context;
 
-    /** @var bool */
-    private static $registered = false;
+    private static bool $registered = false;
 
     /**
      * Uris associated with StreamInterfaces.
-     *
-     * @var array
      */
-    private static $uris = [];
+    private static array $uris = [];
 
-    /** @var array */
-    private static $modes = [
+    private static array $modes = [
         'r'   => 33060,
         'rb'  => 33060,
         'r+'  => 33206,
@@ -49,8 +45,7 @@ final class StreamWrapper
     /** @var StreamInterface */
     private $stream;
 
-    /** @var int */
-    private $mode = 0;
+    private int $mode = 0;
 
     /**
      * Check if StreamInterface ended.

--- a/src/Streams/src/StreamWrapper.php
+++ b/src/Streams/src/StreamWrapper.php
@@ -45,7 +45,10 @@ final class StreamWrapper
     /** @var StreamInterface */
     private $stream;
 
-    private int $mode = 0;
+    /**
+     * @var string|int
+     */
+    private $mode = 0;
 
     /**
      * Check if StreamInterface ended.

--- a/src/Tokenizer/src/Bootloader/TokenizerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerBootloader.php
@@ -33,8 +33,7 @@ final class TokenizerBootloader extends Bootloader implements SingletonInterface
         InvocationsInterface::class => InvocationLocator::class,
     ];
 
-    /** @var ConfiguratorInterface */
-    private $config;
+    private ConfiguratorInterface $config;
 
     public function __construct(ConfiguratorInterface $config)
     {

--- a/src/Tokenizer/src/Reflection/ReflectionArgument.php
+++ b/src/Tokenizer/src/Reflection/ReflectionArgument.php
@@ -24,7 +24,8 @@ final class ReflectionArgument
     public const CONSTANT   = 'constant';   //Scalar constant and not variable.
     public const VARIABLE   = 'variable';   //PHP variable
     public const EXPRESSION = 'expression'; //PHP code (expression).
-    public const STRING     = 'string';     private string $type;
+    public const STRING     = 'string';
+    private string $type;
 
     private string $value;
 

--- a/src/Tokenizer/src/Reflection/ReflectionArgument.php
+++ b/src/Tokenizer/src/Reflection/ReflectionArgument.php
@@ -24,13 +24,9 @@ final class ReflectionArgument
     public const CONSTANT   = 'constant';   //Scalar constant and not variable.
     public const VARIABLE   = 'variable';   //PHP variable
     public const EXPRESSION = 'expression'; //PHP code (expression).
-    public const STRING     = 'string';     //Simple scalar string, can be fetched using stringValue().
+    public const STRING     = 'string';     private string $type;
 
-    /** @var string */
-    private $type;
-
-    /** @var string */
-    private $value;
+    private string $value;
 
     /**
      * New instance of ReflectionArgument.

--- a/src/Tokenizer/src/Reflection/ReflectionFile.php
+++ b/src/Tokenizer/src/Reflection/ReflectionFile.php
@@ -46,10 +46,8 @@ final class ReflectionFile
     /**
      * Set of tokens required to detect classes, traits, interfaces and function declarations. We
      * don't need any other token for that.
-     *
-     * @var array
      */
-    private static $processTokens = [
+    private static array $processTokens = [
         '{',
         '}',
         ';',
@@ -69,56 +67,49 @@ final class ReflectionFile
         T_AS,
     ];
 
-    /** @var string */
-    private $filename = '';
+    private string $filename = '';
 
     /**
      * Parsed tokens array.
      *
      * @internal
-     * @var array
      */
-    private $tokens = [];
+    private array $tokens = [];
 
     /**
      * Total tokens count.
      *
      * @internal
-     * @var int
      */
-    private $countTokens = 0;
+    private int $countTokens = 0;
 
     /**
      * Indicator that file has external includes.
      *
      * @internal
-     * @var bool
      */
-    private $hasIncludes = false;
+    private bool $hasIncludes = false;
 
     /**
      * Namespaces used in file and their token positions.
      *
      * @internal
-     * @var array
      */
-    private $namespaces = [];
+    private array $namespaces = [];
 
     /**
      * Declarations of classes, interfaces and traits.
      *
      * @internal
-     * @var array
      */
-    private $declarations = [];
+    private array $declarations = [];
 
     /**
      * Declarations of new functions.
      *
      * @internal
-     * @var array
      */
-    private $functions = [];
+    private array $functions = [];
 
     /**
      * Every found method/function invocation.
@@ -126,7 +117,7 @@ final class ReflectionFile
      * @internal
      * @var ReflectionInvocation[]
      */
-    private $invocations = [];
+    private array $invocations = [];
 
     public function __construct(string $filename)
     {

--- a/src/Tokenizer/src/Reflection/ReflectionInvocation.php
+++ b/src/Tokenizer/src/Reflection/ReflectionInvocation.php
@@ -20,33 +20,25 @@ use Spiral\Tokenizer\Exception\ReflectionException;
  */
 final class ReflectionInvocation
 {
-    /** @var string */
-    private $filename = '';
+    private string $filename = '';
 
-    /** @var int */
-    private $line = 0;
+    private int $line = 0;
 
-    /** @var string */
-    private $class = '';
+    private string $class = '';
 
-    /** @var string */
-    private $operator = '';
+    private string $operator = '';
 
-    /** @var string */
-    private $name = '';
+    private string $name = '';
 
-    /** @var string */
-    private $source = '';
+    private string $source = '';
 
     /** @var ReflectionArgument[] */
-    private $arguments = [];
+    private array $arguments = [];
 
     /**
      * Was a function used inside another function call?
-     *
-     * @var int
      */
-    private $level = 0;
+    private int $level = 0;
 
     /**
      * New call reflection.

--- a/src/Tokenizer/src/Tokenizer.php
+++ b/src/Tokenizer/src/Tokenizer.php
@@ -29,8 +29,7 @@ final class Tokenizer implements SingletonInterface, InjectorInterface
     public const CODE = 1;
     public const LINE = 2;
 
-    /** @var TokenizerConfig */
-    protected $config;
+    protected TokenizerConfig $config;
 
     /**
      * Tokenizer constructor.

--- a/src/Translator/src/Catalogue.php
+++ b/src/Translator/src/Catalogue.php
@@ -20,11 +20,10 @@ use Symfony\Component\Translation\MessageCatalogue;
  */
 final class Catalogue implements CatalogueInterface
 {
-    /** @var string */
-    private $locale;
+    private string $locale;
 
     /** @var array<string, array<string, string>> */
-    private $data = [];
+    private array $data = [];
 
     public function __construct(string $locale, array $data = [])
     {

--- a/src/Translator/src/Catalogue/CatalogueLoader.php
+++ b/src/Translator/src/Catalogue/CatalogueLoader.php
@@ -22,8 +22,7 @@ final class CatalogueLoader implements LoaderInterface
 {
     use LoggerTrait;
 
-    /** @var TranslatorConfig */
-    private $config;
+    private TranslatorConfig $config;
 
     public function __construct(TranslatorConfig $config)
     {

--- a/src/Translator/src/Catalogue/CatalogueManager.php
+++ b/src/Translator/src/Catalogue/CatalogueManager.php
@@ -20,20 +20,17 @@ use Spiral\Translator\CatalogueManagerInterface;
  */
 final class CatalogueManager implements CatalogueManagerInterface
 {
-    /** @var LoaderInterface */
-    private $loader;
+    private LoaderInterface $loader;
 
     /**
      * @internal
-     * @var CacheInterface
      */
-    private $cache;
+    private CacheInterface $cache;
 
-    /** @var array */
-    private $locales = [];
+    private array $locales = [];
 
     /** @var Catalogue[] */
-    private $catalogues = [];
+    private array $catalogues = [];
 
     public function __construct(LoaderInterface $loader, CacheInterface $cache = null)
     {

--- a/src/Translator/src/Catalogue/RuntimeLoader.php
+++ b/src/Translator/src/Catalogue/RuntimeLoader.php
@@ -19,7 +19,7 @@ final class RuntimeLoader implements LoaderInterface
     /**
      * @var CatalogueInterface[]
      */
-    private $catalogues = [];
+    private array $catalogues = [];
 
     /**
      * @inheritdoc

--- a/src/Translator/src/Config/TranslatorConfig.php
+++ b/src/Translator/src/Config/TranslatorConfig.php
@@ -37,8 +37,7 @@ final class TranslatorConfig extends InjectableConfig
         'dumpers'        => [],
     ];
 
-    /** @var Matcher */
-    private $matcher;
+    private Matcher $matcher;
 
     public function __construct(array $config = [])
     {

--- a/src/Translator/src/Indexer.php
+++ b/src/Translator/src/Indexer.php
@@ -32,15 +32,12 @@ final class Indexer
 {
     use LoggerTrait;
 
-    /** @var TranslatorConfig */
-    private $config;
+    private TranslatorConfig $config;
 
     /**
      * Catalogue to aggregate messages into.
-     *
-     * @var CatalogueInterface
      */
-    private $catalogue;
+    private CatalogueInterface $catalogue;
 
     public function __construct(TranslatorConfig $config, CatalogueInterface $catalogue)
     {

--- a/src/Translator/src/Translator.php
+++ b/src/Translator/src/Translator.php
@@ -23,17 +23,14 @@ use Symfony\Component\Translation\IdentityTranslator;
  */
 final class Translator implements TranslatorInterface, SingletonInterface
 {
-    /** @var TranslatorConfig */
-    private $config;
+    private TranslatorConfig $config;
 
-    /** @var string */
-    private $locale = '';
+    private string $locale = '';
 
     /** @var IdentityTranslator @internal */
-    private $identityTranslator;
+    private IdentityTranslator $identityTranslator;
 
-    /** @var CatalogueManagerInterface */
-    private $catalogueManager;
+    private CatalogueManagerInterface $catalogueManager;
 
     public function __construct(
         TranslatorConfig $config,
@@ -96,8 +93,8 @@ final class Translator implements TranslatorInterface, SingletonInterface
      */
     public function trans(string $id, array $parameters = [], $domain = null, $locale = null): string
     {
-        $domain = $domain ?? $this->config->getDefaultDomain();
-        $locale = $locale ?? $this->locale;
+        $domain ??= $this->config->getDefaultDomain();
+        $locale ??= $this->locale;
 
         $message = $this->get($locale, $domain, $id);
 
@@ -120,8 +117,8 @@ final class Translator implements TranslatorInterface, SingletonInterface
         $domain = null,
         $locale = null
     ) {
-        $domain = $domain ?? $this->config->getDefaultDomain();
-        $locale = $locale ?? $this->locale;
+        $domain ??= $this->config->getDefaultDomain();
+        $locale ??= $this->locale;
 
         try {
             $message = $this->get($locale, $domain, $id);

--- a/src/Validation/src/AbstractChecker.php
+++ b/src/Validation/src/AbstractChecker.php
@@ -29,8 +29,7 @@ abstract class AbstractChecker implements CheckerInterface
     /** List of methods which are allowed to handle empty values. */
     public const ALLOW_EMPTY_VALUES = [];
 
-    /** @var ValidatorInterface */
-    private $validator;
+    private ?ValidatorInterface $validator = null;
 
     /**
      * {@inheritdoc}

--- a/src/Validation/src/AbstractValidator.php
+++ b/src/Validation/src/AbstractValidator.php
@@ -15,17 +15,14 @@ use Spiral\Validation\Exception\ValidationException;
 
 abstract class AbstractValidator implements ValidatorInterface
 {
-    /** @var array */
-    private $errors;
+    private array $errors;
 
-    /** @var array */
-    private $rules;
+    private array $rules;
 
     /** @var mixed */
     private $context;
 
-    /** @var RulesInterface */
-    private $provider;
+    private ?RulesInterface $provider;
 
     /**
      * @param mixed          $context

--- a/src/Validation/src/CallableRule.php
+++ b/src/Validation/src/CallableRule.php
@@ -29,11 +29,9 @@ final class CallableRule extends AbstractRule
     /** @var callable */
     private $check;
 
-    /** @var array */
-    private $args;
+    private array $args;
 
-    /** @var string|null */
-    private $message;
+    private ?string $message;
 
     public function __construct(callable $check, array $args = [], ?string $message = null)
     {

--- a/src/Validation/src/Checker/ArrayChecker.php
+++ b/src/Validation/src/Checker/ArrayChecker.php
@@ -19,8 +19,7 @@ class ArrayChecker extends AbstractChecker
         'range' => '[[Number of elements must be between {1} and {2}.]]',
     ];
 
-    /** @var ValidationInterface */
-    private $validation;
+    private ValidationInterface $validation;
 
     public function __construct(ValidationInterface $validation)
     {

--- a/src/Validation/src/Checker/DatetimeChecker.php
+++ b/src/Validation/src/Checker/DatetimeChecker.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Validation\Checker;
 
+use Spiral\Validation\Checker\DatetimeChecker\ThresholdChecker;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Validation\AbstractChecker;
 
@@ -38,13 +39,12 @@ final class DatetimeChecker extends AbstractChecker implements SingletonInterfac
 
     /** @var callable|\DateTimeInterface|string|numeric|null */
     private $now;
-    /** @var DatetimeChecker\ThresholdChecker */
-    private $threshold;
+    private ThresholdChecker $threshold;
 
     public function __construct($now = null)
     {
         $this->now = $now;
-        $this->threshold = new DatetimeChecker\ThresholdChecker();
+        $this->threshold = new ThresholdChecker();
     }
 
     /**

--- a/src/Validation/src/CheckerRule.php
+++ b/src/Validation/src/CheckerRule.php
@@ -18,17 +18,13 @@ final class CheckerRule extends AbstractRule
 {
     use TranslatorTrait;
 
-    /** @var CheckerInterface */
-    private $checker;
+    private CheckerInterface $checker;
 
-    /** @var string */
-    private $method;
+    private string $method;
 
-    /** @var array */
-    private $args;
+    private array $args;
 
-    /** @var string|null */
-    private $message;
+    private ?string $message;
 
     public function __construct(
         CheckerInterface $checker,

--- a/src/Validation/src/Condition/AnyOfCondition.php
+++ b/src/Validation/src/Condition/AnyOfCondition.php
@@ -16,8 +16,7 @@ use Spiral\Validation\ValidatorInterface;
 
 class AnyOfCondition extends AbstractCondition
 {
-    /** @var Compositor */
-    private $compositor;
+    private Compositor $compositor;
 
     public function __construct(Compositor $compositor)
     {

--- a/src/Validation/src/Condition/Compositor.php
+++ b/src/Validation/src/Condition/Compositor.php
@@ -19,8 +19,7 @@ use Spiral\Validation\RulesInterface;
  */
 final class Compositor
 {
-    /** @var RulesInterface $provider */
-    private $provider;
+    private RulesInterface $provider;
 
     public function __construct(RulesInterface $provider)
     {

--- a/src/Validation/src/Condition/NoneOfCondition.php
+++ b/src/Validation/src/Condition/NoneOfCondition.php
@@ -16,8 +16,7 @@ use Spiral\Validation\ValidatorInterface;
 
 class NoneOfCondition extends AbstractCondition
 {
-    /** @var Compositor */
-    private $compositor;
+    private Compositor $compositor;
 
     public function __construct(Compositor $compositor)
     {

--- a/src/Validation/src/Config/ValidatorConfig.php
+++ b/src/Validation/src/Config/ValidatorConfig.php
@@ -123,6 +123,6 @@ final class ValidatorConfig extends InjectableConfig
      */
     private function normalizeAliases(array $aliases): array
     {
-        return array_map(static fn($value) => str_replace('::', ':', $value), $aliases);
+        return array_map(static fn ($value) => str_replace('::', ':', $value), $aliases);
     }
 }

--- a/src/Validation/src/Config/ValidatorConfig.php
+++ b/src/Validation/src/Config/ValidatorConfig.php
@@ -123,8 +123,6 @@ final class ValidatorConfig extends InjectableConfig
      */
     private function normalizeAliases(array $aliases): array
     {
-        return array_map(static function ($value) {
-            return str_replace('::', ':', $value);
-        }, $aliases);
+        return array_map(static fn($value) => str_replace('::', ':', $value), $aliases);
     }
 }

--- a/src/Validation/src/RuleParser.php
+++ b/src/Validation/src/RuleParser.php
@@ -130,6 +130,6 @@ final class RuleParser implements ParserInterface
      */
     protected function getID($rule): string
     {
-        return json_encode($rule);
+        return json_encode($rule, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Validation/src/ValidationProvider.php
+++ b/src/Validation/src/ValidationProvider.php
@@ -21,17 +21,15 @@ use Spiral\Validation\Config\ValidatorConfig;
 
 final class ValidationProvider implements ValidationInterface, RulesInterface, SingletonInterface
 {
-    /** @var ValidatorConfig */
-    private $config;
+    private ?ValidatorConfig $config;
 
-    /** @var ParserInterface */
-    private $parser;
+    private ParserInterface $parser;
 
     /** @var FactoryInterface */
     private $factory;
 
     /** @var RuleInterface[] */
-    private $rules = [];
+    private array $rules = [];
 
     /**
      * @param ParserInterface|null  $parser

--- a/src/Views/src/Context/ValueDependency.php
+++ b/src/Views/src/Context/ValueDependency.php
@@ -18,14 +18,12 @@ use Spiral\Views\DependencyInterface;
  */
 final class ValueDependency implements DependencyInterface
 {
-    /** @var string */
-    private $name;
+    private string $name;
 
     /** @var mixed */
     private $value;
 
-    /** @var array */
-    private $variants;
+    private array $variants;
 
     /**
      * @param mixed  $value

--- a/src/Views/src/ContextGenerator.php
+++ b/src/Views/src/ContextGenerator.php
@@ -19,8 +19,7 @@ use Spiral\Views\Context\ValueDependency;
  */
 final class ContextGenerator
 {
-    /** @var ContextInterface */
-    private $context;
+    private ContextInterface $context;
 
     public function __construct(ContextInterface $context)
     {

--- a/src/Views/src/Engine/Native/NativeEngine.php
+++ b/src/Views/src/Engine/Native/NativeEngine.php
@@ -20,8 +20,7 @@ final class NativeEngine extends AbstractEngine
 {
     protected const EXTENSION = 'php';
 
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     /**
      * NativeEngine constructor.

--- a/src/Views/src/Engine/Native/NativeView.php
+++ b/src/Views/src/Engine/Native/NativeView.php
@@ -23,11 +23,9 @@ final class NativeView implements ViewInterface
     /*** @var ViewSource */
     protected $view;
 
-    /** @var ContainerInterface */
-    protected $container;
+    protected ContainerInterface $container;
 
-    /** @var ContextInterface */
-    protected $context;
+    protected ContextInterface $context;
 
     public function __construct(ViewSource $view, ContainerInterface $container, ContextInterface $context)
     {

--- a/src/Views/src/Exception/CompileException.php
+++ b/src/Views/src/Exception/CompileException.php
@@ -13,8 +13,7 @@ namespace Spiral\Views\Exception;
 
 class CompileException extends EngineException
 {
-    /** @var array */
-    private $userTrace = [];
+    private array $userTrace = [];
 
     /**
      * {@inheritdoc}

--- a/src/Views/src/Exception/RenderException.php
+++ b/src/Views/src/Exception/RenderException.php
@@ -13,8 +13,7 @@ namespace Spiral\Views\Exception;
 
 class RenderException extends ViewException
 {
-    /** @var array */
-    private $userTrace = [];
+    private array $userTrace = [];
 
     /**
      * {@inheritdoc}

--- a/src/Views/src/Loader/PathParser.php
+++ b/src/Views/src/Loader/PathParser.php
@@ -19,11 +19,9 @@ use Spiral\Views\LoaderInterface;
  */
 final class PathParser
 {
-    /** @var string */
-    private $defaultNamespace;
+    private string $defaultNamespace;
 
-    /** @var string */
-    private $extension;
+    private string $extension;
 
     public function __construct(string $defaultNamespace, string $extension)
     {

--- a/src/Views/src/Loader/ViewPath.php
+++ b/src/Views/src/Loader/ViewPath.php
@@ -13,14 +13,11 @@ namespace Spiral\Views\Loader;
 
 final class ViewPath
 {
-    /** @var string */
-    private $namespace;
+    private string $namespace;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var string */
-    private $basename;
+    private string $basename;
 
     public function __construct(string $namespace, string $name, string $basename)
     {

--- a/src/Views/src/Processor/ContextProcessor.php
+++ b/src/Views/src/Processor/ContextProcessor.php
@@ -35,6 +35,7 @@ final class ContextProcessor implements ProcessorInterface
      */
     public function process(ViewSource $source, ContextInterface $context): ViewSource
     {
-        return $source->withCode(preg_replace_callback($this->pattern, static fn ($matches) => $context->resolveValue($matches[1]), $source->getCode()));
+        return $source->withCode(preg_replace_callback($this->pattern, static fn ($matches) =>
+            $context->resolveValue($matches[1]), $source->getCode()));
     }
 }

--- a/src/Views/src/Processor/ContextProcessor.php
+++ b/src/Views/src/Processor/ContextProcessor.php
@@ -35,6 +35,6 @@ final class ContextProcessor implements ProcessorInterface
      */
     public function process(ViewSource $source, ContextInterface $context): ViewSource
     {
-        return $source->withCode(preg_replace_callback($this->pattern, static fn($matches) => $context->resolveValue($matches[1]), $source->getCode()));
+        return $source->withCode(preg_replace_callback($this->pattern, static fn ($matches) => $context->resolveValue($matches[1]), $source->getCode()));
     }
 }

--- a/src/Views/src/Processor/ContextProcessor.php
+++ b/src/Views/src/Processor/ContextProcessor.php
@@ -23,8 +23,7 @@ final class ContextProcessor implements ProcessorInterface
     // Context injection pattern @{key|default}
     private const PATTERN = '/@\\{(?P<name>[a-z0-9_\\.\\-]+)(?: *\\| *(?P<default>[^}]+))?}/i';
 
-    /** @var string */
-    private $pattern = '';
+    private string $pattern = '';
 
     public function __construct(string $pattern = null)
     {
@@ -36,8 +35,6 @@ final class ContextProcessor implements ProcessorInterface
      */
     public function process(ViewSource $source, ContextInterface $context): ViewSource
     {
-        return $source->withCode(preg_replace_callback($this->pattern, static function ($matches) use ($context) {
-            return $context->resolveValue($matches[1]);
-        }, $source->getCode()));
+        return $source->withCode(preg_replace_callback($this->pattern, static fn($matches) => $context->resolveValue($matches[1]), $source->getCode()));
     }
 }

--- a/src/Views/src/ViewCache.php
+++ b/src/Views/src/ViewCache.php
@@ -15,8 +15,7 @@ use Spiral\Views\Exception\CacheException;
 
 final class ViewCache
 {
-    /** @var array */
-    private $cache = [];
+    private array $cache = [];
 
     /**
      * @param ContextInterface|null $context

--- a/src/Views/src/ViewContext.php
+++ b/src/Views/src/ViewContext.php
@@ -22,7 +22,7 @@ use Spiral\Views\Exception\ContextException;
 final class ViewContext implements ContextInterface
 {
     /** @var DependencyInterface[] */
-    private $dependencies = [];
+    private array $dependencies = [];
 
     /**
      * {@inheritdoc}

--- a/src/Views/src/ViewLoader.php
+++ b/src/Views/src/ViewLoader.php
@@ -22,17 +22,13 @@ use Spiral\Views\Loader\ViewPath;
  */
 final class ViewLoader implements LoaderInterface
 {
-    /** @var FilesInterface */
-    private $files;
+    private FilesInterface $files;
 
-    /** @var PathParser|null */
-    private $parser;
+    private ?PathParser $parser = null;
 
-    /** @var array */
-    private $namespaces;
+    private array $namespaces;
 
-    /** @var string */
-    private $defaultNamespace;
+    private string $defaultNamespace;
 
     public function __construct(
         array $namespaces,

--- a/src/Views/src/ViewManager.php
+++ b/src/Views/src/ViewManager.php
@@ -70,7 +70,8 @@ final class ViewManager implements ViewsInterface
     {
         $this->engines[] = $engine->withLoader($this->loader);
 
-        \uasort($this->engines, static fn (EngineInterface $a, EngineInterface $b) => \strcmp($a->getLoader()->getExtension(), $b->getLoader()->getExtension()));
+        \uasort($this->engines, static fn (EngineInterface $a, EngineInterface $b) =>
+            \strcmp($a->getLoader()->getExtension(), $b->getLoader()->getExtension()));
 
         $this->engines = \array_values($this->engines);
     }

--- a/src/Views/src/ViewManager.php
+++ b/src/Views/src/ViewManager.php
@@ -17,20 +17,17 @@ use Spiral\Views\Exception\ViewException;
 
 final class ViewManager implements ViewsInterface
 {
-    /** @var ViewsConfig */
-    private $config;
+    private ViewsConfig $config;
 
-    /** @var ContextInterface */
-    private $context;
+    private ContextInterface $context;
 
     /** @var LoaderInterface */
     private $loader;
 
-    /** @var ViewCache|null */
-    private $cache;
+    private ?ViewCache $cache = null;
 
     /** @var EngineInterface[] */
-    private $engines = [];
+    private array $engines = [];
 
     public function __construct(ViewsConfig $config, FactoryInterface $factory, ?ContextInterface $context = null)
     {
@@ -73,9 +70,7 @@ final class ViewManager implements ViewsInterface
     {
         $this->engines[] = $engine->withLoader($this->loader);
 
-        \uasort($this->engines, static function (EngineInterface $a, EngineInterface $b) {
-            return \strcmp($a->getLoader()->getExtension(), $b->getLoader()->getExtension());
-        });
+        \uasort($this->engines, static fn(EngineInterface $a, EngineInterface $b) => \strcmp($a->getLoader()->getExtension(), $b->getLoader()->getExtension()));
 
         $this->engines = \array_values($this->engines);
     }

--- a/src/Views/src/ViewManager.php
+++ b/src/Views/src/ViewManager.php
@@ -70,7 +70,7 @@ final class ViewManager implements ViewsInterface
     {
         $this->engines[] = $engine->withLoader($this->loader);
 
-        \uasort($this->engines, static fn(EngineInterface $a, EngineInterface $b) => \strcmp($a->getLoader()->getExtension(), $b->getLoader()->getExtension()));
+        \uasort($this->engines, static fn (EngineInterface $a, EngineInterface $b) => \strcmp($a->getLoader()->getExtension(), $b->getLoader()->getExtension()));
 
         $this->engines = \array_values($this->engines);
     }

--- a/src/Views/src/ViewSource.php
+++ b/src/Views/src/ViewSource.php
@@ -16,17 +16,13 @@ namespace Spiral\Views;
  */
 final class ViewSource
 {
-    /** @var string */
-    private $filename;
+    private string $filename;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var string */
-    private $namespace;
+    private string $namespace;
 
-    /** @var string|null */
-    private $code;
+    private ?string $code = null;
 
     public function __construct(string $filename, string $namespace, string $name)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?       | ✔️

This PR do the followings:

- Update rector dependency to latest 0.13.8
- Update LevelSetList to `LevelSetList::UP_TO_PHP_74` as current composer.json require php 7.4, and run it.
- Set auto import option to make typed property use its name instead of fqcn when possible, with exclude short class name.

Note: For update to typed property, to avoid BC break:

- On non-final class, it only update private property only when possible.
- On final class, it allow update protected property that doesn't has parent property usage.