### PR TITLE
Fix Psalm in ValidationProvider

### DIFF
--- a/src/Filters/src/Model/FilterDefinitionInterface.php
+++ b/src/Filters/src/Model/FilterDefinitionInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Filters\Model;
 
+/**
+ * @template TFilterDefinition of FilterDefinitionInterface
+ */
 interface FilterDefinitionInterface
 {
     /**

--- a/src/Validation/src/ValidationProvider.php
+++ b/src/Validation/src/ValidationProvider.php
@@ -10,6 +10,7 @@ use Spiral\Validation\Exception\ValidationException;
 
 /**
  * @template TValidation of ValidationInterface
+ * @template TFilterDefinition
  */
 final class ValidationProvider implements ValidationProviderInterface, SingletonInterface
 {
@@ -22,7 +23,7 @@ final class ValidationProvider implements ValidationProviderInterface, Singleton
     }
 
     /**
-     * @param class-string<TValidation> $name
+     * @param class-string<TFilterDefinition> $name
      */
     public function register(string $name, \Closure $resolver): void
     {

--- a/src/Validation/src/ValidationProviderInterface.php
+++ b/src/Validation/src/ValidationProviderInterface.php
@@ -6,12 +6,13 @@ namespace Spiral\Validation;
 
 /**
  * @template TValidation
+ * @template TFilterDefinition
  */
 interface ValidationProviderInterface
 {
     /**
      * Get validation object by name.
-     * @param class-string<TValidation> $name
+     * @param class-string<TFilterDefinition> $name
      * @psalm-return TValidation
      */
     public function getValidation(string $name, array $params = []): ValidationInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌

The `$name` parameter in the `register` and `getValidation` methods of the `ValidationProvider` class is an implementation of the `FilterDefinitionInterface`, not a `ValidationInterface`.

