### PR TITLE
Fixing RR mode checking

### DIFF
--- a/src/Framework/Console/ConsoleDispatcher.php
+++ b/src/Framework/Console/ConsoleDispatcher.php
@@ -33,7 +33,7 @@ final class ConsoleDispatcher implements DispatcherInterface
     public function canServe(): bool
     {
         // only run in pure CLI more, ignore under RoadRunner
-        return (PHP_SAPI === 'cli' && $this->env->get('RR') === null);
+        return (PHP_SAPI === 'cli' && $this->env->get('RR_MODE') === null);
     }
 
     public function serve(InputInterface $input = null, OutputInterface $output = null): int

--- a/tests/Framework/Dispatcher/ConsoleDispatcherTest.php
+++ b/tests/Framework/Dispatcher/ConsoleDispatcherTest.php
@@ -21,7 +21,7 @@ final class ConsoleDispatcherTest extends BaseTest
 
     public function testCanNotServe(): void
     {
-        $this->initApp(['RR' => true]);
+        $this->initApp(['RR_MODE' => 'http']);
         $this->assertDispatcherCannotBeServed(ConsoleDispatcher::class);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

RR is always `null`. Replaced by checking the variable `RR_MODE`.