### PR TITLE
Adds ValidationHandlerMiddleware for handling filter validation exception.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
-## v3.0.0 - Unreleased
+## Unreleased
+- **High Impact Changes**
+- **Medium Impact Changes**
+- **Other Features**
+  - [spiral/filters] Added `Spiral\Filter\ValidationHandlerMiddleware` for handling filter validation exception.
+  - [spiral/router] Fixed the problem with parsing a pattern with `0` value in route parameter.
+
+## v3.0.0 - 2022-09-13
 - **High Impact Changes**
   - Component `spiral/data-grid-bridge` is removed from `spiral/framework` repository.
     Please, use standalone package `spiral/data-grid-bridge` instead.

--- a/src/Filters/src/ErrorMapper.php
+++ b/src/Filters/src/ErrorMapper.php
@@ -13,6 +13,10 @@ final class ErrorMapper
     ) {
     }
 
+    /**
+     * @param array<string, string> $errors
+     * @return array<string, string>
+     */
     public function mapErrors(array $errors): array
     {
         // De-mapping

--- a/src/Filters/src/ErrorsRendererInterface.php
+++ b/src/Filters/src/ErrorsRendererInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Filters;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface ErrorsRendererInterface
+{
+    /**
+     * Convert errors into a response object.
+     * @param array<string, string> $errors
+     */
+    public function render(array $errors, mixed $context = null): ResponseInterface;
+}

--- a/src/Framework/Filter/JsonErrorsRenderer.php
+++ b/src/Framework/Filter/JsonErrorsRenderer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Filter;
+
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Filters\ErrorsRendererInterface;
+use Spiral\Http\ResponseWrapper;
+
+final class JsonErrorsRenderer implements ErrorsRendererInterface
+{
+    public function __construct(
+        private readonly ResponseWrapper $wrapper
+    ) {
+    }
+
+    public function render(array $errors, mixed $context = null): ResponseInterface
+    {
+        return $this->wrapper->json([
+            'errors' => $errors,
+        ])
+            ->withStatus(422, 'The given data was invalid.');
+    }
+}

--- a/src/Framework/Filter/ValidationHandlerMiddleware.php
+++ b/src/Framework/Filter/ValidationHandlerMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Filter;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Filters\ErrorsRendererInterface;
+
+final class ValidationHandlerMiddleware implements MiddlewareInterface
+{
+    protected ErrorsRendererInterface $renderErrors;
+
+    /**
+     * @param ErrorsRendererInterface|null $renderErrors Renderer for all filter errors.
+     *        By default, will be used {@see JsonErrorsRenderer}
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __construct(
+        ContainerInterface $container,
+        ?ErrorsRendererInterface $renderErrors = null
+    ) {
+        $this->renderErrors = $renderErrors ?? $container->get(JsonErrorsRenderer::class);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        try {
+            return $handler->handle($request);
+        } catch (ValidationException $e) {
+            return $this->renderErrors->render($e->errors, $e->context);
+        }
+    }
+}

--- a/src/Http/src/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Http/src/Middleware/ErrorHandlerMiddleware.php
@@ -77,6 +77,7 @@ final class ErrorHandlerMiddleware implements MiddlewareInterface
                 format: $format
             )
         );
+
         return $response;
     }
 

--- a/tests/Framework/Filter/JsonErrorsRendererTest.php
+++ b/tests/Framework/Filter/JsonErrorsRendererTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Filter;
+
+use Spiral\Filter\JsonErrorsRenderer;
+use Spiral\Http\ResponseWrapper;
+use Spiral\Tests\Framework\BaseTest;
+
+final class JsonErrorsRendererTest extends BaseTest
+{
+    public function testRender(): void
+    {
+        $renderer = new JsonErrorsRenderer(
+            $this->getContainer()->get(ResponseWrapper::class)
+        );
+
+        $response = $renderer->render(
+            ['foo' => 'bar',],
+            'foo_context'
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('The given data was invalid.', $response->getReasonPhrase());
+        $this->assertSame(
+            '{"errors":{"foo":"bar"}}',
+            (string) $response->getBody()
+        );
+    }
+}

--- a/tests/Framework/Filter/ValidationHandlerMiddlewareTest.php
+++ b/tests/Framework/Filter/ValidationHandlerMiddlewareTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Filter;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Filter\JsonErrorsRenderer;
+use Spiral\Filter\ValidationHandlerMiddleware;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Filters\ErrorsRendererInterface;
+
+final class ValidationHandlerMiddlewareTest extends TestCase
+{
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    private ValidationHandlerMiddleware $middleware;
+    private ErrorsRendererInterface|m\MockInterface $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = m::mock(ContainerInterface::class);
+        $this->renderer = m::mock(ErrorsRendererInterface::class);
+
+        $this->middleware = new ValidationHandlerMiddleware(
+            $container, $this->renderer
+        );
+    }
+
+    public function testDefaultRendererShouldBeUsed(): void
+    {
+        $container = m::mock(ContainerInterface::class);
+
+        $container->shouldReceive('get')
+            ->once()
+            ->with(JsonErrorsRenderer::class)
+            ->andReturn($this->renderer);
+
+        new ValidationHandlerMiddleware($container);
+    }
+
+    public function testRequestWithoutValidationExceptionShouldBeProcessed(): void
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $handler = m::mock(RequestHandlerInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with($request)
+            ->andReturn($response = m::mock(ResponseInterface::class));
+
+        $this->assertSame(
+            $response,
+            $this->middleware->process($request, $handler)
+        );
+    }
+
+    public function testRequestWithNonValidationExceptionShouldThrowIt(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $request = m::mock(ServerRequestInterface::class);
+        $handler = m::mock(RequestHandlerInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->andThrow(new \Exception('something went wrong'));
+
+
+        $this->middleware->process($request, $handler);
+    }
+
+    public function testRequestWithValidationExceptionShouldBeProcessedByRenderer(): void
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $handler = m::mock(RequestHandlerInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->andThrow(new ValidationException($errors = [
+                'foo' => 'bar'
+            ], $context = 'foo_context'));
+
+        $this->renderer->shouldReceive('render')
+            ->once()
+            ->with($errors, $context)
+            ->andReturn($response = m::mock(ResponseInterface::class));
+
+        $this->assertSame(
+            $response,
+            $this->middleware->process($request, $handler)
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ✔️

Now you can handle filter validation exception via `Spiral\Filter\ValidationHandlerMiddleware` middleware.

By default, the middleware uses `Spiral\Filter\JsonErrorsRenderer` for rendering filter errors, but you can use your own implementation.


```php
<?php

declare(strict_types=1);

namespace Spiral\Filter;

use Psr\Http\Message\ResponseInterface;
use Spiral\Filters\ErrorsRendererInterface;
use Spiral\Http\ResponseWrapper;

final class CustomJsonErrorsRenderer implements ErrorsRendererInterface
{
    public function __construct(
        private readonly ResponseWrapper $wrapper
    ) {
    }

    public function render(array $errors, mixed $context = null): ResponseInterface
    {
        return $this->wrapper->json([
            'errors' => $errors,
            'context' => (string) $context
        ])
            ->withStatus(422, 'The given data was invalid.');
    }
}
```

And then register it via Bootloader

```php
use Spiral\Boot\Bootloader\Bootloader;

class AppBootloader extends Bootloader
{
    protected const SINGLETONS = [
        \Spiral\Filters\ErrorsRendererInterface::class => CustomJsonErrorsRenderer::class,
    ];
}
```