### PR TITLE
Router improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+- **High Impact Changes**
+- **Medium Impact Changes**
+- **Other Features**
+- [spiral/router] Added the ability to add a `prefix` to the `name` of all routes in a **group**.
+
 ## 3.2.0 - 2022-10-21
 - **High Impact Changes**
 - **Medium Impact Changes**

--- a/src/AnnotatedRoutes/src/Annotation/Route.php
+++ b/src/AnnotatedRoutes/src/Annotation/Route.php
@@ -26,6 +26,9 @@ use Spiral\Attributes\NamedArgumentConstructor;
 #[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
 final class Route
 {
+    /**
+     * @deprecated Deprecated since v3.3.0.
+     */
     public const DEFAULT_GROUP = 'web';
 
     /**
@@ -40,7 +43,7 @@ final class Route
         public readonly ?string $name = null,
         public readonly array|string $methods = \Spiral\Router\Route::VERBS,
         public readonly array $defaults = [],
-        public readonly string $group = self::DEFAULT_GROUP,
+        public readonly ?string $group = null,
         public readonly array $middleware = [],
         public readonly int $priority = 0
     ) {

--- a/src/AnnotatedRoutes/src/RouteLocatorListener.php
+++ b/src/AnnotatedRoutes/src/RouteLocatorListener.php
@@ -37,8 +37,9 @@ final class RouteLocatorListener implements TokenizationListenerInterface
 
     public function finalize(): void
     {
-        $routes = [];
+        $defaultGroup = $this->groups->getDefaultGroup();
 
+        $routes = [];
         foreach ($this->attributes as $classes) {
             [$method, $route] = $classes;
             $class = $method->getDeclaringClass();
@@ -47,7 +48,7 @@ final class RouteLocatorListener implements TokenizationListenerInterface
                 'pattern' => $route->route,
                 'controller' => $class->getName(),
                 'action' => $method->getName(),
-                'group' => $route->group,
+                'group' => $route->group ?? $defaultGroup,
                 'verbs' => (array)$route->methods,
                 'defaults' => $route->defaults,
                 'middleware' => $route->middleware,

--- a/src/AnnotatedRoutes/tests/App/Controller/HomeController.php
+++ b/src/AnnotatedRoutes/tests/App/Controller/HomeController.php
@@ -11,7 +11,7 @@ class HomeController
     /**
      * @Route(route="/", name="index", methods="GET")
      */
-    public function index()
+    public function index(): string
     {
         return 'index';
     }
@@ -19,13 +19,13 @@ class HomeController
     /**
      * @Route(route="/", name="method", methods="POST")
      */
-    public function method()
+    public function method(): string
     {
         return 'method';
     }
 
     #[Route(route: '/attribute', name: 'attribute', methods: 'GET', group: 'test')]
-    public function attribute()
+    public function attribute(): string
     {
         return 'attribute';
     }

--- a/src/AnnotatedRoutes/tests/RouteLocatorListenerTest.php
+++ b/src/AnnotatedRoutes/tests/RouteLocatorListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\UriFactoryInterface;
+use Spiral\Attributes\Factory;
+use Spiral\Core\Container;
+use Spiral\Router\GroupRegistry;
+use Spiral\Router\RouteLocatorListener;
+use Spiral\Router\Router;
+use Spiral\Router\RouterInterface;
+use Spiral\Router\UriHandler;
+use Spiral\Tests\Router\App\Controller\PageController;
+
+final class RouteLocatorListenerTest extends TestCase
+{
+    private RouteLocatorListener $listener;
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        $this->configureRouter();
+    }
+
+    public function testDefaultGroup(): void
+    {
+        $this->listener->listen(new \ReflectionClass(PageController::class));
+        $this->listener->finalize();
+
+        $groups = $this->container->get(GroupRegistry::class);
+
+        $this->assertSame(['web'], \array_keys(\iterator_to_array($groups)));
+    }
+
+    public function testChangedDefaultGroup(): void
+    {
+        $groups = $this->container->get(GroupRegistry::class);
+        $groups->setDefaultGroup('other');
+
+        $this->listener->listen(new \ReflectionClass(PageController::class));
+        $this->listener->finalize();
+
+        $groups = $this->container->get(GroupRegistry::class);
+
+        $this->assertSame(['other'], \array_keys(\iterator_to_array($groups)));
+    }
+
+    private function configureRouter(): void
+    {
+        $this->container = new Container();
+
+        $this->container->bindSingleton(UriFactoryInterface::class, new Psr17Factory());
+        $this->container->bindSingleton(RouterInterface::class, static function (UriHandler $handler, Container $container) {
+            return new Router('/', $handler, $container);
+        });
+        $this->container->bindSingleton(GroupRegistry::class, new GroupRegistry($this->container));
+
+        $this->listener = new RouteLocatorListener(
+            (new Factory())->create(),
+            $this->container->get(GroupRegistry::class)
+        );
+    }
+}

