### PR TITLE
Added the ability to configure default validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v3.1.0 - Unreleased
+## Unreleased
 - **High Impact Changes**     
 - **Medium Impact Changes**
 - **Other Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
-## v3.0.0 - Unreleased
+## v3.1.0 - Unreleased
+- **High Impact Changes**     
+- **Medium Impact Changes**
+- **Other Features**
+  - [spiral/validation] Added the ability to configure the default validator via method `setDefaultValidator` 
+    in the `Spiral\Validation\Bootloader\ValidationBootloader`.
+
+## v3.0.0 - 2022-09-13
 - **High Impact Changes**
   - Component `spiral/data-grid-bridge` is removed from `spiral/framework` repository.
     Please, use standalone package `spiral/data-grid-bridge` instead.

--- a/src/Validation/src/Bootloader/ValidationBootloader.php
+++ b/src/Validation/src/Bootloader/ValidationBootloader.php
@@ -21,7 +21,7 @@ final class ValidationBootloader extends Bootloader implements SingletonInterfac
 {
     protected const SINGLETONS = [
         ValidationProviderInterface::class => ValidationProvider::class,
-        ValidationInterface::class => [self::class, 'initDefaultValidator']
+        ValidationInterface::class => [self::class, 'initDefaultValidator'],
     ];
 
     public function __construct(

--- a/src/Validation/src/Bootloader/ValidationBootloader.php
+++ b/src/Validation/src/Bootloader/ValidationBootloader.php
@@ -5,13 +5,58 @@ declare(strict_types=1);
 namespace Spiral\Validation\Bootloader;
 
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Set;
 use Spiral\Core\Container\SingletonInterface;
+use Spiral\Validation\Config\ValidationConfig;
+use Spiral\Validation\Exception\ValidationException;
+use Spiral\Validation\ValidationInterface;
 use Spiral\Validation\ValidationProvider;
 use Spiral\Validation\ValidationProviderInterface;
 
+/**
+ * @template TFilterDefinition
+ */
 final class ValidationBootloader extends Bootloader implements SingletonInterface
 {
     protected const SINGLETONS = [
         ValidationProviderInterface::class => ValidationProvider::class,
+        ValidationInterface::class => [self::class, 'initDefaultValidator']
     ];
+
+    public function __construct(
+        private readonly ConfiguratorInterface $config
+    ) {
+    }
+
+    public function init(): void
+    {
+        $this->config->setDefaults(ValidationConfig::CONFIG, [
+            'defaultValidator' => null,
+        ]);
+    }
+
+    /**
+     * @param class-string<TFilterDefinition> $name
+     */
+    public function setDefaultValidator(string $name): void
+    {
+        if ($this->config->getConfig(ValidationConfig::CONFIG)['defaultValidator'] === null) {
+            $this->config->modify(ValidationConfig::CONFIG, new Set('defaultValidator', $name));
+        }
+    }
+
+    /**
+     * @noRector RemoveUnusedPrivateMethodRector
+     */
+    private function initDefaultValidator(
+        ValidationConfig $config,
+        ValidationProviderInterface $provider
+    ): ValidationInterface {
+        if ($config->getDefaultValidator() === null) {
+            throw new ValidationException('Default Validator is not configured.');
+        }
+
+        return $provider->getValidation($config->getDefaultValidator());
+    }
 }

--- a/src/Validation/src/Config/ValidationConfig.php
+++ b/src/Validation/src/Config/ValidationConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Validation\Config;
+
+use Spiral\Core\InjectableConfig;
+
+final class ValidationConfig extends InjectableConfig
+{
+    public const CONFIG = 'validation';
+
+    protected array $config = [
+        'defaultValidator' => null,
+    ];
+
+    public function getDefaultValidator(): ?string
+    {
+        return $this->config['defaultValidator'] ?? null;
+    }
+}

--- a/src/Validation/src/Config/ValidationConfig.php
+++ b/src/Validation/src/Config/ValidationConfig.php
@@ -16,6 +16,6 @@ final class ValidationConfig extends InjectableConfig
 
     public function getDefaultValidator(): ?string
     {
-        return $this->config['defaultValidator'] ?? null;
+        return $this->config['defaultValidator'];
     }
 }

--- a/src/Validation/tests/Config/ValidationConfigTest.php
+++ b/src/Validation/tests/Config/ValidationConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Validation\Config;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Validation\Config\ValidationConfig;
+
+final class ValidationConfigTest extends TestCase
+{
+    public function testDefaultValidatorIsNotSet(): void
+    {
+        $config = new ValidationConfig();
+
+        $this->assertNull($config->getDefaultValidator());
+    }
+
+    public function testDefaultValidator(): void
+    {
+        $config = new ValidationConfig(['defaultValidator' => 'some']);
+
+        $this->assertSame('some', $config->getDefaultValidator());
+    }
+}

--- a/tests/Framework/Bootloader/Validation/ValidationBootloaderTest.php
+++ b/tests/Framework/Bootloader/Validation/ValidationBootloaderTest.php
@@ -4,14 +4,75 @@ declare(strict_types=1);
 
 namespace Framework\Bootloader\Validation;
 
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Set;
 use Spiral\Tests\Framework\BaseTest;
+use Spiral\Validation\Bootloader\ValidationBootloader;
+use Spiral\Validation\Config\ValidationConfig;
+use Spiral\Validation\Exception\ValidationException;
+use Spiral\Validation\ValidationInterface;
 use Spiral\Validation\ValidationProvider;
 use Spiral\Validation\ValidationProviderInterface;
+use Spiral\Validation\ValidatorInterface;
 
 final class ValidationBootloaderTest extends BaseTest
 {
     public function testValidationProviderInterfaceBinding(): void
     {
         $this->assertContainerBoundAsSingleton(ValidationProviderInterface::class, ValidationProvider::class);
+    }
+
+    public function testValidationInterfaceBinding(): void
+    {
+        $validator = $this->createValidator();
+
+        $this->getContainer()->bind(ValidationConfig::class, new ValidationConfig(['defaultValidator' => 'foo']));
+        $this->getContainer()
+            ->get(ValidationProviderInterface::class)
+            ->register('foo', static fn () => $validator);
+
+        $this->assertContainerBoundAsSingleton(ValidationInterface::class, $validator::class);
+    }
+
+    public function testValidatorIsNotConfigured(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Default Validator is not configured.');
+        $this->getContainer()->get(ValidationInterface::class);
+    }
+
+    public function testSetDefaultValidator(): void
+    {
+        $validator = $this->createValidator();
+        $this->getContainer()
+            ->get(ValidationProviderInterface::class)
+            ->register('bar', static fn () => $validator);
+
+        $bootloader = $this->getContainer()->get(ValidationBootloader::class);
+        $bootloader->setDefaultValidator('bar');
+
+        $this->assertContainerBoundAsSingleton(ValidationInterface::class, $validator::class);
+    }
+
+    public function testSetDefaultValidatorNotOverrideValueInConfig(): void
+    {
+        $this->getContainer()
+            ->get(ConfiguratorInterface::class)
+            ->modify(ValidationConfig::CONFIG, new Set('defaultValidator', 'foo'));
+
+        $bootloader = $this->getContainer()->get(ValidationBootloader::class);
+        $bootloader->setDefaultValidator('bar');
+
+        $this->assertSame('foo', $this->getConfig(ValidationConfig::CONFIG)['defaultValidator']);
+    }
+
+    private function createValidator(): ValidationInterface
+    {
+        return new class implements ValidationInterface
+        {
+            public function validate(object|array $data, array $rules, mixed $context = null): ValidatorInterface
+            {
+            }
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

 Added the ability to configure the default validator via method `setDefaultValidator` in the `Spiral\Validation\Bootloader\ValidationBootloader`.

```php
public function boot(ValidationProvider $provider, ValidationBootloader $validation): void 
{
    $provider->register(
        FilterDefinition::class,
        static fn(Validation $validation): ValidationInterface => $validation
    );

    $validation->setDefaultValidator(FilterDefinition::class);
}
```

Or via the config file (with the highest priority).

```php
// file app/config/validation.php
use Spiral\Validation\Symfony\FilterDefinition;

return [
    'defaultValidator' => FilterDefinition::class
];
```