### PR TITLE
Adds `Spiral\Telemetry\Bootloader\TelemetryBootloader` dependency to QueueBootloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+- **Bug Fixes**
+    - [spiral/queue] Added `Spiral\Telemetry\Bootloader\TelemetryBootloader` dependency to QueueBootloader.
+
 ## 3.3.0 - 2022-11-17
 - **High Impact Changes**
   - [spiral/router] Added the ability to add a `prefix` to the `name` of all routes in a **group**.

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -32,10 +32,15 @@ use Spiral\Queue\QueueInterface;
 use Spiral\Queue\QueueManager;
 use Spiral\Queue\QueueRegistry;
 use Spiral\Queue\SerializerRegistryInterface;
+use Spiral\Telemetry\Bootloader\TelemetryBootloader;
 use Spiral\Telemetry\TracerFactoryInterface;
 
 final class QueueBootloader extends Bootloader
 {
+    protected const DEPENDENCIES = [
+        TelemetryBootloader::class,
+    ];
+
     protected const SINGLETONS = [
         HandlerRegistryInterface::class => QueueRegistry::class,
         SerializerRegistryInterface::class => QueueRegistry::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️