### PR TITLE
Adding SerializerRegistry and ability to define job serializers

### DIFF
--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -11,6 +11,7 @@ use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
 use Spiral\Core\Container;
+use Spiral\Core\Container\Autowire;
 use Spiral\Core\FactoryInterface;
 use Spiral\Queue\Config\QueueConfig;
 use Spiral\Queue\ContainerRegistry;
@@ -66,7 +67,7 @@ final class QueueBootloader extends Bootloader
             }
 
             foreach ($config->getRegistrySerializers() as $jobType => $serializer) {
-                if ($serializer instanceof Container\Autowire || \is_string($serializer)) {
+                if ($serializer instanceof Autowire || \is_string($serializer)) {
                     $serializer = $container->get($serializer);
                 }
                 $serializersRegistry->addSerializer($jobType, $serializer);
@@ -96,7 +97,7 @@ final class QueueBootloader extends Bootloader
     {
         $default = $config->getDefaultSerializer();
 
-        if ($default instanceof Container\Autowire || \is_string($default)) {
+        if ($default instanceof Autowire || \is_string($default)) {
             $default = $container->get($default);
         }
 

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -15,7 +15,6 @@ use Spiral\Core\FactoryInterface;
 use Spiral\Queue\Config\QueueConfig;
 use Spiral\Queue\ContainerRegistry;
 use Spiral\Queue\Core\QueueInjector;
-use Spiral\Queue\DefaultSerializer;
 use Spiral\Queue\Driver\NullDriver;
 use Spiral\Queue\Driver\SyncDriver;
 use Spiral\Queue\Failed\FailedJobHandlerInterface;
@@ -26,6 +25,8 @@ use Spiral\Queue\QueueInterface;
 use Spiral\Queue\QueueManager;
 use Spiral\Queue\QueueRegistry;
 use Spiral\Queue\SerializerInterface;
+use Spiral\Queue\SerializerRegistry;
+use Spiral\Queue\SerializerRegistryInterface;
 
 final class QueueBootloader extends Bootloader
 {
@@ -33,8 +34,11 @@ final class QueueBootloader extends Bootloader
         HandlerRegistryInterface::class => QueueRegistry::class,
         FailedJobHandlerInterface::class => LogFailedJobHandler::class,
         QueueConnectionProviderInterface::class => QueueManager::class,
+        SerializerRegistryInterface::class => SerializerRegistry::class,
+        SerializerInterface::class => SerializerRegistryInterface::class,
         QueueManager::class => [self::class, 'initQueueManager'],
         QueueRegistry::class => [self::class, 'initRegistry'],
+        SerializerRegistry::class => [self::class, 'initSerializerRegistry'],
     ];
 
     private ConfiguratorInterface $config;
@@ -47,7 +51,6 @@ final class QueueBootloader extends Bootloader
     public function boot(Container $container, EnvironmentInterface $env, AbstractKernel $kernel): void
     {
         $this->initQueueConfig($env);
-        $this->registerJobsSerializer($container);
         $this->registerQueue($container);
 
         $this->registerDriverAlias(SyncDriver::class, 'sync');
@@ -56,9 +59,17 @@ final class QueueBootloader extends Bootloader
         $kernel->started(static function () use ($container): void {
             $registry = $container->get(HandlerRegistryInterface::class);
             $config = $container->get(QueueConfig::class);
+            $serializersRegistry = $container->get(SerializerRegistryInterface::class);
 
             foreach ($config->getRegistryHandlers() as $jobType => $handler) {
                 $registry->setHandler($jobType, $handler);
+            }
+
+            foreach ($config->getRegistrySerializers() as $jobType => $serializer) {
+                if ($serializer instanceof Container\Autowire || \is_string($serializer)) {
+                    $serializer = $container->get($serializer);
+                }
+                $serializersRegistry->addSerializer($jobType, $serializer);
             }
         });
     }
@@ -66,7 +77,7 @@ final class QueueBootloader extends Bootloader
     public function registerDriverAlias(string $driverClass, string $alias): void
     {
         $this->config->modify(
-            'queue',
+            QueueConfig::CONFIG,
             new Append('driverAliases', $alias, $driverClass)
         );
     }
@@ -81,9 +92,15 @@ final class QueueBootloader extends Bootloader
         return new QueueRegistry($container, $registry);
     }
 
-    private function registerJobsSerializer(Container $container): void
+    protected function initSerializerRegistry(Container $container, QueueConfig $config): SerializerRegistry
     {
-        $container->bindSingleton(SerializerInterface::class, static fn () => new DefaultSerializer());
+        $default = $config->getDefaultSerializer();
+
+        if ($default instanceof Container\Autowire || \is_string($default)) {
+            $default = $container->get($default);
+        }
+
+        return new SerializerRegistry($default);
     }
 
     private function registerQueue(Container $container): void
@@ -107,6 +124,7 @@ final class QueueBootloader extends Bootloader
                 ],
                 'registry' => [
                     'handlers' => [],
+                    'serializers' => [],
                 ],
                 'driverAliases' => [
                     'sync' => SyncDriver::class,

--- a/src/Queue/src/Config/QueueConfig.php
+++ b/src/Queue/src/Config/QueueConfig.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Queue\Config;
 
+use Spiral\Core\Container\Autowire;
 use Spiral\Core\InjectableConfig;
+use Spiral\Queue\DefaultSerializer;
 use Spiral\Queue\Exception\InvalidArgumentException;
+use Spiral\Queue\SerializerInterface;
 
 final class QueueConfig extends InjectableConfig
 {
@@ -16,6 +19,11 @@ final class QueueConfig extends InjectableConfig
         'aliases' => [],
         'driverAliases' => [],
         'connections' => [],
+        'defaultSerializer' => null,
+        'registry' => [
+            'handlers' => [],
+            'serializers' => [],
+        ],
     ];
 
     /**
@@ -129,5 +137,21 @@ final class QueueConfig extends InjectableConfig
     public function getRegistryHandlers(): array
     {
         return (array)($this->config['registry']['handlers'] ?? []);
+    }
+
+    /**
+     * @psalm-return array<string, SerializerInterface|class-string|Autowire>
+     */
+    public function getRegistrySerializers(): array
+    {
+        return (array)($this->config['registry']['serializers'] ?? []);
+    }
+
+    /**
+     * @psalm-return SerializerInterface|class-string|Autowire
+     */
+    public function getDefaultSerializer()
+    {
+        return $this->config['defaultSerializer'] ?? new DefaultSerializer();
     }
 }

--- a/src/Queue/src/DefaultSerializer.php
+++ b/src/Queue/src/DefaultSerializer.php
@@ -9,9 +9,6 @@ use Spiral\Queue\Exception\SerializationException;
 use function Opis\Closure\serialize;
 use function Opis\Closure\unserialize;
 
-/**
- * @internal
- */
 final class DefaultSerializer implements SerializerInterface
 {
     /**

--- a/src/Queue/src/PhpSerializer.php
+++ b/src/Queue/src/PhpSerializer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+use Spiral\Queue\Exception\SerializationException;
+
+final class PhpSerializer implements SerializerInterface
+{
+    public function serialize(array $payload): string
+    {
+        $result = \serialize($payload);
+
+        if ($result === false) {
+            throw new SerializationException('Failed to serialize data.');
+        }
+
+        return $result;
+    }
+
+    public function deserialize(string $payload): array
+    {
+        $result = \unserialize($payload);
+
+        if ($result === false) {
+            throw new SerializationException('Failed to unserialize data.');
+        }
+
+        return $result;
+    }
+}

--- a/src/Queue/src/SerializerRegistry.php
+++ b/src/Queue/src/SerializerRegistry.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+final class SerializerRegistry implements SerializerInterface, SerializerRegistryInterface
+{
+    /** @var array<non-empty-string, SerializerInterface> */
+    private array $serializers = [];
+    private SerializerInterface $default;
+
+    /** @param array<non-empty-string, SerializerInterface> $serializers */
+    public function __construct(SerializerInterface $default)
+    {
+        $this->default = $default;
+    }
+
+    public function serialize(array $payload): string
+    {
+        return $this->default->serialize($payload);
+    }
+
+    public function deserialize(string $payload): array
+    {
+        return $this->default->deserialize($payload);
+    }
+
+    public function getSerializer(string $jobType): SerializerInterface
+    {
+        if (!$this->hasSerializer($jobType)) {
+            return $this->default;
+        }
+
+        return $this->serializers[$jobType];
+    }
+
+    public function addSerializer(string $jobType, SerializerInterface $serializer): void
+    {
+        if (!$this->hasSerializer($jobType)) {
+            $this->serializers[$jobType] = $serializer;
+        }
+    }
+
+    public function hasSerializer(string $jobType): bool
+    {
+        return isset($this->serializers[$jobType]);
+    }
+}

--- a/src/Queue/tests/Config/QueueConfigTest.php
+++ b/src/Queue/tests/Config/QueueConfigTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Queue\Config;
 
+use Spiral\Core\Container\Autowire;
 use Spiral\Queue\Config\QueueConfig;
+use Spiral\Queue\DefaultSerializer;
 use Spiral\Queue\Exception\InvalidArgumentException;
+use Spiral\Queue\PhpSerializer;
 use Spiral\Tests\Queue\TestCase;
 
 final class QueueConfigTest extends TestCase
@@ -233,5 +236,42 @@ final class QueueConfigTest extends TestCase
         $config = new QueueConfig();
 
         $this->assertSame([], $config->getRegistryHandlers());
+    }
+
+    public function testGetRegistrySerializers(): void
+    {
+        $config = new QueueConfig([
+            'registry' => [
+                'serializers' => ['foo' => 'some', 'bar' => 'other'],
+            ]
+        ]);
+
+        $this->assertSame(['foo' => 'some', 'bar' => 'other'], $config->getRegistrySerializers());
+    }
+
+    public function testGetNotExistsRegistrySerializers(): void
+    {
+        $config = new QueueConfig();
+
+        $this->assertSame([], $config->getRegistrySerializers());
+    }
+
+    /** @dataProvider defaultSerializerDataProvider */
+    public function testGetDefaultSerializer($serializer, $expected): void
+    {
+        $config = new QueueConfig([
+            'defaultSerializer' => $serializer
+        ]);
+
+        $this->assertEquals($expected, $config->getDefaultSerializer());
+    }
+
+    public function defaultSerializerDataProvider(): \Traversable
+    {
+        yield [null, new DefaultSerializer()];
+        yield ['class-string', 'class-string'];
+        yield [PhpSerializer::class, PhpSerializer::class];
+        yield [new DefaultSerializer(), new DefaultSerializer()];
+        yield [new Autowire(PhpSerializer::class), new Autowire(PhpSerializer::class)];
     }
 }

