### PR TITLE
Added session kv driver for RoadRunner

### DIFF
--- a/src/Session/composer.json
+++ b/src/Session/composer.json
@@ -29,11 +29,14 @@
     "require": {
         "php": ">=8.1",
         "spiral/core": "^3.4",
-        "spiral/files": "^3.4"
+        "spiral/files": "^3.4",
+        "spiral/cache": "^3.4",
+        "psr/simple-cache": "2 - 3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
-        "vimeo/psalm": "^4.27"
+        "vimeo/psalm": "^4.27",
+        "mockery/mockery": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Session/phpunit.xml
+++ b/src/Session/phpunit.xml
@@ -16,11 +16,11 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>

--- a/src/Session/src/Handler/CacheHandler.php
+++ b/src/Session/src/Handler/CacheHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Session\Handler;
+
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+use Spiral\Cache\CacheStorageProviderInterface;
+
+final class CacheHandler implements \SessionHandlerInterface
+{
+    private readonly CacheInterface $cache;
+
+    public function __construct(
+        CacheStorageProviderInterface $storageProvider,
+        private readonly ?string $storage = null,
+        private readonly int $ttl = 86400
+    ) {
+        $this->cache = $storageProvider->storage($this->storage);
+    }
+
+    public function close(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function destroy(string $id): bool
+    {
+        $this->cache->delete($id);
+
+        return true;
+    }
+
+    public function gc(int $max_lifetime): int|false
+    {
+        return 0;
+    }
+
+    public function open(string $path, string $name): bool
+    {
+        return true;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function read(string $id): string|false
+    {
+        $result = $this->cache->get($id);
+
+        return is_string($result) ? $result : '';
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function write(string $id, string $data): bool
+    {
+        return $this->cache->set($this->getKey($id), $data, $this->ttl);
+    }
+
+    private function getKey(string $id): string
+    {
+        return 'session:' . $id;
+    }
+}

--- a/src/Session/tests/CacheHandlerTest.php
+++ b/src/Session/tests/CacheHandlerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Session;
+
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+use Spiral\Cache\CacheStorageProviderInterface;
+use Spiral\Session\Handler\CacheHandler;
+use Mockery as m;
+
+final class CacheHandlerTest extends TestCase
+{
+    public function testClose(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn(m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $this->assertTrue($handler->close());
+    }
+
+    public function testDestroy(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn($cache = m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $cache->shouldReceive('delete')->with('1')->andReturn(false);
+
+        $this->assertTrue($handler->destroy('1'));
+    }
+
+    public function testGc(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn(m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $this->assertSame(0, $handler->gc(100));
+    }
+
+    public function testOpen(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn(m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $this->assertTrue($handler->open('root', 'test'));
+    }
+
+    public function testRead(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn($cache = m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $cache->shouldReceive('get')->with('1')->andReturn('foo');
+
+        $this->assertSame('foo', $handler->read('1'));
+    }
+
+    public function testReadExpired(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn($cache = m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $cache->shouldReceive('get')->with('1')->andReturn(null);
+
+        $this->assertSame('', $handler->read('1'));
+    }
+
+    public function testWrite(): void
+    {
+        $storage = m::mock(CacheStorageProviderInterface::class);
+
+        $storage->shouldReceive('storage')->andReturn($cache = m::mock(CacheInterface::class));
+
+        $handler = new CacheHandler(
+            $storage
+        );
+
+        $cache->shouldReceive('set')->with('session:1', 'foo', 86400)->andReturn(true);
+
+        $this->assertTrue($handler->write('1', 'foo'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Breaks BC?    | ❌
| New feature?  | ✔️

Configuration example:

in `app/config/session.php` config
```php
<?php

declare(strict_types=1);

use Spiral\Core\Container\Autowire;
use Spiral\Session\Handler\CacheHandler;

return [
    // ...
    'handler'  => new Autowire(
        CacheHandler::class,
        [
            'storage' => 'my-storage',
            'ttl'  => 86400
        ]
    )
];
```