### PR TITLE
Adding context in the Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+- **High Impact Changes**
+- **Medium Impact Changes**
+- **Other Features**
+  - [spiral/queue] Added the ability to pass additional data in the `context` parameter in the job handlers.
+
 ## v3.1.0 - 2022-09-29
 - **Other Features**
   - [spiral/filters] Added `Spiral\Filter\ValidationHandlerMiddleware` for handling filter validation exception.

--- a/src/Queue/src/Event/JobProcessed.php
+++ b/src/Queue/src/Event/JobProcessed.php
@@ -11,7 +11,8 @@ final class JobProcessed
         public readonly string $driver,
         public readonly string $queue,
         public readonly string $id,
-        public readonly array $payload
+        public readonly array $payload,
+        public readonly array $context = []
     ) {
     }
 }

--- a/src/Queue/src/Event/JobProcessing.php
+++ b/src/Queue/src/Event/JobProcessing.php
@@ -11,7 +11,8 @@ final class JobProcessing
         public readonly string $driver,
         public readonly string $queue,
         public readonly string $id,
-        public readonly array $payload
+        public readonly array $payload,
+        public readonly array $context = []
     ) {
     }
 }

--- a/src/Queue/src/Interceptor/Consume/Core.php
+++ b/src/Queue/src/Interceptor/Consume/Core.php
@@ -15,7 +15,8 @@ use Spiral\Queue\HandlerRegistryInterface;
  *     driver: non-empty-string,
  *     queue: non-empty-string,
  *     id: non-empty-string,
- *     payload: array
+ *     payload: array,
+ *     context: array
  * }
  */
 final class Core implements CoreInterface
@@ -38,6 +39,7 @@ final class Core implements CoreInterface
 
         $this->dispatchEvent(JobProcessing::class, $controller, $parameters);
 
+        /** @psalm-suppress TooManyArguments */
         $this->registry
             ->getHandler($controller)
             ->handle($controller, $parameters['id'], $parameters['payload'], $parameters['context'] ?? []);
@@ -58,7 +60,8 @@ final class Core implements CoreInterface
             driver: $parameters['driver'],
             queue: $parameters['queue'],
             id: $parameters['id'],
-            payload: $parameters['payload']
+            payload: $parameters['payload'],
+            context: $parameters['context'] ?? []
         ));
     }
 }

--- a/src/Queue/src/Interceptor/Consume/Core.php
+++ b/src/Queue/src/Interceptor/Consume/Core.php
@@ -40,7 +40,7 @@ final class Core implements CoreInterface
 
         $this->registry
             ->getHandler($controller)
-            ->handle($controller, $parameters['id'], $parameters['payload']);
+            ->handle($controller, $parameters['id'], $parameters['payload'], $parameters['context'] ?? []);
 
         $this->dispatchEvent(JobProcessed::class, $controller, $parameters);
 

--- a/src/Queue/src/Interceptor/Consume/Handler.php
+++ b/src/Queue/src/Interceptor/Consume/Handler.php
@@ -13,13 +13,20 @@ final class Handler
     ) {
     }
 
-    public function handle(string $name, string $driver, string $queue, string $id, array $payload): mixed
-    {
+    public function handle(
+        string $name,
+        string $driver,
+        string $queue,
+        string $id,
+        array $payload,
+        array $context = []
+    ): mixed {
         return $this->core->callAction($name, 'handle', [
             'driver' => $driver,
             'queue' => $queue,
             'id' => $id,
             'payload' => $payload,
+            'context' => $context,
         ]);
     }
 }

--- a/src/Queue/src/Job/CallableJob.php
+++ b/src/Queue/src/Job/CallableJob.php
@@ -15,7 +15,7 @@ final class CallableJob implements HandlerInterface
     ) {
     }
 
-    public function handle(string $name, string $id, array $payload): void
+    public function handle(string $name, string $id, array $payload, array $context = []): void
     {
         if (!isset($payload['callback'])) {
             throw new InvalidArgumentException('Payload `callback` key is required.');
@@ -30,6 +30,7 @@ final class CallableJob implements HandlerInterface
             [
                 'name' => $name,
                 'id' => $id,
+                'context' => $context,
             ]
         );
     }

--- a/src/Queue/src/Job/ObjectJob.php
+++ b/src/Queue/src/Job/ObjectJob.php
@@ -32,7 +32,7 @@ final class ObjectJob implements HandlerInterface
             [
                 'name' => $name,
                 'id' => $id,
-                'context' => $context
+                'context' => $context,
             ]
         );
     }

--- a/src/Queue/src/Job/ObjectJob.php
+++ b/src/Queue/src/Job/ObjectJob.php
@@ -15,7 +15,7 @@ final class ObjectJob implements HandlerInterface
     ) {
     }
 
