### PR TITLE
Fixes problem with using view context with default value.

### DIFF
--- a/src/Views/src/Processor/ContextProcessor.php
+++ b/src/Views/src/Processor/ContextProcessor.php
@@ -31,13 +31,9 @@ final class ContextProcessor implements ProcessorInterface
                 $this->pattern,
                 static function (array $matches) use ($context) {
                     try {
-                        return $context->resolveValue($matches['name']);
+                        return $context->resolveValue($matches['name']) ?? $matches['default'] ?? null;
                     } catch (ContextException $e) {
-                        if (isset($matches['default'])) {
-                            return $matches['default'];
-                        }
-
-                        throw $e;
+                        return $matches['default'] ?? throw $e;
                     }
                 },
                 $source->getCode()

--- a/src/Views/src/Processor/ContextProcessor.php
+++ b/src/Views/src/Processor/ContextProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Views\Processor;
 
 use Spiral\Views\ContextInterface;
+use Spiral\Views\Exception\ContextException;
 use Spiral\Views\ProcessorInterface;
 use Spiral\Views\ViewSource;
 
@@ -20,15 +21,27 @@ final class ContextProcessor implements ProcessorInterface
 
     public function __construct(string $pattern = null)
     {
-        $this->pattern = $pattern ?? static::PATTERN;
+        $this->pattern = $pattern ?? self::PATTERN;
     }
 
     public function process(ViewSource $source, ContextInterface $context): ViewSource
     {
-        return $source->withCode(\preg_replace_callback(
-            $this->pattern,
-            static fn (array $matches) => $context->resolveValue($matches[1]),
-            $source->getCode()
-        ));
+        return $source->withCode(
+            \preg_replace_callback(
+                $this->pattern,
+                static function (array $matches) use ($context) {
+                    try {
+                        return $context->resolveValue($matches['name']);
+                    } catch (ContextException $e) {
+                        if (isset($matches['default'])) {
+                            return $matches['default'];
+                        }
+
+                        throw $e;
+                    }
+                },
+                $source->getCode()
+            ),
+        );
     }
 }

--- a/src/Views/tests/ContextProcessorTest.php
+++ b/src/Views/tests/ContextProcessorTest.php
@@ -13,21 +13,37 @@ use Spiral\Views\ViewContext;
 use Spiral\Views\ViewLoader;
 use Spiral\Views\ViewSource;
 
-class ContextProcessorTest extends TestCase
+final class ContextProcessorTest extends TestCase
 {
     use ProcessorTrait;
 
     public function testProcessContext(): void
     {
         $this->processors[] = new ContextProcessor();
-
         $source = $this->getSource('other:inject');
-
-        $this->assertSame('hello @{name|default}', $source->getCode());
-
+        $this->assertSame("hello @{name}\n", $source->getCode());
         $ctx = new ViewContext();
         $source2 = $this->process($source, $ctx->withDependency(new ValueDependency('name', 'Bobby')));
-        $this->assertSame('hello Bobby', $source2->getCode());
+        $this->assertSame("hello Bobby\n", $source2->getCode());
+    }
+
+    public function testProcessContextWithDefaultValue(): void
+    {
+        $this->processors[] = new ContextProcessor();
+        $source = $this->getSource('other:injectWithDefault');
+        $this->assertSame("hello @{name|default}\n", $source->getCode());
+        $ctx = new ViewContext();
+        $source2 = $this->process($source, $ctx->withDependency(new ValueDependency('name', 'Bobby')));
+        $this->assertSame("hello Bobby\n", $source2->getCode());
+    }
+
+    public function testProcessContextShouldUseDefaultValueIfKeyNotFound(): void
+    {
+        $this->processors[] = new ContextProcessor();
+        $source = $this->getSource('other:injectWithDefault');
+        $ctx = new ViewContext();
+        $source2 = $this->process($source, $ctx);
+        $this->assertSame("hello default\n", $source2->getCode());
     }
 
     public function testProcessContextException(): void
@@ -37,9 +53,6 @@ class ContextProcessorTest extends TestCase
         $this->processors[] = new ContextProcessor();
 
         $source = $this->getSource('other:inject');
-
-        $this->assertSame('hello @{name|default}', $source->getCode());
-
         $ctx = new ViewContext();
         $this->process($source, $ctx);
     }

--- a/src/Views/tests/ContextProcessorTest.php
+++ b/src/Views/tests/ContextProcessorTest.php
@@ -46,6 +46,15 @@ final class ContextProcessorTest extends TestCase
         $this->assertSame("hello default\n", $source2->getCode());
     }
 
+    public function testProcessContextShouldUseDefaultValueIfContextIsNull(): void
+    {
+        $this->processors[] = new ContextProcessor();
+        $source = $this->getSource('other:injectWithDefault');
+        $ctx = new ViewContext();
+        $source2 = $this->process($source, $ctx->withDependency(new ValueDependency('name', null)));
+        $this->assertSame("hello default\n", $source2->getCode());
+    }
+
     public function testProcessContextException(): void
     {
         $this->expectException(ContextException::class);
@@ -61,7 +70,7 @@ final class ContextProcessorTest extends TestCase
     {
         $loader = new ViewLoader([
             'default' => __DIR__ . '/fixtures/default',
-            'other'   => __DIR__ . '/fixtures/other',
+            'other' => __DIR__ . '/fixtures/other',
         ]);
 
         return $loader->withExtension('php')->load($path);

--- a/src/Views/tests/LoaderTest.php
+++ b/src/Views/tests/LoaderTest.php
@@ -177,7 +177,7 @@ class LoaderTest extends TestCase
         $this->assertContains('other:view', $files);
 
         $files = $loader->list('other');
-        $this->assertCount(4, $files);
+        $this->assertCount(5, $files);
         $this->assertContains('other:view', $files);
     }
 }

--- a/src/Views/tests/fixtures/other/inject.php
+++ b/src/Views/tests/fixtures/other/inject.php
@@ -1,1 +1,1 @@
-hello @{name|default}
+hello @{name}

--- a/src/Views/tests/fixtures/other/injectWithDefault.php
+++ b/src/Views/tests/fixtures/other/injectWithDefault.php
@@ -1,0 +1,1 @@
+hello @{name|default}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌

Spiral Framework has an ability to get values from view context

```html
<!DOCTYPE html>
<html lang="@{locale}">   <----
<head>
    ...
</head>
</html>
```

If context  with given key is not registered an Exception will be thrown. 

But there is an ability to set a default value for the context 
```html
@{locale|default}
```
And a default value will never be used.

The PR fixes this behavior and allows using a default value when context with given key was not found.


