### PR TITLE
Adding Events interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Medium Impact Changes**
 - **Other Features**
   - [spiral/queue] Added the ability to pass headers in the `headers` parameter in the job handlers.
+  - [spiral/events] Added event interceptors.
 
 ## v3.1.0 - 2022-09-29
 - **Other Features**

--- a/src/Events/src/Bootloader/EventsBootloader.php
+++ b/src/Events/src/Bootloader/EventsBootloader.php
@@ -11,11 +11,17 @@ use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Bootloader\Attributes\AttributesBootloader;
 use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Append;
 use Spiral\Core\Container;
+use Spiral\Core\Container\Autowire;
+use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\FactoryInterface;
+use Spiral\Core\InterceptableCore;
 use Spiral\Events\AutowireListenerFactory;
 use Spiral\Events\Config\EventsConfig;
+use Spiral\Events\EventDispatcher;
 use Spiral\Events\EventDispatcherAwareInterface;
+use Spiral\Events\Interceptor\Core;
 use Spiral\Events\ListenerFactoryInterface;
 use Spiral\Events\ListenerProcessorRegistry;
 use Spiral\Events\Processor\AttributeProcessor;
@@ -23,6 +29,9 @@ use Spiral\Events\Processor\ConfigProcessor;
 use Spiral\Events\Processor\ProcessorInterface;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
 
+/**
+ * @psalm-import-type TInterceptor from EventsConfig
+ */
 final class EventsBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
@@ -48,11 +57,12 @@ final class EventsBootloader extends Bootloader
                 AttributeProcessor::class,
                 ConfigProcessor::class,
             ],
+            'interceptors' => [],
         ]);
     }
 
     public function boot(
-        ContainerInterface $container,
+        Container $container,
         FactoryInterface $factory,
         EventsConfig $config,
         AbstractKernel $kernel,
@@ -60,15 +70,14 @@ final class EventsBootloader extends Bootloader
         FinalizerInterface $finalizer,
         ?EventDispatcherInterface $eventDispatcher = null
     ): void {
+        if ($eventDispatcher !== null) {
+            $this->initEventDispatcher(new Core($eventDispatcher), $config, $container, $factory);
+        }
+
         foreach ($config->getProcessors() as $processor) {
-            if (\is_string($processor)) {
-                $processor = $container->get($processor);
-            } elseif ($processor instanceof Container\Autowire) {
-                $processor = $processor->resolve($factory);
-            }
+            $processor = $this->autowire($processor, $container, $factory);
 
             \assert($processor instanceof ProcessorInterface);
-
             $registry->addProcessor($processor);
         }
 
@@ -79,5 +88,42 @@ final class EventsBootloader extends Bootloader
         if ($finalizer instanceof EventDispatcherAwareInterface && $eventDispatcher !== null) {
             $finalizer->setEventDispatcher($eventDispatcher);
         }
+    }
+
+    /**
+     * @param TInterceptor $interceptor
+     */
+    public function addInterceptor(string|CoreInterceptorInterface|Container\Autowire $interceptor): void
+    {
+        $this->configs->modify(EventsConfig::CONFIG, new Append('interceptors', null, $interceptor));
+    }
+
+    private function initEventDispatcher(
+        Core $core,
+        EventsConfig $config,
+        Container $container,
+        FactoryInterface $factory
+    ): void {
+        $core = new InterceptableCore($core);
+
+        foreach ($config->getInterceptors() as $interceptor) {
+            $interceptor = $this->autowire($interceptor, $container, $factory);
+
+            \assert($interceptor instanceof CoreInterceptorInterface);
+            $core->addInterceptor($interceptor);
+        }
+
+        $container->bindSingleton(EventDispatcherInterface::class, new EventDispatcher($core));
+    }
+
+    private function autowire(string|object $id, ContainerInterface $container, FactoryInterface $factory): object
+    {
+        if (\is_string($id)) {
+            $id = $container->get($id);
+        } elseif ($id instanceof Autowire) {
+            $id = $id->resolve($factory);
+        }
+
+        return $id;
     }
 }

--- a/src/Events/src/Config/EventsConfig.php
+++ b/src/Events/src/Config/EventsConfig.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace Spiral\Events\Config;
 
 use Spiral\Core\Container\Autowire;
+use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\InjectableConfig;
 use Spiral\Events\Processor\ProcessorInterface;
 
 /**
  * @psalm-type TProcessor = ProcessorInterface|class-string<ProcessorInterface>|Autowire<ProcessorInterface>
  * @psalm-type TListener = class-string|EventListener
+ * @psalm-type TInterceptor = class-string<CoreInterceptorInterface>|CoreInterceptorInterface|Autowire<CoreInterceptorInterface>
  * @property array{
  *     processors: TProcessor[],
- *     listeners: array<class-string, TListener[]>
+ *     listeners: array<class-string, TListener[]>,
+ *     interceptors: TInterceptor[]
  * } $config
  */
 final class EventsConfig extends InjectableConfig
