### PR TITLE
Adding defaultSerializer in queue

### DIFF
--- a/src/Queue/src/Config/QueueConfig.php
+++ b/src/Queue/src/Config/QueueConfig.php
@@ -8,6 +8,7 @@ use Spiral\Core\Container\Autowire;
 use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\InjectableConfig;
 use Spiral\Queue\Exception\InvalidArgumentException;
+use Spiral\Serializer\SerializerInterface;
 
 final class QueueConfig extends InjectableConfig
 {
@@ -26,6 +27,7 @@ final class QueueConfig extends InjectableConfig
             'push' => [],
             'consume' => [],
         ],
+        'defaultSerializer' => null,
     ];
 
     /**
@@ -164,5 +166,13 @@ final class QueueConfig extends InjectableConfig
     public function getRegistrySerializers(): array
     {
         return (array)($this->config['registry']['serializers'] ?? []);
+    }
+
+    /**
+     * @psalm-return SerializerInterface|class-string|Autowire|null
+     */
+    public function getDefaultSerializer(): SerializerInterface|string|Autowire|null
+    {
+        return $this->config['defaultSerializer'] ?? null;
     }
 }

--- a/src/Queue/tests/Config/QueueConfigTest.php
+++ b/src/Queue/tests/Config/QueueConfigTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Queue\Config;
 
+use Spiral\Core\Container\Autowire;
 use Spiral\Queue\Config\QueueConfig;
 use Spiral\Queue\Exception\InvalidArgumentException;
+use Spiral\Serializer\Serializer\JsonSerializer;
 use Spiral\Tests\Queue\TestCase;
 
 final class QueueConfigTest extends TestCase
@@ -273,5 +275,23 @@ final class QueueConfigTest extends TestCase
         $config = new QueueConfig();
 
         $this->assertSame([], $config->getRegistrySerializers());
+    }
+
+    /** @dataProvider defaultSerializerDataProvider */
+    public function testGetDefaultSerializer(array $config, mixed $expected): void
+    {
+        $config = new QueueConfig($config);
+
+        $this->assertEquals($expected, $config->getDefaultSerializer());
+    }
+
+    public function defaultSerializerDataProvider(): \Generator
+    {
+        yield [[], null];
+        yield [['defaultSerializer' => null], null];
+        yield [['defaultSerializer' => 'json'], 'json'];
+        yield [['defaultSerializer' => JsonSerializer::class], JsonSerializer::class];
+        yield [['defaultSerializer' => new JsonSerializer ()], new JsonSerializer()];
+        yield [['defaultSerializer' => new Autowire(JsonSerializer::class)], new Autowire(JsonSerializer::class)];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

Added the ability to configure a default serializer in the Queue component via the configuration file.

```php
// file app/config/queue.php

declare(strict_types=1);

use Spiral\Core\Container\Autowire;
use Spiral\Serializer\Serializer\JsonSerializer;
use Spiral\Serializer\Serializer\PhpSerializer;

return [
    // ...

    // via class name
    'defaultSerializer' => JsonSerializer::class,
    
    // via instance
    'defaultSerializer' => new JsonSerializer(),
    
    // via Autowire
    'defaultSerializer' => new Autowire(PhpSerializer::class)
];
```