### PR TITLE
Bootloading improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **Other Features**
   - [spiral/boot] Added `Spiral\Boot\BootloadManager\InitializerInterface`. This will allow changing the implementation 
     of this interface by the developer.
-  - [spiral/boot] Added `Spiral\Boot\BootloadManager\CustomizableBootloadManager`. This BootloadManager allows 
+  - [spiral/boot] Added `Spiral\Boot\BootloadManager\StrategyBasedBootloadManager`. This BootloadManager allows 
     the implementation of a custom bootloaders loading strategy.
   - [spiral/boot] Added the ability to register application bootloaders via object instance.
   - [spiral/boot] Removed `final` from the `Spiral\Boot\BootloadManager\Initializer` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - [spiral/boot] Added `Spiral\Boot\BootloadManager\InitializerInterface`. This will allow changing the implementation 
     of this interface by the developer.
   - [spiral/boot] Added the ability to register application bootloaders via object instance.
-  - [spiral/boot] Removed from the `Spiral\Boot\BootloadManager\Initializer`.
+  - [spiral/boot] Removed `final` from the `Spiral\Boot\BootloadManager\Initializer` class.
 
 ## 3.3.0 - 2022-11-17
 - **High Impact Changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+- **High Impact Changes**
+- **Medium Impact Changes**
+- **Other Features**
+  - [spiral/boot] Added `Spiral\Boot\BootloadManager\InitializerInterface`. This will allow changing the implementation 
+    of this interface by the developer.
+  - [spiral/boot] Added the ability to register application bootloaders via object instance.
+  - [spiral/boot] Removed from the `Spiral\Boot\BootloadManager\Initializer`.
+
 ## 3.3.0 - 2022-11-17
 - **High Impact Changes**
   - [spiral/router] Added the ability to add a `prefix` to the `name` of all routes in a **group**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - **Other Features**
   - [spiral/boot] Added `Spiral\Boot\BootloadManager\InitializerInterface`. This will allow changing the implementation 
     of this interface by the developer.
+  - [spiral/boot] Added `Spiral\Boot\BootloadManager\CustomizableBootloadManager`. This BootloadManager allows 
+    the implementation of a custom bootloaders loading strategy.
   - [spiral/boot] Added the ability to register application bootloaders via object instance.
   - [spiral/boot] Removed `final` from the `Spiral\Boot\BootloadManager\Initializer` class.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - **High Impact Changes**
 - **Medium Impact Changes**
+  - [spiral/boot] Class `Spiral\Boot\BootloadManager\BootloadManager` is deprecated. Will be removed in version v4.0.
 - **Other Features**
   - [spiral/boot] Added `Spiral\Boot\BootloadManager\InitializerInterface`. This will allow changing the implementation 
     of this interface by the developer.

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -7,9 +7,11 @@ namespace Spiral\Boot;
 use Closure;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\DefaultStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\Event\Bootstrapped;
 use Spiral\Boot\Event\DispatcherFound;
 use Spiral\Boot\Event\DispatcherNotFound;
@@ -117,8 +119,11 @@ abstract class AbstractKernel implements KernelInterface
         if (!$container->has(InitializerInterface::class)) {
             $container->bind(InitializerInterface::class, Initializer::class);
         }
+        if (!$container->has(InvokerStrategyInterface::class)) {
+            $container->bind(InvokerStrategyInterface::class, DefaultStrategy::class);
+        }
 
-        $bootloadManager ??= $container->make(BootloadManager::class);
+        $bootloadManager ??= $container->make(CustomizableBootloadManager::class);
         \assert($bootloadManager instanceof BootloadManagerInterface);
         $container->bind(BootloadManagerInterface::class, $bootloadManager);
 

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -8,7 +8,7 @@ use Closure;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
 use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
-use Spiral\Boot\BootloadManager\DefaultStrategy;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\BootloadManager\InitializerInterface;
 use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
@@ -17,6 +17,7 @@ use Spiral\Boot\Event\DispatcherFound;
 use Spiral\Boot\Event\DispatcherNotFound;
 use Spiral\Boot\Event\Serving;
 use Spiral\Boot\Exception\BootException;
+use Spiral\Core\Container\Autowire;
 use Spiral\Core\Container;
 use Spiral\Exceptions\ExceptionHandler;
 use Spiral\Exceptions\ExceptionHandlerInterface;
@@ -104,7 +105,7 @@ abstract class AbstractKernel implements KernelInterface
         bool $handleErrors = true,
         ExceptionHandlerInterface|string|null $exceptionHandler = null,
         Container $container = new Container(),
-        ?BootloadManagerInterface $bootloadManager = null
+        BootloadManagerInterface|Autowire|null $bootloadManager = null
     ): static {
         $exceptionHandler ??= ExceptionHandler::class;
 
@@ -120,9 +121,12 @@ abstract class AbstractKernel implements KernelInterface
             $container->bind(InitializerInterface::class, Initializer::class);
         }
         if (!$container->has(InvokerStrategyInterface::class)) {
-            $container->bind(InvokerStrategyInterface::class, DefaultStrategy::class);
+            $container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
         }
 
+        if ($bootloadManager instanceof Autowire) {
+            $bootloadManager = $bootloadManager->resolve($container);
+        }
         $bootloadManager ??= $container->make(CustomizableBootloadManager::class);
         \assert($bootloadManager instanceof BootloadManagerInterface);
         $container->bind(BootloadManagerInterface::class, $bootloadManager);

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -8,6 +8,8 @@ use Closure;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
 use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
 use Spiral\Boot\Event\Bootstrapped;
 use Spiral\Boot\Event\DispatcherFound;
 use Spiral\Boot\Event\DispatcherNotFound;