@@ -23,6 +26,7 @@ final class EventsConfig extends InjectableConfig
     protected array $config = [
         'processors' => [],
         'listeners' => [],
+        'interceptors' => [],
     ];
 
     /**
@@ -49,6 +53,14 @@ final class EventsConfig extends InjectableConfig
     public function getProcessors(): array
     {
         return $this->config['processors'];
+    }
+
+    /**
+     * @return TInterceptor[]
+     */
+    public function getInterceptors(): array
+    {
+        return $this->config['interceptors'];
     }
 
     /**

--- a/src/Events/src/EventDispatcher.php
+++ b/src/Events/src/EventDispatcher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Events;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Core\CoreInterface;
+
+final class EventDispatcher implements EventDispatcherInterface
+{
+    public function __construct(
+        private readonly CoreInterface $core
+    ) {
+    }
+
+    public function dispatch(object $event): object
+    {
+        return $this->core->callAction($event::class, 'dispatch', ['event' => $event]);
+    }
+}

--- a/src/Events/src/Interceptor/Core.php
+++ b/src/Events/src/Interceptor/Core.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Events\Interceptor;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Core\CoreInterface;
+
+/**
+ * @psalm-type TParameters = array{event: object}
+ */
+final class Core implements CoreInterface
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $dispatcher
+    ) {
+    }
+
+    /**
+     * @param string $controller event name
+     * @param-assert TParameters $parameters
+     */
+    public function callAction(string $controller, string $action, array $parameters = []): object
+    {
+        \assert(\is_object($parameters['event']));
+
+        return $this->dispatcher->dispatch($parameters['event']);
+    }
+}

--- a/src/Events/tests/Config/EventsConfigTest.php
+++ b/src/Events/tests/Config/EventsConfigTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Spiral\Tests\Events\Config;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Core\Container\Autowire;
+use Spiral\Core\CoreInterceptorInterface;
+use Spiral\Core\CoreInterface;
 use Spiral\Events\Config\EventListener;
 use Spiral\Events\Config\EventsConfig;
 
@@ -47,5 +50,31 @@ final class EventsConfigTest extends TestCase
         $this->assertSame($listener, $config->getListeners()['foo'][1]);
         $this->assertInstanceOf(EventListener::class, $config->getListeners()['foo'][0]);
         $this->assertSame('bar', $config->getListeners()['foo'][0]->listener);
+    }
+
+    public function testGetsEmptyInterceptors(): void
+    {
+        $config = new EventsConfig();
+
+        $this->assertSame([], $config->getInterceptors());
+    }
+
+    public function testGetsInterceptors(): void
+    {
+        $config = new EventsConfig([
+            'interceptors' => [
+                'bar',
+                new class implements CoreInterceptorInterface {
+                    public function process(string $controller, string $action, array $parameters, CoreInterface $core): mixed
+                    {
+                    }
+                },
+                new Autowire('foo')
+            ]
+        ]);
+
+        $this->assertSame('bar', $config->getInterceptors()[0]);
+        $this->assertInstanceOf(CoreInterceptorInterface::class, $config->getInterceptors()[1]);
+        $this->assertInstanceOf(Autowire::class, $config->getInterceptors()[2]);
     }
 }

--- a/src/Events/tests/EventDispatcherTest.php
+++ b/src/Events/tests/EventDispatcherTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Events\Interceptor;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\CoreInterface;
+use Spiral\Events\EventDispatcher;
+
+final class EventDispatcherTest extends TestCase
+{
+    public function testDispatch(): void
+    {
+        $event = new class() {};
+
+        $core = m::mock(CoreInterface::class);
+        $core
+            ->shouldReceive('callAction')
+            ->once()
+            ->with($event::class, 'dispatch', ['event' => $event])
+            ->andReturn($event);
+
+        $dispatcher = new EventDispatcher($core);
+
+        $this->assertSame($event, $dispatcher->dispatch($event));
+    }
+}

--- a/src/Events/tests/Interceptor/CoreTest.php
+++ b/src/Events/tests/Interceptor/CoreTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Events\Interceptor;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Events\Interceptor\Core;
+
+final class CoreTest extends TestCase
+{
+    public function testCallAction(): void
+    {
+        $event = new class() {};
+
+        $dispatcher = m::mock(EventDispatcherInterface::class);
+        $dispatcher
+            ->shouldReceive('dispatch')
+            ->once()
+            ->with($event)
+            ->andReturn($event);
+
+        $core = new Core($dispatcher);
+
+        $this->assertSame($event, $core->callAction('', '', ['event' => $event]));
+    }
+}

--- a/src/Events/tests/Processor/AttributeProcessorTest.php
+++ b/src/Events/tests/Processor/AttributeProcessorTest.php
@@ -22,7 +22,6 @@ use Spiral\Tests\Events\Fixtures\Listener\MethodAttribute;
 use Spiral\Tests\Events\Fixtures\Listener\MethodAttributeWithParameters;
 use Spiral\Tests\Events\Stub\PlainListenerRegistry;
 use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
-use Spiral\Events\Attribute;
 
 final class AttributeProcessorTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added the ability to use `Interceptors` in the `Events`. They will be called when the `dispatch` method is called from the `EventDispatcher`. In the interceptor, it is possible to receive an `event object`.

An interceptor can be added using a `config file`:

```php
use App\Interceptor\SomeInterceptor;
use Spiral\Core\Container\Autowire;

return [
    'interceptors' => [
        // via fully classified class name
        SomeInterceptor::class,

        // via autowire
        new Autowire(SomeInterceptor::class),
        
        // via object instance
        new SomeInterceptor()
    ]
];
```

Or via `Spiral\Events\Bootloader\EventsBootloader`:

```php
namespace App\Bootloader;

use App\Interceptor\SomeInterceptor;
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Core\Container\Autowire;
use Spiral\Events\Bootloader\EventsBootloader;

final class MyBootloader extends Bootloader
{
    public function init(EventsBootloader $events): void
    {
        // via fully classified class name
        $events->addInterceptor(SomeInterceptor::class);

        // via autowire
        $events->addInterceptor(new Autowire(SomeInterceptor::class));
        
        // via object instance
        $events->addInterceptor(new SomeInterceptor());
    }
}
```