--- a/src/Framework/Bootloader/Http/RouterBootloader.php
+++ b/src/Framework/Bootloader/Http/RouterBootloader.php
@@ -55,14 +55,19 @@ final class RouterBootloader extends Bootloader
 
     public function boot(AbstractKernel $kernel): void
     {
+        $configuratorCallback = static function (RouterInterface $router, RoutingConfigurator $routes): void {
+            $router->import($routes);
+        };
+        $groupsCallback = static function (GroupRegistry $groups): void {
+            $groups->registerRoutes();
+        };
+
         if ($kernel instanceof Kernel) {
-            $kernel->appBooted(static function (RouterInterface $router, RoutingConfigurator $routes): void {
-                $router->import($routes);
-            });
+            $kernel->appBooted($configuratorCallback);
+            $kernel->appBooted($groupsCallback);
         } else {
-            $kernel->booted(static function (RouterInterface $router, RoutingConfigurator $routes): void {
-                $router->import($routes);
-            });
+            $kernel->booted($configuratorCallback);
+            $kernel->booted($groupsCallback);
         }
     }
 

--- a/src/Framework/Bootloader/Http/RouterBootloader.php
+++ b/src/Framework/Bootloader/Http/RouterBootloader.php
@@ -58,8 +58,8 @@ final class RouterBootloader extends Bootloader
         $configuratorCallback = static function (RouterInterface $router, RoutingConfigurator $routes): void {
             $router->import($routes);
         };
