### PR TITLE
Fixes the problem with parsing a pattern

### DIFF
--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -119,7 +119,7 @@ final class UriHandler
         }
 
         $matches = \array_intersect_key(
-            \array_filter($matches, static fn(string $value) => $value !== ''),
+            \array_filter($matches, static fn (string $value) => $value !== ''),
             $this->options
         );
 

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -118,7 +118,10 @@ final class UriHandler
             return null;
         }
 
-        $matches = \array_intersect_key(\array_filter($matches), $this->options);
+        $matches = \array_intersect_key(
+            \array_filter($matches, static fn(string $value) => $value !== ''),
+            $this->options
+        );
 
         return \array_merge($this->options, $defaults, $matches);
     }

--- a/src/Router/tests/PatternsTests.php
+++ b/src/Router/tests/PatternsTests.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router;
+
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
+use Spiral\Router\Route;
+use Spiral\Router\UriHandler;
+use Spiral\Tests\Router\Diactoros\UriFactory;
+
+class PatternsTests extends TestCase
+{
+    public function testDigitWithZeroValue(): void
+    {
+        $route = new Route(
+            '/statistics/set/<moduleType:\d+>/<moduleId:\d+>/<type:\d+>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(new ServerRequest('GET', new Uri('http://site.com/statistics/set/10/285/0')));
+
+        $this->assertSame([
+            'moduleType' => '10',
+            'moduleId' => '285',
+            'type' => '0'
+        ], $match->getMatches());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️

Fixes the problem with parsing a pattern `/statistics/set/<moduleType:\d+>/<moduleId:\d+>/<type:\d+>` when digit is zero `/statistics/set/10/285/0`
