### PR TITLE
Adds an ability to use custom transports for Symfony Mailer

### DIFF
--- a/src/Console/src/Config/ConsoleConfig.php
+++ b/src/Console/src/Config/ConsoleConfig.php
@@ -106,7 +106,6 @@ final class ConsoleConfig extends InjectableConfig
      *     header?: string,
      *     footer?: string
      * } $item
-     * @return SequenceInterface
      * @throws \JsonException
      */
     protected function parseSequence(SequenceInterface|string|array $item): SequenceInterface

--- a/src/Queue/src/QueueRegistry.php
+++ b/src/Queue/src/QueueRegistry.php
@@ -73,7 +73,6 @@ final class QueueRegistry implements HandlerRegistryInterface, QueueSerializerRe
             return $this->serializers[$jobType];
         }
 
-        /** @var QueueConfig $config */
         $config = $this->container->get(QueueConfig::class);
 
         return $config->getDefaultSerializer() === null ?
@@ -93,7 +92,6 @@ final class QueueRegistry implements HandlerRegistryInterface, QueueSerializerRe
      */
     private function resolveSerializer(SerializerInterface|string|Autowire $serializer): SerializerInterface
     {
-        /** @var SerializerRegistryInterface $registry */
         $registry = $this->container->get(SerializerRegistryInterface::class);
 
         if ($serializer instanceof Autowire) {

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -10,7 +10,6 @@ use Spiral\Config\ConfiguratorInterface;
 use Spiral\Core\Container;
 use Spiral\Mailer\MailerInterface;
 use Spiral\Queue\Bootloader\QueueBootloader;
-use Spiral\Queue\HandlerRegistryInterface;
 use Spiral\Queue\QueueConnectionProviderInterface;
 use Spiral\Queue\QueueRegistry;
 use Spiral\SendIt\Config\MailerConfig;
@@ -19,11 +18,12 @@ use Spiral\SendIt\MailQueue;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface as SymfonyMailer;
 use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 
 /**
  * Enables email sending pipeline.
  */
-final class MailerBootloader extends Bootloader
+class MailerBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         QueueBootloader::class,
@@ -33,6 +33,7 @@ final class MailerBootloader extends Bootloader
     protected const SINGLETONS = [
         MailJob::class => MailJob::class,
         SymfonyMailer::class => [self::class, 'mailer'],
+        TransportInterface::class => [self::class, 'initTransport']
     ];
 
     public function __construct(
@@ -63,10 +64,13 @@ final class MailerBootloader extends Bootloader
         $container->get(QueueRegistry::class)->setHandler(MailQueue::JOB_NAME, MailJob::class);
     }
 
-    public function mailer(MailerConfig $config): SymfonyMailer
+    public function initTransport(MailerConfig $config): TransportInterface
     {
-        return new Mailer(
-            Transport::fromDsn($config->getDSN())
-        );
+        return Transport::fromDsn($config->getDSN());
+    }
+
+    public function mailer(TransportInterface $transport): SymfonyMailer
+    {
+        return new Mailer($transport);
     }
 }

--- a/tests/Framework/Bootloader/SendIt/MailerBootloaderTest.php
+++ b/tests/Framework/Bootloader/SendIt/MailerBootloaderTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Framework\Bootloader\SendIt;
 
 use Spiral\Mailer\MailerInterface;
+use Spiral\SendIt\Bootloader\MailerBootloader;
 use Spiral\SendIt\Config\MailerConfig;
 use Spiral\SendIt\MailJob;
 use Spiral\SendIt\MailQueue;
 use Spiral\Tests\Framework\BaseTest;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface as SymfonyMailer;
+use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 
 final class MailerBootloaderTest extends BaseTest
 {
@@ -20,6 +23,16 @@ final class MailerBootloaderTest extends BaseTest
         'MAILER_FROM' => 'Testing <testing@local.host>',
         'MAILER_QUEUE_CONNECTION' => 'sync',
     ];
+
+    public function testBootloaderIsNotFinal(): void
+    {
+        $class = new \ReflectionClass(MailerBootloader::class);
+
+        /**
+         * {@see https://github.com/spiral/framework/pull/683}
+         */
+        $this->assertFalse($class->isFinal(), 'MailerBootloader should not be final.');
+    }
 
     public function testMailJobBinding(): void
     {
@@ -34,6 +47,11 @@ final class MailerBootloaderTest extends BaseTest
     public function testMailerInterfaceBinding(): void
     {
         $this->assertContainerBoundAsSingleton(MailerInterface::class, MailQueue::class);
+    }
+
+    public function testTransportInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(TransportInterface::class, SmtpTransport::class);
     }
 
     public function testConfig(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #683

```php

use Spiral\Boot\Bootloader\Bootloader;
use Symfony\Component\Mailer\Transport\TransportInterface;
use Symfony\Component\Mailer\Transport\RoundRobinTransport;
use Symfony\Component\Mailer\Transport;

class AppBootloader extends Bootloader
{
    protected const SINGLETONS = [
        TransportInterface::class => [self::class, 'initTransport']
    ];

    public function initTransport(MailerConfig $config): TransportInterface
    {
        $transports = [];

        foreach($config->getDsns() as $dsn) {
            $transports[] = Transport::fromDsn($dsn);
        }

        return new RoundRobinTransport(
            $transports
        );
    }
}

```