### PR TITLE
Adding property existence check

### DIFF
--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -49,7 +49,6 @@ final class Container implements
     private ContainerInterface|Internal\Container $container;
     private BinderInterface|Internal\Binder $binder;
     private InvokerInterface|Internal\Invoker $invoker;
-    private Internal\Tracer $tracer;
 
     /**
      * Container constructor.
@@ -60,7 +59,9 @@ final class Container implements
             'state' => new Internal\State(),
         ]);
         foreach ($config as $property => $class) {
-            $this->$property = $constructor->get($property, $class);
+            if (\property_exists($this, $property)) {
+                $this->$property = $constructor->get($property, $class);
+            }
         }
 
         /** @psalm-suppress PossiblyNullPropertyAssignment */

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -49,6 +49,7 @@ final class Container implements
     private ContainerInterface|Internal\Container $container;
     private BinderInterface|Internal\Binder $binder;
     private InvokerInterface|Internal\Invoker $invoker;
+    private Internal\Tracer $tracer;
 
     /**
      * Container constructor.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌

With **PHP 8.2** missing property causes an error:
```php
Creation of dynamic property Spiral\Core\Container::$tracer is deprecated 
```