--- a/src/Queue/tests/PhpSerializerTest.php
+++ b/src/Queue/tests/PhpSerializerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use Spiral\Queue\PhpSerializer;
+
+final class PhpSerializerTest extends TestCase
+{
+    public function testSerializer(): void
+    {
+        $serializer = new PhpSerializer();
+
+        $object = new \stdClass();
+        $object->foo = 'bar';
+
+        $serializedPayload = $serializer->serialize([
+            'int' => 1,
+            'string' => 'foo',
+            'array' => ['foo'],
+            'object' => $object,
+        ]);
+
+        $this->assertIsArray(
+            $payload = $serializer->deserialize($serializedPayload)
+        );
+
+        $this->assertSame(1, $payload['int']);
+        $this->assertSame('foo', $payload['string']);
+        $this->assertInstanceOf(get_class($object), $payload['object']);
+    }
+}

--- a/src/Queue/tests/SerializerRegistryTest.php
+++ b/src/Queue/tests/SerializerRegistryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use Spiral\Queue\DefaultSerializer;
+use Spiral\Queue\PhpSerializer;
+use PHPUnit\Framework\TestCase;
+use Spiral\Queue\SerializerRegistry;
+
+final class SerializerRegistryTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $registry = new SerializerRegistry(new PhpSerializer());
+
+        $object = new \stdClass();
+        $object->foo = 'bar';
+
+        $serialized = $registry->serialize([
+            'int' => 1,
+            'string' => 'foo',
+            'array' => ['foo'],
+            'object' => $object,
+        ]);
+
+        $this->assertSame(
+            'a:4:{s:3:"int";i:1;s:6:"string";s:3:"foo";s:5:"array";a:1:{i:0;s:3:"foo";}s:6:"object";O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}}',
+            $serialized
+        );
+    }
+
+    public function testDeserialize(): void
+    {
+        $registry = new SerializerRegistry(new PhpSerializer());
+
+        $object = new \stdClass();
+        $object->foo = 'bar';
+
+        $serialized = 'a:4:{s:3:"int";i:1;s:6:"string";s:3:"foo";s:5:"array";a:1:{i:0;s:3:"foo";}s:6:"object";O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}}';
+
+        $this->assertIsArray(
+            $payload = $registry->deserialize($serialized)
+        );
+
+        $this->assertSame(1, $payload['int']);
+        $this->assertSame('foo', $payload['string']);
+        $this->assertInstanceOf(\get_class($object), $payload['object']);
+    }
+
+    public function testGetSerializer(): void
+    {
+        $registry = new SerializerRegistry(new PhpSerializer());
+
+        $registry->addSerializer('foo', new DefaultSerializer());
+
+        $this->assertInstanceOf(DefaultSerializer::class, $registry->getSerializer('foo'));
+        $this->assertInstanceOf(PhpSerializer::class, $registry->getSerializer('bar'));
+    }
+
+    public function testAddSerializer(): void
+    {
+        $registry = new SerializerRegistry(new PhpSerializer());
+
+        $this->assertInstanceOf(PhpSerializer::class, $registry->getSerializer('foo'));
+
+        $registry->addSerializer('foo', new DefaultSerializer());
+        $this->assertInstanceOf(DefaultSerializer::class, $registry->getSerializer('foo'));
+    }
+
+    public function testHasSerializer(): void
+    {
+        $registry = new SerializerRegistry(new PhpSerializer());
+
+        $this->assertFalse($registry->hasSerializer('foo'));
+
+        $registry->addSerializer('foo', new DefaultSerializer());
+
+        $this->assertTrue($registry->hasSerializer('foo'));
+    }
+}

