### PR TITLE
Fixing symfony/console version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "psr/simple-cache": "2 - 3",
         "spiral/attributes": "^2.8|^3.0",
         "spiral/composer-publish-plugin": "^1.0",
-        "symfony/console": "^5.3.7|^6.0",
+        "symfony/console": "^6.0",
         "symfony/finder": "^5.3.7|^6.0",
         "symfony/mailer": "^5.1|^6.0",
         "symfony/translation": "^5.1|^6.0",

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -31,7 +31,7 @@
         "spiral/core": "^3.1",
         "spiral/hmvc": "^3.1",
         "spiral/tokenizer": "^3.1",
-        "symfony/console": "^5.3.7|^6.0",
+        "symfony/console": "^6.0",
         "spiral/events": "^3.1"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

The minimum `symfony/console` version must be `6.0`. The versions below are don't have types and not compatible with our code. Tests crash with `--prefer-lowest`.

