### PR TITLE
Changing where Tokenizer listener events are called

### DIFF
--- a/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
@@ -33,7 +33,7 @@ final class TokenizerListenerBootloader extends Bootloader implements
 
     public function boot(AbstractKernel $kernel): void
     {
-        $kernel->bootstrapped(function (ClassesInterface $classes): void {
+        $kernel->booted(function (ClassesInterface $classes): void {
             foreach ($classes->getClasses() as $class) {
                 $this->invokeListeners($class);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌

Sometimes need to have an event where the result of executing the Tokenizer listeners is already available. If are called listeners in the last event, this is not possible.