@@ -110,6 +112,10 @@ abstract class AbstractKernel implements KernelInterface
 
         if ($handleErrors) {
             $exceptionHandler->register();
+        }
+
+        if (!$container->has(InitializerInterface::class)) {
+            $container->bind(InitializerInterface::class, Initializer::class);
         }
 
         $bootloadManager ??= $container->make(BootloadManager::class);

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -7,7 +7,7 @@ namespace Spiral\Boot;
 use Closure;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\BootloadManager\InitializerInterface;
@@ -127,7 +127,7 @@ abstract class AbstractKernel implements KernelInterface
         if ($bootloadManager instanceof Autowire) {
             $bootloadManager = $bootloadManager->resolve($container);
         }
-        $bootloadManager ??= $container->make(CustomizableBootloadManager::class);
+        $bootloadManager ??= $container->make(StrategyBasedBootloadManager::class);
         \assert($bootloadManager instanceof BootloadManagerInterface);
         $container->bind(BootloadManagerInterface::class, $bootloadManager);
 

--- a/src/Boot/src/BootloadManager/AbstractBootloadManager.php
+++ b/src/Boot/src/BootloadManager/AbstractBootloadManager.php
@@ -35,7 +35,7 @@ abstract class AbstractBootloadManager implements BootloadManagerInterface, Cont
     }
 
     /**
-     * Bootloader all given classes.
+     * Bootload all given bootloaders.
      *
      * @param array<class-string>|array<class-string, array<string,mixed>> $classes
      *

--- a/src/Boot/src/BootloadManager/AbstractBootloadManager.php
+++ b/src/Boot/src/BootloadManager/AbstractBootloadManager.php
@@ -38,8 +38,6 @@ abstract class AbstractBootloadManager implements BootloadManagerInterface, Cont
      * Bootload all given bootloaders.
      *
      * @param array<class-string>|array<class-string, array<string,mixed>> $classes
-     *
-     * @throws \Throwable
      */
     abstract protected function boot(array $classes, array $bootingCallbacks, array $bootedCallbacks): void;
 }

--- a/src/Boot/src/BootloadManager/AbstractBootloadManager.php
+++ b/src/Boot/src/BootloadManager/AbstractBootloadManager.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\BootloadManager;
+
+use Spiral\Boot\BootloadManagerInterface;
+use Spiral\Core\Container;
+use Spiral\Core\ScopeInterface;
+
+/**
+ * Provides ability to bootload service providers.
+ */
+abstract class AbstractBootloadManager implements BootloadManagerInterface, Container\SingletonInterface
+{
+    public function __construct(
+        private readonly ScopeInterface $scope,
+        protected readonly InitializerInterface $initializer
+    ) {
+    }
+
+    public function getClasses(): array
+    {
+        return $this->initializer->getRegistry()->getClasses();
+    }
+
+    public function bootload(array $classes, array $bootingCallbacks = [], array $bootedCallbacks = []): void
+    {
+        $this->scope->runScope(
+            [self::class => $this],
+            function () use ($classes, $bootingCallbacks, $bootedCallbacks): void {
+                $this->boot($classes, $bootingCallbacks, $bootedCallbacks);
+            }
+        );
+    }
+
+    /**
+     * Bootloader all given classes.
+     *
+     * @param array<class-string>|array<class-string, array<string,mixed>> $classes
+     *
+     * @throws \Throwable
+     */
+    abstract protected function boot(array $classes, array $bootingCallbacks, array $bootedCallbacks): void;
+}

--- a/src/Boot/src/BootloadManager/BootloadManager.php
+++ b/src/Boot/src/BootloadManager/BootloadManager.php
@@ -9,7 +9,7 @@ use Spiral\Core\ResolverInterface;
 use Spiral\Core\ScopeInterface;
 
 /**
- * @deprecated since v3.4. Use the {@see CustomizableBootloadManager} instead.
+ * @deprecated since v3.4. Use the {@see StrategyBasedBootloadManager} instead.
  */
 final class BootloadManager extends AbstractBootloadManager
 {

--- a/src/Boot/src/BootloadManager/BootloadManager.php
+++ b/src/Boot/src/BootloadManager/BootloadManager.php
@@ -22,7 +22,7 @@ final class BootloadManager implements BootloadManagerInterface, Container\Singl
         private readonly ScopeInterface $scope,
         private readonly InvokerInterface $invoker,
         private readonly ResolverInterface $resolver,
-        private readonly Initializer $initializer
+        private readonly InitializerInterface $initializer
     ) {
     }
 

