### PR TITLE
Removing readonly from Bundle

### DIFF
--- a/src/Stempler/src/Transform/Import/Bundle.php
+++ b/src/Stempler/src/Transform/Import/Bundle.php
@@ -20,8 +20,8 @@ final class Bundle implements ImportInterface
     private ?Template $template = null;
 
     public function __construct(
-        private readonly string $path,
-        private readonly ?string $prefix = null,
+        private string $path,
+        private ?string $prefix = null,
         Context $context = null
     ) {
         $this->context = $context;

--- a/src/Stempler/tests/Transform/MergerTest.php
+++ b/src/Stempler/tests/Transform/MergerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Stempler\Transform;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Stempler\Node\HTML\Tag;
+use Spiral\Stempler\Node\Template;
+use Spiral\Stempler\Transform\Import\Bundle;
+use Spiral\Stempler\Transform\Merger;
+
+final class MergerTest extends TestCase
+{
+    public function testMergeWithBundle(): void
+    {
+        $merger = new Merger();
+
+        $template = $merger->merge(new Template([new Bundle('/')]), new Tag());
+
+        $this->assertCount(1, $template->nodes);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

There is an error with the readonly:
`Error: Cannot modify readonly property Spiral\Stempler\Transform\Import\Bundle::$path`