### PR TITLE
Moving ClassesInterface into a callback function

### DIFF
--- a/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
@@ -31,9 +31,9 @@ final class TokenizerListenerBootloader extends Bootloader implements
         $this->listeners[] = $listener;
     }
 
-    public function boot(AbstractKernel $kernel, ClassesInterface $classes): void
+    public function boot(AbstractKernel $kernel): void
     {
-        $kernel->bootstrapped(function () use ($classes): void {
+        $kernel->bootstrapped(function (ClassesInterface $classes): void {
             foreach ($classes->getClasses() as $class) {
                 $this->invokeListeners($class);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

The `ClassesInterface` implementation is created when the `boot` method is called, and it requires a `TokenizerConfig`.
If we move this class into a `callback function`, then the class will be requested when the event callback function is called.