--- a/src/Boot/src/BootloadManager/BootloadManager.php
+++ b/src/Boot/src/BootloadManager/BootloadManager.php
@@ -24,9 +24,9 @@ final class BootloadManager extends AbstractBootloadManager
     ) {
         parent::__construct($scope, $initializer);
 
-        $this->invokerStrategy = $invokerStrategy ?? new DefaultStrategy(
-            ...$this->resolver->resolveArguments((new \ReflectionClass(DefaultStrategy::class))->getConstructor())
-        );
+        $this->invokerStrategy = $invokerStrategy ?? new DefaultInvokerStrategy(...$this->resolver->resolveArguments(
+            (new \ReflectionClass(DefaultInvokerStrategy::class))->getConstructor()
+        ));
     }
 
     /**

--- a/src/Boot/src/BootloadManager/BootloadManager.php
+++ b/src/Boot/src/BootloadManager/BootloadManager.php
@@ -4,45 +4,33 @@ declare(strict_types=1);
 
 namespace Spiral\Boot\BootloadManager;
 
-use Closure;
-use Spiral\Boot\Bootloader\BootloaderInterface;
-use Spiral\Boot\BootloadManagerInterface;
-use Spiral\Core\Container;
 use Spiral\Core\InvokerInterface;
 use Spiral\Core\ResolverInterface;
 use Spiral\Core\ScopeInterface;
 
 /**
- * Provides ability to bootload ServiceProviders.
+ * @deprecated since v3.4. Use the {@see CustomizableBootloadManager} instead.
  */
