### PR TITLE
CoreHandler do not mention internal errors in ClientException

### DIFF
--- a/src/Router/src/CoreHandler.php
+++ b/src/Router/src/CoreHandler.php
@@ -153,11 +153,11 @@ final class CoreHandler implements RequestHandlerInterface
     private function mapException(ControllerException $exception): ClientException
     {
         return match ($exception->getCode()) {
-            ControllerException::BAD_ACTION => new NotFoundException($exception->getMessage()),
-            ControllerException::NOT_FOUND => new NotFoundException($exception->getMessage()),
-            ControllerException::FORBIDDEN => new ForbiddenException($exception->getMessage()),
-            ControllerException::UNAUTHORIZED => new UnauthorizedException($exception->getMessage()),
-            default => new BadRequestException($exception->getMessage()),
+            ControllerException::BAD_ACTION,
+            ControllerException::NOT_FOUND => new NotFoundException('Not found', $exception),
+            ControllerException::FORBIDDEN => new ForbiddenException('Forbidden', $exception),
+            ControllerException::UNAUTHORIZED => new UnauthorizedException('Unauthorized', $exception),
+            default => new BadRequestException('Bad request', $exception),
         };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #812 <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

Do not show to end user internal exception error. Also adds previous exception property