--- a/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
+++ b/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Bootloader\Queue;
+
+use Spiral\App\TestApp;
+use Spiral\Config\ConfigManager;
+use Spiral\Config\LoaderInterface;
+use Spiral\Queue\Bootloader\QueueBootloader;
+use Spiral\Queue\Config\QueueConfig;
+use Spiral\Queue\Failed\FailedJobHandlerInterface;
+use Spiral\Queue\Failed\LogFailedJobHandler;
+use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\QueueConnectionProviderInterface;
+use Spiral\Queue\QueueManager;
+use Spiral\Queue\QueueRegistry;
+use Spiral\Queue\SerializerRegistry;
+use Spiral\Queue\SerializerRegistryInterface;
+use Spiral\Tests\Framework\BaseTest;
+
+final class QueueBootloaderTest extends BaseTest
+{
+    private TestApp $app;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app = $this->makeApp();
+    }
+
+    public function testHandlerRegistryInterfaceBinding(): void
+    {
+        $this->assertInstanceOf(HandlerRegistryInterface::class, $this->app->get(QueueRegistry::class));
+    }
+
+    public function testFailedJobHandlerInterfaceBinding(): void
+    {
+        $this->assertInstanceOf(FailedJobHandlerInterface::class, $this->app->get(LogFailedJobHandler::class));
+    }
+
+    public function testQueueConnectionProviderInterfaceBinding(): void
+    {
+        $this->assertInstanceOf(QueueConnectionProviderInterface::class, $this->app->get(QueueManager::class));
+    }
+
+    public function testSerializerRegistryInterfaceBinding(): void
+    {
+        $this->assertInstanceOf(SerializerRegistryInterface::class, $this->app->get(SerializerRegistry::class));
+    }
+
+    public function testQueueManagerBinding(): void
+    {
+        $this->assertInstanceOf(QueueManager::class, $this->app->get(QueueManager::class));
+    }
+
+    public function testQueueRegistryBinding(): void
+    {
+        $this->assertInstanceOf(QueueRegistry::class, $this->app->get(QueueRegistry::class));
+    }
+
+    public function testSerializerRegistryBinding(): void
+    {
+        $this->assertInstanceOf(SerializerRegistry::class, $this->app->get(SerializerRegistry::class));
+    }
+
+    public function testConfig(): void
+    {
+        $this->assertSame([
+            'default' => 'sync',
+            'connections' => [
+                'sync' => ['driver' => 'sync'],
+            ],
+
+            'registry' => [
+                'handlers' => [],
+                'serializers' => [],
+            ],
+            'driverAliases' => [
+                'sync' => \Spiral\Queue\Driver\SyncDriver::class,
+                'null' => \Spiral\Queue\Driver\NullDriver::class,
+            ],
+        ], $this->app->get(QueueConfig::class)->toArray());
+    }
+
+    public function testRegisterDriverAlias(): void
+    {
+        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs->setDefaults(QueueConfig::CONFIG, ['driverAliases' => []]);
+
+        $bootloader = new QueueBootloader($configs);
+        $bootloader->registerDriverAlias('foo', 'bar');
+
+        $this->assertSame([
+            'bar' => 'foo'
+        ], $configs->getConfig(QueueConfig::CONFIG)['driverAliases']);
+    }
+}