-final class BootloadManager implements BootloadManagerInterface, Container\SingletonInterface
+final class BootloadManager extends AbstractBootloadManager
 {
+    private InvokerStrategyInterface $invokerStrategy;
+
     public function __construct(
-        /* @internal */
-        private readonly ScopeInterface $scope,
+        ScopeInterface $scope,
         private readonly InvokerInterface $invoker,
         private readonly ResolverInterface $resolver,
-        private readonly InitializerInterface $initializer
+        InitializerInterface $initializer,
+        ?InvokerStrategyInterface $invokerStrategy = null
     ) {
-    }
+        parent::__construct($scope, $initializer);
 
-    public function getClasses(): array
-    {
-        return $this->initializer->getRegistry()->getClasses();
-    }
-
-    public function bootload(array $classes, array $bootingCallbacks = [], array $bootedCallbacks = []): void
-    {
-        $this->scope->runScope(
-            [self::class => $this],
-            function () use ($classes, $bootingCallbacks, $bootedCallbacks): void {
-                $this->boot($classes, $bootingCallbacks, $bootedCallbacks);
-            }
+        $this->invokerStrategy = $invokerStrategy ?? new DefaultStrategy(
+            ...$this->resolver->resolveArguments((new \ReflectionClass(DefaultStrategy::class))->getConstructor())
         );
     }
 
     /**
-     * Bootloader all given classes.
+     * Bootload all given bootloaders.
      *
      * @param array<class-string>|array<class-string, array<string,mixed>> $classes
      *
@@ -50,45 +38,6 @@ final class BootloadManager implements BootloadManagerInterface, Container\Singl
      */
     protected function boot(array $classes, array $bootingCallbacks, array $bootedCallbacks): void
     {
-        $bootloaders = \iterator_to_array($this->initializer->init($classes));
-
-        foreach ($bootloaders as $data) {
-            $this->invokeBootloader($data['bootloader'], Methods::INIT, $data['options']);
-        }
-
-        $this->fireCallbacks($bootingCallbacks);
-
-        foreach ($bootloaders as $data) {
-            $this->invokeBootloader($data['bootloader'], Methods::BOOT, $data['options']);
-        }
-
-        $this->fireCallbacks($bootedCallbacks);
-    }
-
-    private function invokeBootloader(BootloaderInterface $bootloader, Methods $method, array $options): void
-    {
-        $refl = new \ReflectionClass($bootloader);
-        if (!$refl->hasMethod($method->value)) {
-            return;
-        }
-
-        $method = $refl->getMethod($method->value);
-
-        $args = $this->resolver->resolveArguments($method);
-        if (!isset($args['boot'])) {
-            $args['boot'] = $options;
-        }
-
-        $method->invokeArgs($bootloader, \array_values($args));
-    }
-
-    /**
-     * @param array<Closure> $callbacks
-     */
-    private function fireCallbacks(array $callbacks): void
-    {
-        foreach ($callbacks as $callback) {
-            $this->invoker->invoke($callback);
-        }
+        $this->invokerStrategy->invokeBootloaders($classes, $bootingCallbacks, $bootedCallbacks);
     }
 }

--- a/src/Boot/src/BootloadManager/CustomizableBootloadManager.php
+++ b/src/Boot/src/BootloadManager/CustomizableBootloadManager.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\BootloadManager;
+
+use Spiral\Core\ScopeInterface;
+
+final class CustomizableBootloadManager extends AbstractBootloadManager
+{
+    public function __construct(
+        private readonly InvokerStrategyInterface $invoker,
+        ScopeInterface $scope,
+        InitializerInterface $initializer
+    ) {
+        parent::__construct($scope, $initializer);
+    }
+
+    /**
+     * Bootload all given bootloaders.
+     *
+     * @param array<class-string>|array<class-string, array<string,mixed>> $classes
+     *
+     * @throws \Throwable
+     */
+    protected function boot(array $classes, array $bootingCallbacks, array $bootedCallbacks): void
+    {
+        $this->invoker->invokeBootloaders($classes, $bootingCallbacks, $bootedCallbacks);
+    }
+}

--- a/src/Boot/src/BootloadManager/DefaultInvokerStrategy.php
+++ b/src/Boot/src/BootloadManager/DefaultInvokerStrategy.php
@@ -8,7 +8,7 @@ use Spiral\Boot\Bootloader\BootloaderInterface;
 use Spiral\Core\InvokerInterface;
 use Spiral\Core\ResolverInterface;
 
-final class DefaultStrategy implements InvokerStrategyInterface
+final class DefaultInvokerStrategy implements InvokerStrategyInterface
 {
     public function __construct(
         private readonly InitializerInterface $initializer,

--- a/src/Boot/src/BootloadManager/DefaultStrategy.php
+++ b/src/Boot/src/BootloadManager/DefaultStrategy.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\BootloadManager;
+
+use Spiral\Boot\Bootloader\BootloaderInterface;
+use Spiral\Core\InvokerInterface;
+use Spiral\Core\ResolverInterface;
+
+final class DefaultStrategy implements InvokerStrategyInterface
+{
+    public function __construct(
+        private readonly InitializerInterface $initializer,
+        private readonly InvokerInterface $invoker,
+        private readonly ResolverInterface $resolver
+    ) {
+    }
+
+    public function invokeBootloaders(array $classes, array $bootingCallbacks, array $bootedCallbacks): void
+    {
+        $bootloaders = \iterator_to_array($this->initializer->init($classes));
+
+        foreach ($bootloaders as $data) {
+            $this->invokeBootloader($data['bootloader'], Methods::INIT, $data['options']);
+        }
+
+        $this->fireCallbacks($bootingCallbacks);
+
+        foreach ($bootloaders as $data) {
+            $this->invokeBootloader($data['bootloader'], Methods::BOOT, $data['options']);
+        }
+
+        $this->fireCallbacks($bootedCallbacks);
+    }
+
+    private function invokeBootloader(BootloaderInterface $bootloader, Methods $method, array $options): void
+    {
+        $refl = new \ReflectionClass($bootloader);
+        if (!$refl->hasMethod($method->value)) {
+            return;
+        }
+
+        $method = $refl->getMethod($method->value);
+
+        $args = $this->resolver->resolveArguments($method);
+        if (!isset($args['boot'])) {
+            $args['boot'] = $options;
+        }
+
+        $method->invokeArgs($bootloader, \array_values($args));
+    }
+
+    /**
+     * @param array<Closure> $callbacks
+     */
+    private function fireCallbacks(array $callbacks): void
+    {
+        foreach ($callbacks as $callback) {
+            $this->invoker->invoke($callback);
+        }
+    }
+}

--- a/src/Boot/src/BootloadManager/DefaultStrategy.php
+++ b/src/Boot/src/BootloadManager/DefaultStrategy.php
@@ -52,7 +52,7 @@ final class DefaultStrategy implements InvokerStrategyInterface
     }
 
     /**
-     * @param array<Closure> $callbacks
+     * @param array<\Closure> $callbacks
      */
     private function fireCallbacks(array $callbacks): void
     {

--- a/src/Boot/src/BootloadManager/InitializerInterface.php
+++ b/src/Boot/src/BootloadManager/InitializerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\BootloadManager;
+
+use Spiral\Boot\BootloadManagerInterface;
+
+/**
+ * @psalm-import-type TClass from BootloadManagerInterface
+ */
+interface InitializerInterface
+{
+    /**
+     * Instantiate bootloader objects and resolve dependencies
+     *
+     * @param TClass[]|array<TClass, array<string,mixed>> $classes
+     */
+    public function init(array $classes): \Generator;
+
+    public function getRegistry(): ClassesRegistry;
+}

--- a/src/Boot/src/BootloadManager/InvokerStrategyInterface.php
+++ b/src/Boot/src/BootloadManager/InvokerStrategyInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\BootloadManager;
+
+interface InvokerStrategyInterface
+{
+    /**
+     * Bootload all given bootloaders.
+     *
+     * @param array<class-string>|array<class-string, array<string,mixed>> $classes
+     */
+    public function invokeBootloaders(array $classes, array $bootingCallbacks, array $bootedCallbacks): void;
+}

--- a/src/Boot/src/BootloadManager/StrategyBasedBootloadManager.php
+++ b/src/Boot/src/BootloadManager/StrategyBasedBootloadManager.php
@@ -6,7 +6,7 @@ namespace Spiral\Boot\BootloadManager;
 
 use Spiral\Core\ScopeInterface;
 
-final class CustomizableBootloadManager extends AbstractBootloadManager
+final class StrategyBasedBootloadManager extends AbstractBootloadManager
 {
     public function __construct(
         private readonly InvokerStrategyInterface $invoker,

--- a/src/Boot/tests/BootloadManager/BootloadManagerTest.php
+++ b/src/Boot/tests/BootloadManager/BootloadManagerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\BootloadManager;
+
+use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Core\Container;
+use Spiral\Tests\Boot\Fixtures\BootloaderA;
+use Spiral\Tests\Boot\Fixtures\BootloaderB;
+use Spiral\Tests\Boot\Fixtures\SampleBoot;
+use Spiral\Tests\Boot\Fixtures\SampleBootWithMethodBoot;
+use Spiral\Tests\Boot\Fixtures\SampleClass;
+use Spiral\Tests\Boot\TestCase;
+
+final class BootloadManagerTest extends TestCase
+{
+    public function testWithoutInvokerStrategy(): void
+    {
+        $container = new Container();
+        $container->bind(InitializerInterface::class, new Initializer($container, $container));
+
+        $bootloader = new BootloadManager(
+            $container,
+            $container,
+            $container,
+            $container->get(InitializerInterface::class)
+        );
+
+        $bootloader->bootload($classes = [
+            SampleClass::class,
+            SampleBootWithMethodBoot::class,
+            SampleBoot::class,
+        ], [
+            static function(Container $container, SampleBoot $boot) {
+                $container->bind('efg', $boot);
+            }
+        ], [
+            static function(Container $container, SampleBoot $boot) {
+                $container->bind('ghi', $boot);
+            }
+        ]);
+
+        $this->assertTrue($container->has('abc'));
+        $this->assertTrue($container->hasInstance('cde'));
+        $this->assertTrue($container->hasInstance('def'));
+        $this->assertTrue($container->hasInstance('efg'));
+        $this->assertTrue($container->has('single'));
+        $this->assertTrue($container->has('ghi'));
+        $this->assertNotInstanceOf(SampleBoot::class, $container->get('efg'));
+        $this->assertInstanceOf(SampleBoot::class, $container->get('ghi'));
+
+        $this->assertSame(\array_merge($classes, [
+            BootloaderA::class,
+            BootloaderB::class,
+        ]), $bootloader->getClasses());
+    }
+}

--- a/src/Boot/tests/BootloadManager/BootloadersTest.php
+++ b/src/Boot/tests/BootloadManager/BootloadersTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Boot\BootloadManager;
 
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\BinderInterface;
 use Spiral\Core\Container;
 use Spiral\Tests\Boot\Fixtures\BootloaderA;
 use Spiral\Tests\Boot\Fixtures\BootloaderB;
@@ -76,6 +78,39 @@ class BootloadersTest extends TestCase
             BootloaderA::class,
             BootloaderB::class,
         ], $bootloader->getClasses());
+    }
+
+    public function testBootloadFromAnonymousClass(): void
+    {
+        $container = new Container();
+
+        $bootloader = $this->getBootloadManager($container);
+
+        $bootloader->bootload([
+            new class () extends Bootloader {
+                public const BINDINGS = ['abc' => self::class];
+                public const SINGLETONS = ['single' => self::class];
+
+                public function init(BinderInterface $binder): void
+                {
+                    $binder->bind('def', new SampleBoot());
+                }
+
+                public function boot(BinderInterface $binder): void
+                {
+                    $binder->bind('efg', new SampleClass());
+                    $binder->bind('ghi', 'foo');
+                }
+            },
+        ]);
+
+        $this->assertTrue($container->has('abc'));
+        $this->assertTrue($container->has('single'));
+        $this->assertTrue($container->hasInstance('def'));
+        $this->assertTrue($container->hasInstance('efg'));
+        $this->assertTrue($container->has('ghi'));
+
+        $this->assertCount(1, $bootloader->getClasses());
     }
 
     public function testException(): void

--- a/src/Boot/tests/BootloadManager/BootloadersTest.php
+++ b/src/Boot/tests/BootloadManager/BootloadersTest.php
@@ -50,6 +50,34 @@ class BootloadersTest extends TestCase
         ]), $bootloader->getClasses());
     }
 