-    public function handle(string $name, string $id, array $payload): void
+    public function handle(string $name, string $id, array $payload, array $context = []): void
     {
         if (!isset($payload['object'])) {
             throw new InvalidArgumentException('Payload `object` key is required.');
@@ -32,6 +32,7 @@ final class ObjectJob implements HandlerInterface
             [
                 'name' => $name,
                 'id' => $id,
+                'context' => $context
             ]
         );
     }

--- a/src/Queue/src/JobHandler.php
+++ b/src/Queue/src/JobHandler.php
@@ -22,12 +22,12 @@ abstract class JobHandler implements HandlerInterface
     ) {
     }
 
-    public function handle(string $name, string $id, array $payload): void
+    public function handle(string $name, string $id, array $payload, array $context = []): void
     {
         try {
             $this->invoker->invoke(
                 [$this, $this->getHandlerMethod()],
-                \array_merge(['payload' => $payload, 'id' => $id], $payload)
+                \array_merge(['payload' => $payload, 'id' => $id, 'context' => $context], $payload)
             );
         } catch (\Throwable $e) {
             $message = \sprintf('[%s] %s', $this::class, $e->getMessage());

--- a/src/Queue/tests/Driver/SyncDriverTest.php
+++ b/src/Queue/tests/Driver/SyncDriverTest.php
@@ -42,7 +42,8 @@ final class SyncDriverTest extends TestCase
                 'driver' => 'sync',
                 'queue' => 'default',
                 'id' => $uuid->toString(),
-                'payload' => ['foo' => 'bar']
+                'payload' => ['foo' => 'bar'],
+                'context' => []
             ])
             ->once();
 
@@ -65,7 +66,8 @@ final class SyncDriverTest extends TestCase
                 'driver' => 'sync',
                 'queue' => 'default',
                 'id' => $uuid->toString(),
-                'payload' => ['object' => $object]
+                'payload' => ['object' => $object],
+                'context' => []
             ])
             ->once();
 

--- a/src/Queue/tests/Interceptor/Consume/CoreTest.php
+++ b/src/Queue/tests/Interceptor/Consume/CoreTest.php
@@ -48,8 +48,8 @@ final class CoreTest extends TestCase
             ->method('dispatch')
             ->with(
                 $this->logicalOr(
-                    new JobProcessing('foo', 'bar', 'other', 'id', []),
-                    new JobProcessed('foo', 'bar', 'other', 'id', [])
+                    new JobProcessing('foo', 'bar', 'other', 'id', [], []),
+                    new JobProcessed('foo', 'bar', 'other', 'id', [], [])
                 )
             );
 

--- a/src/Queue/tests/Interceptor/Consume/CoreTest.php
+++ b/src/Queue/tests/Interceptor/Consume/CoreTest.php
@@ -25,7 +25,7 @@ final class CoreTest extends TestCase
             ->andReturn($handler = m::mock(HandlerInterface::class));
 
         $handler->shouldReceive('handle')->once()
-            ->with('foo', 'job-id', ['baz' => 'baf']);
+            ->with('foo', 'job-id', ['baz' => 'baf'], ['foo']);
 
         $core->callAction(
             controller: 'foo',
@@ -35,6 +35,7 @@ final class CoreTest extends TestCase
                 'queue' => 'default',
                 'id' => 'job-id',
                 'payload' => ['baz' => 'baf'],
+                'context' => ['foo']
             ]
         );
     }
@@ -60,7 +61,7 @@ final class CoreTest extends TestCase
         $registry->shouldReceive('getHandler')->with('foo')->once()
             ->andReturn($handler = m::mock(HandlerInterface::class));
         $handler->shouldReceive('handle')->once()
-            ->with('foo', 'id', []);
+            ->with('foo', 'id', [], []);
 
         $core->callAction('foo', 'bar', [
             'driver' => 'bar',

--- a/src/Queue/tests/Interceptor/Consume/HandlerTest.php
+++ b/src/Queue/tests/Interceptor/Consume/HandlerTest.php
@@ -22,8 +22,9 @@ final class HandlerTest extends TestCase
                 'queue' => 'default',
                 'id' => 'job-id',
                 'payload' => ['baz' => 'bar'],
+                'context' => ['some' => 'data'],
             ]);
 
-        $handler->handle('foo', 'sync', 'default', 'job-id', ['baz' => 'bar']);
+        $handler->handle('foo', 'sync', 'default', 'job-id', ['baz' => 'bar'], ['some' => 'data']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added the ability to pass additional data in the `context`:
```php

/** @var Spiral\Queue\Interceptor\Consume\Handler $handler */
$handler = $this->container->get(Handler::class);
 
$handler->handle(
    name: $task->getName(),
    driver: 'roadrunner',
    queue: $task->getQueue(),
    id: $task->getId(),
    payload: $task->getPayload(),
    context: [
        'headers' => $task->getHeaders()
    ]
);
``` 