-        $groupsCallback = static function (GroupRegistry $groups): void {
-            $groups->registerRoutes();
+        $groupsCallback = static function (RouterInterface $router, GroupRegistry $groups): void {
+            $groups->registerRoutes($router);
         };
 
         if ($kernel instanceof Kernel) {

--- a/src/Framework/Bootloader/Http/RoutesBootloader.php
+++ b/src/Framework/Bootloader/Http/RoutesBootloader.php
@@ -7,10 +7,8 @@ namespace Spiral\Bootloader\Http;
 use Psr\Http\Server\MiddlewareInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\BinderInterface;
-use Spiral\Http\Pipeline;
 use Spiral\Router\GroupRegistry;
 use Spiral\Router\Loader\Configurator\RoutingConfigurator;
-use Spiral\Router\PipelineFactory;
 
 abstract class RoutesBootloader extends Bootloader
 {
@@ -23,10 +21,7 @@ abstract class RoutesBootloader extends Bootloader
 
     public function boot(RoutingConfigurator $routes, BinderInterface $binder, GroupRegistry $groups): void
     {
-        $middlewareGroups = $this->middlewareGroups();
-
-        $this->registerMiddlewareGroups($binder, $middlewareGroups);
-        $this->registerMiddlewareForRouteGroups($groups, \array_keys($middlewareGroups));
+        $this->registerMiddlewareForRouteGroups($groups, $this->middlewareGroups());
 
         $this->configureRouteGroups($groups);
         $this->defineRoutes($routes);
@@ -56,22 +51,12 @@ abstract class RoutesBootloader extends Bootloader
      */
     abstract protected function middlewareGroups(): array;
 
-    private function registerMiddlewareGroups(BinderInterface $binder, array $groups): void
-    {
-        foreach ($groups as $group => $middleware) {
-            $binder->bind(
-                'middleware:' . $group,
-                static function (PipelineFactory $factory) use ($middleware): Pipeline {
-                    return $factory->createWithMiddleware($middleware);
-                }
-            );
-        }
-    }
-
     private function registerMiddlewareForRouteGroups(GroupRegistry $registry, array $groups): void
     {
-        foreach ($groups as $group) {
-            $registry->getGroup($group)->addMiddleware('middleware:' . $group);
+        foreach ($groups as $group => $middlewares) {
+            foreach ($middlewares as $middleware) {
+                $registry->getGroup($group)->addMiddleware($middleware);
+            }
         }
     }
 }

--- a/src/Framework/Bootloader/Http/RoutesBootloader.php
+++ b/src/Framework/Bootloader/Http/RoutesBootloader.php
@@ -7,8 +7,10 @@ namespace Spiral\Bootloader\Http;
 use Psr\Http\Server\MiddlewareInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\BinderInterface;
+use Spiral\Http\Pipeline;
 use Spiral\Router\GroupRegistry;
 use Spiral\Router\Loader\Configurator\RoutingConfigurator;
+use Spiral\Router\PipelineFactory;
 
 abstract class RoutesBootloader extends Bootloader
 {
@@ -21,7 +23,10 @@ abstract class RoutesBootloader extends Bootloader
 
     public function boot(RoutingConfigurator $routes, BinderInterface $binder, GroupRegistry $groups): void
     {
-        $this->registerMiddlewareForRouteGroups($groups, $this->middlewareGroups());
+        $middlewareGroups = $this->middlewareGroups();
+
+        $this->registerMiddlewareGroups($binder, $middlewareGroups);
+        $this->registerMiddlewareForRouteGroups($groups, \array_keys($middlewareGroups));
 
         $this->configureRouteGroups($groups);
         $this->defineRoutes($routes);
@@ -51,12 +56,22 @@ abstract class RoutesBootloader extends Bootloader
      */
     abstract protected function middlewareGroups(): array;
 
+    private function registerMiddlewareGroups(BinderInterface $binder, array $groups): void
+    {
+        foreach ($groups as $group => $middleware) {
+            $binder->bind(
+                'middleware:' . $group,
+                static function (PipelineFactory $factory) use ($middleware): Pipeline {
+                    return $factory->createWithMiddleware($middleware);
+                }
+            );
+        }
+    }
+
     private function registerMiddlewareForRouteGroups(GroupRegistry $registry, array $groups): void
     {
-        foreach ($groups as $group => $middlewares) {
-            foreach ($middlewares as $middleware) {
-                $registry->getGroup($group)->addMiddleware($middleware);
-            }
+        foreach ($groups as $group) {
+            $registry->getGroup($group)->addMiddleware('middleware:' . $group);
         }
     }
 }

--- a/src/Framework/Bootloader/Http/RoutesBootloader.php
+++ b/src/Framework/Bootloader/Http/RoutesBootloader.php
@@ -28,6 +28,7 @@ abstract class RoutesBootloader extends Bootloader
         $this->registerMiddlewareGroups($binder, $middlewareGroups);
         $this->registerMiddlewareForRouteGroups($groups, \array_keys($middlewareGroups));
 
+        $this->configureRouteGroups($groups);
         $this->defineRoutes($routes);
     }
 
@@ -35,6 +36,13 @@ abstract class RoutesBootloader extends Bootloader
      * Override this method to configure application routes
      */
     protected function defineRoutes(RoutingConfigurator $routes): void
+    {
+    }
+
+    /**
+     * Override this method to configure route groups
+     */
+    protected function configureRouteGroups(GroupRegistry $groups): void
     {
     }
 

--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -83,6 +83,7 @@ final class ListCommand extends Command implements SingletonInterface
     private function getPattern(Route $route): string
     {
         $pattern = $this->getValue($route->getUriHandler(), 'pattern');
+        $prefix = $this->getValue($route->getUriHandler(), 'prefix');
         $pattern = \str_replace(
             '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}',
             'uuid',
@@ -92,7 +93,7 @@ final class ListCommand extends Command implements SingletonInterface
         return \preg_replace_callback(
             '/<([^>]*)>/',
             static fn ($m) => \sprintf('<fg=magenta>%s</>', $m[0]),
-            $pattern
+            !empty($prefix) ? $prefix . '/' .  \trim($pattern, '/') : $pattern
         );
     }
 

--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -93,7 +93,7 @@ final class ListCommand extends Command implements SingletonInterface
         return \preg_replace_callback(
             '/<([^>]*)>/',
             static fn ($m) => \sprintf('<fg=magenta>%s</>', $m[0]),
-            !empty($prefix) ? $prefix . '/' .  \trim($pattern, '/') : $pattern
+            !empty($prefix) ? $prefix . '/' . \trim($pattern, '/') : $pattern
         );
     }
 

--- a/src/Router/src/GroupRegistry.php
+++ b/src/Router/src/GroupRegistry.php
@@ -24,7 +24,7 @@ final class GroupRegistry implements \IteratorAggregate
     public function getGroup(string $name): RouteGroup
     {
         if (!isset($this->groups[$name])) {
-            $this->groups[$name] = $this->factory->make(RouteGroup::class);
+            $this->groups[$name] = $this->factory->make(RouteGroup::class, ['name' => $name]);
         }
 
         return $this->groups[$name];

--- a/src/Router/src/GroupRegistry.php
+++ b/src/Router/src/GroupRegistry.php
@@ -24,7 +24,7 @@ final class GroupRegistry implements \IteratorAggregate
     public function getGroup(string $name): RouteGroup
     {
         if (!isset($this->groups[$name])) {
-            $this->groups[$name] = $this->factory->make(RouteGroup::class, ['name' => $name]);
+            $this->groups[$name] = $this->factory->make(RouteGroup::class);
         }
 
         return $this->groups[$name];
@@ -40,6 +40,18 @@ final class GroupRegistry implements \IteratorAggregate
     public function getDefaultGroup(): string
     {
         return $this->defaultGroup;
+    }
+
+    /**
+     * Push routes from each group to the router.
+     *
+     * @internal
+     */
+    public function registerRoutes(): void
+    {
+        foreach ($this->groups as $group) {
+            $group->register($this->factory->make(RouterInterface::class), $this->factory);
+        }
     }
 
     /**

--- a/src/Router/src/GroupRegistry.php
+++ b/src/Router/src/GroupRegistry.php
@@ -47,10 +47,10 @@ final class GroupRegistry implements \IteratorAggregate
      *
      * @internal
      */
-    public function registerRoutes(): void
+    public function registerRoutes(RouterInterface $router): void
     {
         foreach ($this->groups as $group) {
-            $group->register($this->factory->make(RouterInterface::class), $this->factory);
+            $group->register($router, $this->factory);
         }
     }
 

--- a/src/Router/src/Loader/Configurator/ImportConfigurator.php
+++ b/src/Router/src/Loader/Configurator/ImportConfigurator.php
@@ -40,6 +40,9 @@ final class ImportConfigurator
         return $this;
     }
 
+    /**
+     * @param non-empty-string $group
+     */
     public function group(string $group): self
     {
         foreach ($this->routes->all() as $configurator) {
@@ -49,10 +52,26 @@ final class ImportConfigurator
         return $this;
     }
 
+    /**
+     * @param non-empty-string $prefix
+     */
     public function prefix(string $prefix): self
     {
         foreach ($this->routes->all() as $configurator) {
             $configurator->prefix($prefix);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $prefix
+     */
+    public function namePrefix(string $prefix): self
+    {
+        foreach ($this->routes->all() as $name => $configurator) {
+            $this->routes->add($prefix . $name, $configurator);
+            $this->routes->remove($name);
         }
 
         return $this;

--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -6,10 +6,9 @@ namespace Spiral\Router;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use Spiral\Core\BinderInterface;
 use Spiral\Core\Container\Autowire;
 use Spiral\Core\CoreInterface;
-use Spiral\Http\Pipeline;
+use Spiral\Core\FactoryInterface;
 use Spiral\Router\Target\AbstractTarget;
 
 /**
@@ -20,21 +19,22 @@ final class RouteGroup
     private string $prefix = '';
     private string $namePrefix = '';
 
-    /** @var string[] */
+    /** @var array<non-empty-string, Route> */
     private array $routes = [];
 
     /** @var array<class-string<MiddlewareInterface>|MiddlewareInterface|Autowire> */
     private array $middleware = [];
 
-    private ?CoreInterface $core = null;
+    private Autowire|CoreInterface|string|null $core = null;
 
     public function __construct(
-        private readonly ContainerInterface $container,
-        private readonly RouterInterface $router,
-        private readonly UriHandler $handler,
-        private readonly ?string $name = null
+        /** @deprecated since v3.3.0 */
+        private readonly ?ContainerInterface $container = null,
+        /** @deprecated since v3.3.0 */
+        private readonly ?RouterInterface $router = null,
+        /** @deprecated since v3.3.0 */
+        private readonly ?UriHandler $handler = null
     ) {
-        $this->bindMiddlewares();
     }
 
     /**
@@ -42,7 +42,7 @@ final class RouteGroup
      */
     public function hasRoute(string $name): bool
     {
-        return \in_array($name, $this->routes);
+        return \array_key_exists($name, $this->routes);
     }
 
     /**
@@ -51,9 +51,6 @@ final class RouteGroup
     public function setPrefix(string $prefix): self
     {
         $this->prefix = $prefix;
-
-        // update routes
-        $this->flushRoutes();
 
         return $this;
     }
@@ -65,21 +62,12 @@ final class RouteGroup
     {
         $this->namePrefix = $prefix;
 
-        // update routes
-        $this->flushRoutes();
-
         return $this;
     }
 
     public function setCore(Autowire|CoreInterface|string $core): self
     {
-        if (!$core instanceof CoreInterface) {
-            $core = $this->container->get($core);
-        }
         $this->core = $core;
-
-        // update routes
-        $this->flushRoutes();
 
         return $this;
     }
@@ -99,10 +87,30 @@ final class RouteGroup
      *
      * @internal
      */
-    public function flushRoutes(): void
+    public function register(RouterInterface $router, FactoryInterface $factory): void
     {
-        foreach ($this->routes as $name) {
-            $this->router->setRoute($name, $this->applyGroupParams($this->router->getRoute($name)));
+        foreach ($this->routes as $name => $route) {
+            if ($this->core !== null) {
+                if (!$this->core instanceof CoreInterface) {
+                    $this->core = $factory->make($this->core);
+                }
+
+                $target = $route->getTarget();
+                if ($target instanceof AbstractTarget) {
+                    $route = $route->withTarget($target->withCore($this->core));
+                }
+            }
+
+            try {
+                $uriHandler = $route->getUriHandler();
+            } catch (\Throwable) {
+                $uriHandler = $factory->make(UriHandler::class);
+            }
+
+            $router->setRoute(
+                $name,
+                $route->withUriHandler($uriHandler->withPrefix($this->prefix))->withMiddleware(...$this->middleware)
+            );
         }
     }
 
@@ -111,45 +119,8 @@ final class RouteGroup
      */
     public function addRoute(string $name, Route $route): self
     {
-        if ($this->name !== null && $this->middleware !== []) {
-            $route = $route->withMiddleware('middleware:' . $this->name);
-        }
-
-        $this->routes[] = $this->namePrefix . $name;
-
-        $this->router->setRoute($this->namePrefix . $name, $this->applyGroupParams($route));
+        $this->routes[$this->namePrefix . $name] = $route;
 
         return $this;
-    }
-
-    private function applyGroupParams(Route $route): Route
-    {
-        if ($this->core !== null) {
-            $target = $route->getTarget();
-
-            if ($target instanceof AbstractTarget) {
-                $route = $route->withTarget($target->withCore($this->core));
-            }
-        }
-
-        try {
-            $uriHandler = $route->getUriHandler();
-        } catch (\Throwable) {
-            $uriHandler = $this->handler;
-        }
-
-        return $route->withUriHandler($uriHandler->withPrefix($this->prefix));
-    }
-
-    private function bindMiddlewares(): void
-    {
-        if ($this->container instanceof BinderInterface && $this->name !== null) {
-            $this->container->bind(
-                'middleware:' . $this->name,
-                function (PipelineFactory $factory): Pipeline {
-                    return $factory->createWithMiddleware($this->middleware);
-                }
-            );
-        }
     }
 }

--- a/src/Router/src/RouteGroup.php
+++ b/src/Router/src/RouteGroup.php
@@ -34,6 +34,7 @@ final class RouteGroup
         private readonly UriHandler $handler,
         private readonly ?string $name = null
     ) {
+        $this->bindMiddlewares();
     }
 
     /**
@@ -90,18 +91,6 @@ final class RouteGroup
     {
         $this->middleware[] = $middleware;
 
-        if ($this->container instanceof BinderInterface && $this->name !== null) {
-            $this->container->bind(
-                'middleware:' . $this->name,
-                function (PipelineFactory $factory): Pipeline {
-                    return $factory->createWithMiddleware($this->middleware);
-                }
-            );
-        }
-
-        // update routes
-        $this->flushRoutes();
-
         return $this;
     }
 
@@ -150,5 +139,17 @@ final class RouteGroup
         }
 
         return $route->withUriHandler($uriHandler->withPrefix($this->prefix));
+    }
+
+    private function bindMiddlewares(): void
+    {
+        if ($this->container instanceof BinderInterface && $this->name !== null) {
+            $this->container->bind(
+                'middleware:' . $this->name,
+                function (PipelineFactory $factory): Pipeline {
+                    return $factory->createWithMiddleware($this->middleware);
+                }
+            );
+        }
     }
 }

--- a/src/Router/tests/RouteTest.php
+++ b/src/Router/tests/RouteTest.php
@@ -13,15 +13,23 @@ use Spiral\Tests\Router\Stub\TestMiddleware;
 
 class RouteTest extends BaseTest
 {
-    public function testPrefix(): void
+    public function testEmptyPrefix(): void
     {
         $route = new Route('/action', Call::class);
         $route = $route->withUriHandler(new UriHandler(new UriFactory()));
-        $this->assertSame('', $route->getUriHandler()->getPrefix());
 
-        $route2 = $route->withUriHandler($route->getUriHandler()->withPrefix('/something'));
-        $this->assertSame('/something', $route2->getUriHandler()->getPrefix());
         $this->assertSame('', $route->getUriHandler()->getPrefix());
+    }
+
+    /**
+     * @dataProvider prefixesDataProvider
+     */
+    public function testPrefix(string $prefix, string $expected): void
+    {
+        $route = new Route('/action', Call::class);
+        $route = $route->withUriHandler((new UriHandler(new UriFactory()))->withPrefix($prefix));
+
+        $this->assertSame($expected, $route->getUriHandler()->getPrefix());
     }
 
     public function testContainerException(): void
@@ -45,5 +53,15 @@ class RouteTest extends BaseTest
 
         $this->assertCount(1, $m);
         $this->assertInstanceOf(TestMiddleware::class, $m[0]);
+    }
+
+    public function prefixesDataProvider(): \Traversable
+    {
+        yield ['something', 'something'];
+        yield ['/something/', 'something'];
+        yield ['//something/', 'something'];
+        yield ['something//', 'something'];
+        yield ['something/other', 'something/other'];
+        yield ['/something/other/', 'something/other'];
     }
 }

--- a/tests/Framework/Router/Loader/Configurator/ImportConfiguratorTest.php
+++ b/tests/Framework/Router/Loader/Configurator/ImportConfiguratorTest.php
@@ -21,9 +21,34 @@ final class ImportConfiguratorTest extends BaseTest
         /** import in @see RoutesBootloader */
         $this->assertSame(3, \count($ref->getProperty('routes')->getValue($group)));
 
-        // routes with prefix
-        $this->assertSame('/api/test-import', (string) $router->getRoute('test-import-index')->uri());
-        $this->assertSame('/api/test-import/posts', (string) $router->getRoute('test-import-posts')->uri());
-        $this->assertSame('/api/test-import/post/5', (string) $router->getRoute('test-import-post')->uri(['id' => 5]));
+        // routes with prefix and name prefix
+        $this->assertSame(
+            '/api/test-import',
+            (string) $router->getRoute('api.test-import-index')->uri()
+        );
+        $this->assertSame(
+            '/api/test-import/posts',
+            (string) $router->getRoute('api.test-import-posts')->uri()
+        );
+        $this->assertSame(
+            '/api/test-import/post/5',
+            (string) $router->getRoute('api.test-import-post')->uri(['id' => 5])
+        );
+    }
+
+    public function testImportWithoutNamePrefix(): void
+    {
+        $group = $this->getContainer()->get(GroupRegistry::class)->getGroup('other');
+        $router = $this->getContainer()->get(RouterInterface::class);
+
+        $ref = new \ReflectionObject($group);
+
+        /** import in @see RoutesBootloader */
+        $this->assertSame(3, \count($ref->getProperty('routes')->getValue($group)));
+
+        // routes with prefix and name prefix
+        $this->assertSame('/other/test-import', (string) $router->getRoute('test-import-index')->uri());
+        $this->assertSame('/other/test-import/posts', (string) $router->getRoute('test-import-posts')->uri());
+        $this->assertSame('/other/test-import/post/5', (string) $router->getRoute('test-import-post')->uri(['id' => 5]));
     }
 }

--- a/tests/app/src/Bootloader/RoutesBootloader.php
+++ b/tests/app/src/Bootloader/RoutesBootloader.php
@@ -158,8 +158,18 @@ final class RoutesBootloader extends BaseRoutesBootloader
                 new Interceptor\Append('six'),
             ]));
 
-        // for testing routes import
-        $routes->import(\dirname(__DIR__, 2) . '/routes/api.php')->group('api')->prefix('api');
+        // with group, prefix, name prefix
+        $routes
+            ->import(\dirname(__DIR__, 2) . '/routes/api.php')
+            ->group('api')
+            ->prefix('api')
+            ->namePrefix('api.');
+
+        // with group, prefix
+        $routes
+            ->import(\dirname(__DIR__, 2) . '/routes/api.php')
+            ->group('other')
+            ->prefix('other');
 
         $routes
             ->default('/<action>[/<name>]')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### Route name prefix

Added the ability to add a `prefix` to the `name` of all routes in a **group**. All route names in the group will start with the specified prefix.

Via `Spiral\Router\GroupRegistry`:

```php
namespace App\Bootloader;

use Spiral\Bootloader\Http\RoutesBootloader as BaseRoutesBootloader;
use Spiral\Router\GroupRegistry;

final class RoutesBootloader extends BaseRoutesBootloader
{
    // ...
    
    protected function configureRouteGroups(GroupRegistry $groups): void
    {
        $groups->getGroup('api')->setNamePrefix('api.');
    }
    
    // ...
}

```

Then add a route:

```php
#[Route(route: '/', name: 'index', group: 'api')]
public function index(): string
{
    return $this->views->render('home.dark.php');
}
```
The route name will be **api.index**:

```bash
+-----------+--------+----------+----------------------------------+--------+
| Name:     | Verbs: | Pattern: | Target:                          | Group: |
+-----------+--------+----------+----------------------------------+--------+
| api.index | *      | /        | Controller\HomeController->index | api    |
+-----------+--------+----------+----------------------------------+--------+
```
Or via `Spiral\Router\Loader\Configurator\RoutingConfigurator` during import from a file:

```php
namespace App\Bootloader;

use Spiral\Bootloader\Http\RoutesBootloader as BaseRoutesBootloader;
use Spiral\Router\Loader\Configurator\RoutingConfigurator;

final class RoutesBootloader extends BaseRoutesBootloader
{
    // ...
    
    protected function defineRoutes(RoutingConfigurator $routes): void
    {
        $routes
            ->import(\dirname(__DIR__, 2) . '/routes/api.php')
            ->group('api')
            ->prefix('api')
            ->namePrefix('api.');
    }
    
    // ...
}
```

### Default group in the Annotated Routes

Added the ability to set a default group for routes added by the Annotated Routes package.

```php
namespace App\Bootloader;

use Spiral\Bootloader\Http\RoutesBootloader as BaseRoutesBootloader;
use Spiral\Router\GroupRegistry;

final class RoutesBootloader extends BaseRoutesBootloader
{
    // ...
    
    protected function configureRouteGroups(GroupRegistry $groups): void
    {
        $groups->setDefaultGroup('custom');
    }
    
    // ...
}
```

### Method **configureRouteGroups** in the **RoutesBootloader**

Added the ability to add the `configureRouteGroups` method to the `RoutesBootloader` class. The method will be called automatically and one `Spiral\Router\GroupRegistry` parameter will be passed to it. With this method, you can easilyconfigure route groups.

### Prefix

Fixed bug with the route prefix in groups.