+    public function testBootloadFromInstance(): void
+    {
+        $container = new Container();
+
+        $bootloader = $this->getBootloadManager($container);
+
+        $bootloader->bootload([
+            SampleClass::class,
+            new SampleBootWithMethodBoot(),
+            new SampleBoot(),
+        ]);
+
+        $this->assertTrue($container->has('abc'));
+        $this->assertTrue($container->has('single'));
+        $this->assertTrue($container->hasInstance('def'));
+        $this->assertTrue($container->hasInstance('efg'));
+        $this->assertTrue($container->hasInstance('cde'));
+        $this->assertTrue($container->has('ghi'));
+
+        $this->assertSame([
+            SampleClass::class,
+            SampleBootWithMethodBoot::class,
+            SampleBoot::class,
+            BootloaderA::class,
+            BootloaderB::class,
+        ], $bootloader->getClasses());
+    }
+
     public function testException(): void
     {
         $this->expectException(\Spiral\Boot\Exception\ClassNotFoundException::class);

--- a/src/Boot/tests/Fixtures/CustomInitializer.php
+++ b/src/Boot/tests/Fixtures/CustomInitializer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\BootloadManager\ClassesRegistry;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+
+final class CustomInitializer implements InitializerInterface
+{
+    public function init(array $classes): \Generator
+    {
+        yield 'foo' => ['bootloader' => new BootloaderA(), 'options' => []];
+    }
+
+    public function getRegistry(): ClassesRegistry
+    {
+    }
+}

--- a/src/Boot/tests/Fixtures/CustomInvokerStrategy.php
+++ b/src/Boot/tests/Fixtures/CustomInvokerStrategy.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Fixtures;
+
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
+
+final class CustomInvokerStrategy implements InvokerStrategyInterface
+{
+    public function invokeBootloaders(array $classes, array $bootingCallbacks, array $bootedCallbacks): void
+    {
+    }
+}

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -6,6 +6,8 @@ namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
 use Spiral\Boot\DispatcherInterface;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Boot\Event\Bootstrapped;
@@ -14,6 +16,7 @@ use Spiral\Boot\Event\DispatcherNotFound;
 use Spiral\Boot\Event\Serving;
 use Spiral\Boot\Exception\BootException;
 use Spiral\Core\Container;
+use Spiral\Tests\Boot\Fixtures\CustomInitializer;
 use Spiral\Tests\Boot\Fixtures\TestCore;
 use Throwable;
 
@@ -194,5 +197,26 @@ class KernelTest extends TestCase
         $this->expectException(BootException::class);
 
         $kernel->run()->serve();
+    }
+
+    public function testDefaultInitializerShouldBeBound(): void
+    {
+        $container = new Container();
+
+        TestCore::create(directories: ['root' => __DIR__], container: $container);
+
+        $this->assertTrue($container->has(InitializerInterface::class));
+        $this->assertInstanceOf(Initializer::class, $container->get(InitializerInterface::class));
+    }
+
+    public function testCustomInitializerShouldBeBound(): void
+    {
+        $container = new Container();
+        $container->bind(InitializerInterface::class, CustomInitializer::class);
+
+        TestCore::create(directories: ['root' => __DIR__], container: $container);
+
+        $this->assertTrue($container->has(InitializerInterface::class));
+        $this->assertInstanceOf(CustomInitializer::class, $container->get(InitializerInterface::class));
     }
 }

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -6,8 +6,10 @@ namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Boot\BootloadManager\DefaultStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\DispatcherInterface;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Boot\Event\Bootstrapped;
@@ -17,6 +19,7 @@ use Spiral\Boot\Event\Serving;
 use Spiral\Boot\Exception\BootException;
 use Spiral\Core\Container;
 use Spiral\Tests\Boot\Fixtures\CustomInitializer;
