### PR TITLE
Fixing NestedFilter creation

### DIFF
--- a/src/Filters/src/Model/Schema/AttributeMapper.php
+++ b/src/Filters/src/Model/Schema/AttributeMapper.php
@@ -37,8 +37,6 @@ final class AttributeMapper
         $class = new \ReflectionClass($filter);
 
         foreach ($class->getProperties() as $property) {
-            $property->setAccessible(true);
-
             foreach ($this->reader->getPropertyMetadata($property) as $attribute) {
                 if ($attribute instanceof AbstractInput) {
                     $this->setValue($filter, $property, $attribute->getValue($input, $property));
@@ -47,7 +45,9 @@ final class AttributeMapper
                     try {
                         $value = $this->provider->createFilter(
                             $attribute->class,
-                            $attribute->prefix ? $input->withPrefix($attribute->prefix) : $input
+                            $attribute->prefix ?
+                                $input->withPrefix($attribute->prefix) :
+                                $input->withPrefix($property->name)
                         );
 
                         $this->setValue($filter, $property, $value);

--- a/src/Filters/tests/Fixtures/AddressFilter.php
+++ b/src/Filters/tests/Fixtures/AddressFilter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Filters\Fixtures;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Model\Filter;
+
+class AddressFilter extends Filter
+{
+    #[Post]
+    public string $city;
+
+    #[Post]
+    public string $address;
+}

--- a/src/Filters/tests/Fixtures/SomeFilter.php
+++ b/src/Filters/tests/Fixtures/SomeFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Filters\Fixtures;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\NestedFilter;
+use Spiral\Filters\Model\Filter;
+
+class SomeFilter extends Filter
+{
+    #[Post]
+    public string $name;
+
+    #[NestedFilter(class: AddressFilter::class)]
+    public AddressFilter $address;
+}

--- a/src/Filters/tests/Model/FilterProviderTest.php
+++ b/src/Filters/tests/Model/FilterProviderTest.php
@@ -4,9 +4,46 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Filters\Model;
 
+use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
+use Spiral\Attributes\Factory;
+use Spiral\Filter\InputScope;
+use Spiral\Filters\Model\FilterProvider;
+use Spiral\Filters\Model\FilterProviderInterface;
+use Spiral\Filters\Model\Interceptor\Core;
+use Spiral\Filters\Model\Schema\AttributeMapper;
+use Spiral\Http\Request\InputManager;
 use Spiral\Tests\Filters\BaseTest;
+use Spiral\Tests\Filters\Fixtures\SomeFilter;
 
 final class FilterProviderTest extends BaseTest
 {
+    public function testCreateNestedFilterWithIdenticalPropertyNames(): void
+    {
+        $request = new ServerRequest('POST', '/');
+        $request = $request->withParsedBody([
+            'name' => 'John',
+            'address' => [
+                'address' => 'Some street',
+                'city' => 'Portland'
+            ]
+        ]);
+        $this->container->bind(ServerRequestInterface::class, $request);
 
+        $inputManager = new InputManager($this->container);
+        $input = new InputScope($inputManager);
+
+        $provider = new FilterProvider($this->container, new Core());
+        $this->container->bind(FilterProviderInterface::class, $provider);
+
+        $mapper = new AttributeMapper($provider, (new Factory())->create());
+        $this->container->bind(AttributeMapper::class, $mapper);
+
+        /** @var SomeFilter $filter */
+        $filter = $provider->createFilter(SomeFilter::class, $input);
+
+        $this->assertSame('John', $filter->name);
+        $this->assertSame('Some street', $filter->address->address);
+        $this->assertSame('Portland', $filter->address->city);
+    }
 }

--- a/src/Filters/tests/Model/Schema/AttributeMapperTest.php
+++ b/src/Filters/tests/Model/Schema/AttributeMapperTest.php
@@ -45,6 +45,7 @@ final class AttributeMapperTest extends BaseTest
         $input->shouldReceive('withPrefix')->once()->with('bar')->andReturn($barInput);
         $input->shouldReceive('withPrefix')->once()->with('bazFilter.first')->andReturn($bazInputFirst);
         $input->shouldReceive('withPrefix')->once()->with('bazFilter.second')->andReturn($bazInputSecond);
+        $input->shouldReceive('withPrefix')->once()->with('fooFilter')->andReturn($input);
 
         $this->provider->shouldReceive('createFilter')->once()->with('fooFilter', $input)
             ->andReturn($fooFilter = m::mock(FilterInterface::class));
@@ -149,6 +150,7 @@ final class AttributeMapperTest extends BaseTest
         $bazInputSecond = m::mock(InputInterface::class);
         $input->shouldReceive('withPrefix')->once()->with('baz.first')->andReturn($bazInputFirst);
         $input->shouldReceive('withPrefix')->once()->with('baz.second')->andReturn($bazInputSecond);
+        $input->shouldReceive('withPrefix')->once()->with('fooFilter')->andReturn($input);
 
         $this->provider->shouldReceive('createFilter')->once()->with('fooFilter', $input)
             ->andThrow(new ValidationException(['fooFilter' => 'Error']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

Fixed error `TypeError : Cannot assign array to property Spiral\Tests\Filters\Fixtures\AddressFilter::$address of type string`