--- a/tests/app/src/TestApp.php
+++ b/tests/app/src/TestApp.php
@@ -22,6 +22,7 @@ use Spiral\Bootloader;
 use Spiral\Console\Console;
 use Spiral\Core\Container;
 use Spiral\Framework\Kernel;
+use Spiral\Queue\Bootloader\QueueBootloader;
 use Spiral\Stempler\Bootloader\StemplerBootloader;
 
 class TestApp extends Kernel
@@ -83,6 +84,9 @@ class TestApp extends Kernel
 
         // Storage
         Bootloader\Storage\StorageBootloader::class,
+
+        // Queue
+        QueueBootloader::class,
 
         // Framework commands
         Bootloader\CommandBootloader::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ✔️

This PR adds the ability to configure the default Queue serializer and configure serializers for jobs.

### Default serializer

The default serializer `Spiral\Queue\DefaultSerializer` uses `opis/closure` package which doesn't work on PHP 8.1.

The code below replaces the default serializer in the Queue component to `Spiral\Queue\PhpSerializer`.
This simplest implementation of the serializer doesn't use additional dependencies and works on PHP 8.1.

```php
 // file app/app/config/queue.php
return [
    'defaultSerializer' => \Spiral\Queue\PhpSerializer::class,
];
```

### Jobs serializers

Each job can use a separate serializer. This can be configured in the config file.

```php
 // file app/app/config/queue.php
return [
    'registry' => [
        'serializers' => [
            \App\Job\Ping::class => \Spiral\Queue\PhpSerializer::class,
            // other ways
            // Ping::class => new \Spiral\Queue\PhpSerializer(),
            // Ping::class => new \Spiral\Core\Container\Autowire(\Spiral\Queue\PhpSerializer::class),
        ]
    ],
];
```