+use Spiral\Tests\Boot\Fixtures\CustomInvokerStrategy;
 use Spiral\Tests\Boot\Fixtures\TestCore;
 use Throwable;
 
@@ -218,5 +221,26 @@ class KernelTest extends TestCase
 
         $this->assertTrue($container->has(InitializerInterface::class));
         $this->assertInstanceOf(CustomInitializer::class, $container->get(InitializerInterface::class));
+    }
+
+    public function testDefaultInvokerStrategyShouldBeBound(): void
+    {
+        $container = new Container();
+
+        TestCore::create(directories: ['root' => __DIR__], container: $container);
+
+        $this->assertTrue($container->has(InvokerStrategyInterface::class));
+        $this->assertInstanceOf(DefaultStrategy::class, $container->get(InvokerStrategyInterface::class));
+    }
+
+    public function testCustomInvokerStrategyShouldBeBound(): void
+    {
+        $container = new Container();
+        $container->bind(InvokerStrategyInterface::class, CustomInvokerStrategy::class);
+
+        TestCore::create(directories: ['root' => __DIR__], container: $container);
+
+        $this->assertTrue($container->has(InvokerStrategyInterface::class));
+        $this->assertInstanceOf(CustomInvokerStrategy::class, $container->get(InvokerStrategyInterface::class));
     }
 }

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\BootloadManager\InitializerInterface;
@@ -254,7 +254,7 @@ class KernelTest extends TestCase
         TestCore::create(
             directories: ['root' => __DIR__],
             container: $container,
-            bootloadManager: new Autowire(CustomizableBootloadManager::class, [
+            bootloadManager: new Autowire(StrategyBasedBootloadManager::class, [
                 'invoker' => new CustomInvokerStrategy()
             ])
         );

--- a/src/Boot/tests/TestCase.php
+++ b/src/Boot/tests/TestCase.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Boot;
 
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Core\Container;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function getBootloadManager(Container $container = new Container()): CustomizableBootloadManager
+    public function getBootloadManager(Container $container = new Container()): StrategyBasedBootloadManager
     {
         $initializer = new Initializer($container, $container);
 
-        return new CustomizableBootloadManager(
+        return new StrategyBasedBootloadManager(
             new DefaultInvokerStrategy($initializer, $container, $container),
             $container,
             $initializer

--- a/src/Boot/tests/TestCase.php
+++ b/src/Boot/tests/TestCase.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Boot;
 
 use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
-use Spiral\Boot\BootloadManager\DefaultStrategy;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Core\Container;
 
@@ -16,7 +16,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $initializer = new Initializer($container, $container);
 
         return new CustomizableBootloadManager(
-            new DefaultStrategy($initializer, $container, $container),
+            new DefaultInvokerStrategy($initializer, $container, $container),
             $container,
             $initializer
         );

--- a/src/Boot/tests/TestCase.php
+++ b/src/Boot/tests/TestCase.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Boot;
 
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\DefaultStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Core\Container;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function getBootloadManager(Container $container = new Container()): BootloadManager
+    public function getBootloadManager(Container $container = new Container()): CustomizableBootloadManager
     {
-        return new BootloadManager(
+        $initializer = new Initializer($container, $container);
+
+        return new CustomizableBootloadManager(
+            new DefaultStrategy($initializer, $container, $container),
             $container,
-            $container,
-            $container,
-            new Initializer($container, $container)
+            $initializer
         );
     }
 }

--- a/src/Bridge/Monolog/tests/FactoryTest.php
+++ b/src/Bridge/Monolog/tests/FactoryTest.php
@@ -10,7 +10,7 @@ use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
 use Psr\Log\LoggerInterface;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -70,7 +70,7 @@ class FactoryTest extends BaseTest
         $this->container->bind(FinalizerInterface::class, $finalizer = \Mockery::mock(FinalizerInterface::class));
         $finalizer->shouldReceive('addFinalizer')->once();
 
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->bind(LogFactory::class, $factory);
 
         $this->assertSame($logger, $this->container->get(Logger::class));
@@ -112,7 +112,7 @@ class FactoryTest extends BaseTest
         $processor->shouldReceive('reset')->once();
 
         $this->container->bind(LogFactory::class, $factory);
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LogsInterface::class)->getLogger();
         $finalizer->finalize();
     }
@@ -152,7 +152,7 @@ class FactoryTest extends BaseTest
         $processor->shouldReceive('reset')->never();
 
         $this->container->bind(LogFactory::class, $factory);
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LogsInterface::class)->getLogger();
         $finalizer->finalize(true);
     }

--- a/src/Bridge/Monolog/tests/FactoryTest.php
+++ b/src/Bridge/Monolog/tests/FactoryTest.php
@@ -10,7 +10,7 @@ use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
 use Psr\Log\LoggerInterface;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -70,7 +70,7 @@ class FactoryTest extends BaseTest
         $this->container->bind(FinalizerInterface::class, $finalizer = \Mockery::mock(FinalizerInterface::class));
         $finalizer->shouldReceive('addFinalizer')->once();
 
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->bind(LogFactory::class, $factory);
 
         $this->assertSame($logger, $this->container->get(Logger::class));
@@ -112,7 +112,7 @@ class FactoryTest extends BaseTest
         $processor->shouldReceive('reset')->once();
 
         $this->container->bind(LogFactory::class, $factory);
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LogsInterface::class)->getLogger();
         $finalizer->finalize();
     }
