### PR TITLE
Fixes problem with passing value via `withValue` method

### DIFF
--- a/src/DataGrid/src/Specification/Filter/Postgres/ILike.php
+++ b/src/DataGrid/src/Specification/Filter/Postgres/ILike.php
@@ -23,7 +23,9 @@ final class ILike implements FilterInterface
     public function withValue($value): ?SpecificationInterface
     {
         $filter = clone $this;
-        return $filter->like->withValue($value);
+        $filter->like = $filter->like->withValue($value);
+
+        return $filter;
     }
 
     public function getExpression(): string

--- a/src/DataGrid/tests/Specification/Filter/Postgres/ILikeTest.php
+++ b/src/DataGrid/tests/Specification/Filter/Postgres/ILikeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\DataGrid\Specification\Filter\Postgres;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\DataGrid\Specification\Filter\Postgres\ILike;
+
+final class ILikeTest extends TestCase
+{
+    public function testWithValue(): void
+    {
+        $filter = new ILike('foo');
+
+        $filter = $filter->withValue('bar');
+        $this->assertInstanceOf(ILike::class, $filter);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    |❌ 
| New feature?  | ❌

```php
$filter = new ILike('foo');

// Before
$filter->withValue('bar') instanseof ILike // false

// After
$filter->withValue('bar') instanseof ILike // true
```