### PR TITLE
Removing opis/closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "myclabs/deep-copy": "^1.9",
         "nette/php-generator": "^4.0.1",
         "nikic/php-parser": "^4.13.2",
-        "opis/closure": "^3.6",
         "psr/cache": ">=1.0",
         "psr/container": "^1.1|^2.0",
         "psr/http-factory": "^1.0",

--- a/src/Queue/composer.json
+++ b/src/Queue/composer.json
@@ -19,7 +19,6 @@
         "spiral/snapshots": "^2.14",
         "spiral/attributes": "^3.0",
         "doctrine/inflector": "^1.4|^2.0",
-        "opis/closure": "^3.6",
         "ramsey/uuid": "^4.2.3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

Removed `opis/closure`. 
Formerly used in https://github.com/spiral/framework/blob/master/src/Queue/src/DefaultSerializer.php. This class has now been removed.