@@ -152,7 +152,7 @@ class FactoryTest extends BaseTest
         $processor->shouldReceive('reset')->never();
 
         $this->container->bind(LogFactory::class, $factory);
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LogsInterface::class)->getLogger();
         $finalizer->finalize(true);
     }

--- a/src/Bridge/Monolog/tests/HandlersTest.php
+++ b/src/Bridge/Monolog/tests/HandlersTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -42,7 +42,7 @@ class HandlersTest extends BaseTest
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 
     public function testNoHandlers(): void

--- a/src/Bridge/Monolog/tests/HandlersTest.php
+++ b/src/Bridge/Monolog/tests/HandlersTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -42,7 +42,7 @@ class HandlersTest extends BaseTest
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 
     public function testNoHandlers(): void

--- a/src/Bridge/Monolog/tests/LoggerTest.php
+++ b/src/Bridge/Monolog/tests/LoggerTest.php
@@ -8,7 +8,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -46,7 +46,7 @@ class LoggerTest extends BaseTest
 
         $injector->shouldReceive('createInjection')->once()->andReturn($logger);
 
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LoggerInterface::class);
 
         $finalizer->finalize();

--- a/src/Bridge/Monolog/tests/LoggerTest.php
+++ b/src/Bridge/Monolog/tests/LoggerTest.php
@@ -8,7 +8,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -46,7 +46,7 @@ class LoggerTest extends BaseTest
 
         $injector->shouldReceive('createInjection')->once()->andReturn($logger);
 
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LoggerInterface::class);
 
         $finalizer->finalize();

--- a/src/Bridge/Monolog/tests/ProcessorsTest.php
+++ b/src/Bridge/Monolog/tests/ProcessorsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Monolog;
 
 use Monolog\Processor\PsrLogMessageProcessor;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -40,7 +40,7 @@ class ProcessorsTest extends BaseTest
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 
     public function testDefaultProcessor(): void

--- a/src/Bridge/Monolog/tests/ProcessorsTest.php
+++ b/src/Bridge/Monolog/tests/ProcessorsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Monolog;
 
 use Monolog\Processor\PsrLogMessageProcessor;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -40,7 +40,7 @@ class ProcessorsTest extends BaseTest
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 
     public function testDefaultProcessor(): void

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -34,7 +34,7 @@ class RotateHandlerTest extends BaseTest
                 }
             }
         ));
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
 
         $autowire = new Container\Autowire('log.rotate', [
             'filename' => 'monolog.log'

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -34,7 +34,7 @@ class RotateHandlerTest extends BaseTest
                 }
             }
         ));
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
 
         $autowire = new Container\Autowire('log.rotate', [
             'filename' => 'monolog.log'

--- a/src/Bridge/Monolog/tests/TraitTest.php
+++ b/src/Bridge/Monolog/tests/TraitTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Logger;
 use Psr\Log\NullLogger;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -61,7 +61,7 @@ class TraitTest extends BaseTest
                 }
             }
         ));
-        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->bind(MonologConfig::class, new MonologConfig());
         $this->container->bind(ListenerRegistryInterface::class, new ListenerRegistry());
 

--- a/src/Bridge/Monolog/tests/TraitTest.php
+++ b/src/Bridge/Monolog/tests/TraitTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Logger;
 use Psr\Log\NullLogger;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
@@ -61,7 +61,7 @@ class TraitTest extends BaseTest
                 }
             }
         ));
-        $this->container->get(BootloadManager::class)->bootload([MonologBootloader::class]);
+        $this->container->get(CustomizableBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->bind(MonologConfig::class, new MonologConfig());
         $this->container->bind(ListenerRegistryInterface::class, new ListenerRegistry());
 

--- a/src/Bridge/Stempler/tests/BaseTest.php
+++ b/src/Bridge/Stempler/tests/BaseTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Stempler;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
-use Spiral\Boot\BootloadManager\DefaultStrategy;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\Directories;
 use Spiral\Boot\DirectoriesInterface;
@@ -65,7 +65,7 @@ abstract class BaseTest extends TestCase
 
         $initializer = new Initializer($this->container, $this->container);
         $this->app = new CustomizableBootloadManager(
-            new DefaultStrategy($initializer, $this->container, $this->container),
+            new DefaultInvokerStrategy($initializer, $this->container, $this->container),
             $this->container,
             $initializer
         );

--- a/src/Bridge/Stempler/tests/BaseTest.php
+++ b/src/Bridge/Stempler/tests/BaseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Stempler;
 
 use PHPUnit\Framework\TestCase;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\Directories;
@@ -33,7 +33,7 @@ abstract class BaseTest extends TestCase
     ];
 
     protected Container $container;
-    protected CustomizableBootloadManager $app;
+    protected StrategyBasedBootloadManager $app;
 
     public function setUp(): void
     {
@@ -64,7 +64,7 @@ abstract class BaseTest extends TestCase
         $this->container->bind(ViewsInterface::class, ViewManager::class);
 
         $initializer = new Initializer($this->container, $this->container);
-        $this->app = new CustomizableBootloadManager(
+        $this->app = new StrategyBasedBootloadManager(
             new DefaultInvokerStrategy($initializer, $this->container, $this->container),
             $this->container,
             $initializer

--- a/src/Bridge/Stempler/tests/BaseTest.php
+++ b/src/Bridge/Stempler/tests/BaseTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Spiral\Tests\Stempler;
 
 use PHPUnit\Framework\TestCase;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\DefaultStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\Directories;
 use Spiral\Boot\DirectoriesInterface;
@@ -30,12 +31,9 @@ abstract class BaseTest extends TestCase
         StemplerBootloader::class,
         PrettyPrintBootloader::class
     ];
-    /** @var Container */
-    protected $container;
-    /**
-     * @var BootloadManager
-     */
-    protected $app;
+
+    protected Container $container;
+    protected CustomizableBootloadManager $app;
 
     public function setUp(): void
     {
@@ -65,13 +63,13 @@ abstract class BaseTest extends TestCase
 
         $this->container->bind(ViewsInterface::class, ViewManager::class);
 
-        $this->app = new BootloadManager(
+        $initializer = new Initializer($this->container, $this->container);
+        $this->app = new CustomizableBootloadManager(
+            new DefaultStrategy($initializer, $this->container, $this->container),
             $this->container,
-            $this->container,
-            $this->container,
-            new Initializer($this->container, $this->container)
+            $initializer
         );
-        
+
         $this->app->bootload(static::BOOTLOADERS);
     }
 

--- a/tests/app/src/Bootloader/AuthBootloader.php
+++ b/tests/app/src/Bootloader/AuthBootloader.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Spiral\App\Bootloader;
 
 use Spiral\Boot\Bootloader\Bootloader;
-use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
+use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Bootloader\Auth\HttpAuthBootloader;
 
 class AuthBootloader extends Bootloader
 {
-    public function init(CustomizableBootloadManager $bootloadManager): void
+    public function init(StrategyBasedBootloadManager $bootloadManager): void
     {
         $bootloadManager->bootload([HttpAuthBootloader::class]);
     }

--- a/tests/app/src/Bootloader/AuthBootloader.php
+++ b/tests/app/src/Bootloader/AuthBootloader.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Spiral\App\Bootloader;
 
 use Spiral\Boot\Bootloader\Bootloader;
-use Spiral\Boot\BootloadManager\BootloadManager;
+use Spiral\Boot\BootloadManager\CustomizableBootloadManager;
 use Spiral\Bootloader\Auth\HttpAuthBootloader;
 
 class AuthBootloader extends Bootloader
 {
-    public function init(BootloadManager $bootloadManager): void
+    public function init(CustomizableBootloadManager $bootloadManager): void
     {
         $bootloadManager->bootload([HttpAuthBootloader::class]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

- Added `Spiral\Boot\BootloadManager\InitializerInterface`. This will allow changing the implementation of this interface by the developer.
- Added the ability to register application bootloaders via object instance.

```php
namespace App\Application;

use App\Application\Bootloader;

class Kernel extends \Spiral\Framework\Kernel
{
    // ...
    
    protected function defineBootloaders(): array
    {
        return [
            new Bootloader\RoutesBootloader(),
            new class () extends Bootloader {
                public const BINDINGS = [
                    // ...
                ];
                public const SINGLETONS = [
                    // ...
                ];

                public function init(BinderInterface $binder): void
                {
                    // ...
                }

                public function boot(BinderInterface $binder): void
                {
                     // ...
                }
            },
        ];
    }
    
    // ...
}
```

- Removed `final` from the `Spiral\Boot\BootloadManager\Initializer` class.
- Added `Spiral\Boot\BootloadManager\StrategyBasedBootloadManager`. This BootloadManager allows 
    the implementation of a custom bootloaders loading strategy.

```php
// file app.php

use App\Application\Kernel;
use App\Application\Service\ErrorHandler\Handler;
use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
use Spiral\Boot\BootloadManager\Initializer;
use Spiral\Core\Container;

// ...

$container = new Container();

$app = Kernel::create(
    directories: ['root' => __DIR__],
    exceptionHandler: Handler::class,
    bootloadManager: new StrategyBasedBootloadManager(
        new RoadRunnerEnvInvokerStrategy(), 
        $container, 
        new Initializer($container, $container)
    )
)->run();

// ...
```

Or via **Spiral\Core\Container\Autowire**:

```php
use App\Application\Kernel;
use App\Application\Service\ErrorHandler\Handler;
use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
use Spiral\Core\Container;
use Spiral\Core\Container\Autowire;

// ...

$container = new Container();

$app = Kernel::create(
    directories: ['root' => __DIR__],
    exceptionHandler: Handler::class,
    bootloadManager: new Autowire(StrategyBasedBootloadManager::class, [
        'invoker' => new CustomInvokerStrategy()
    ])
)->run();

// ...
```
