### PR TITLE
Add route pattern registry

### DIFF
--- a/src/Framework/Bootloader/Http/RouterBootloader.php
+++ b/src/Framework/Bootloader/Http/RouterBootloader.php
@@ -23,6 +23,8 @@ use Spiral\Router\Loader\LoaderInterface;
 use Spiral\Router\Loader\LoaderRegistry;
 use Spiral\Router\Loader\LoaderRegistryInterface;
 use Spiral\Router\Loader\PhpFileLoader;
+use Spiral\Router\Registry\DefaultPatternRegistry;
+use Spiral\Router\Registry\RoutePatternRegistryInterface;
 use Spiral\Router\RouteInterface;
 use Spiral\Router\Router;
 use Spiral\Router\RouterInterface;
@@ -46,6 +48,7 @@ final class RouterBootloader extends Bootloader
         LoaderRegistryInterface::class => [self::class, 'initRegistry'],
         GroupRegistry::class => GroupRegistry::class,
         RoutingConfigurator::class => RoutingConfigurator::class,
+        RoutePatternRegistryInterface::class => DefaultPatternRegistry::class,
     ];
 
     public function __construct(

--- a/src/Router/src/Registry/DefaultPatternRegistry.php
+++ b/src/Router/src/Registry/DefaultPatternRegistry.php
@@ -4,20 +4,15 @@ namespace Spiral\Router\Registry;
 
 final class DefaultPatternRegistry implements RoutePatternRegistryInterface
 {
-    private array $patterns = [];
-
-    public function __construct(array $defaultPatterns = [])
-    {
-        foreach ($defaultPatterns as $name => $pattern) {
-            $this->register($name, $pattern);
-        }
-    }
+    private array $patterns = [
+        'int' => '\d+',
+        'integer' => '\d+',
+        'uuid' => '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}',
+    ];
 
     public function register(string $name, string|\Stringable $pattern): void
     {
-        if (!isset($this->patterns[$name])) {
-            $this->patterns[$name] = (string)$pattern;
-        }
+        $this->patterns[$name] = (string)$pattern;
     }
 
     public function all(): array

--- a/src/Router/src/Registry/DefaultPatternRegistry.php
+++ b/src/Router/src/Registry/DefaultPatternRegistry.php
@@ -4,6 +4,9 @@ namespace Spiral\Router\Registry;
 
 final class DefaultPatternRegistry implements RoutePatternRegistryInterface
 {
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
     private array $patterns = [
         'int' => '\d+',
         'integer' => '\d+',

--- a/src/Router/src/Registry/DefaultPatternRegistry.php
+++ b/src/Router/src/Registry/DefaultPatternRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spiral\Router\Registry;
+
+final class DefaultPatternRegistry implements RoutePatternRegistryInterface
+{
+    private array $patterns = [];
+
+    public function __construct(array $defaultPatterns = [])
+    {
+        foreach ($defaultPatterns as $name => $pattern) {
+            $this->register($name, $pattern);
+        }
+    }
+
+    public function register(string $name, string|\Stringable $pattern): void
+    {
+        if (!isset($this->patterns[$name])) {
+            $this->patterns[$name] = (string)$pattern;
+        }
+    }
+
+    public function all(): array
+    {
+        return $this->patterns;
+    }
+}

--- a/src/Router/src/Registry/DefaultPatternRegistry.php
+++ b/src/Router/src/Registry/DefaultPatternRegistry.php
@@ -17,10 +17,6 @@ final class DefaultPatternRegistry implements RoutePatternRegistryInterface
      * @param non-empty-string $name
      * @param non-empty-string|\Stringable $pattern
      */
-    /**
-     * @param non-empty-string $name
-     * @param non-empty-string|\Stringable $pattern
-     */
     public function register(string $name, string|\Stringable $pattern): void
     {
         $this->patterns[$name] = (string)$pattern;

--- a/src/Router/src/Registry/RoutePatternRegistryInterface.php
+++ b/src/Router/src/Registry/RoutePatternRegistryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spiral\Router\Registry;
+
+interface RoutePatternRegistryInterface
+{
+    public function register(string $name, string|\Stringable $pattern): void;
+
+    /**
+     * @return array<string, string>
+     */
+    public function all(): array;
+}

--- a/src/Router/src/Registry/RoutePatternRegistryInterface.php
+++ b/src/Router/src/Registry/RoutePatternRegistryInterface.php
@@ -7,7 +7,7 @@ interface RoutePatternRegistryInterface
     public function register(string $name, string|\Stringable $pattern): void;
 
     /**
-     * @return array<string, string>
+     * @return array<non-empty-string, non-empty-string>
      */
     public function all(): array;
 }

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -135,7 +135,7 @@ final class UriHandler
         }
 
         $matches = \array_intersect_key(
-            \array_filter($matches, static fn(string $value) => $value !== ''),
+            \array_filter($matches, static fn (string $value) => $value !== ''),
             $this->options
         );
 
@@ -306,7 +306,7 @@ final class UriHandler
             !isset($this->constrains[$name]) => self::DEFAULT_SEGMENT,
             \is_array($this->constrains[$name]) => \implode(
                 '|',
-                \array_map(fn(string $segment): string => $this->filterSegment($segment), $this->constrains[$name])
+                \array_map(fn (string $segment): string => $this->filterSegment($segment), $this->constrains[$name])
             ),
             default => $this->filterSegment((string)$this->constrains[$name])
         };

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -22,11 +22,6 @@ final class UriHandler
     private const DEFAULT_SEGMENT = '[^\/]+';
     private const PATTERN_REPLACES = ['/' => '\\/', '[' => '(?:', ']' => ')?', '.' => '\.'];
     private const SEGMENT_REPLACES = ['/' => '\\/', '.' => '\.'];
-    private const SEGMENT_TYPES = [
-        'int' => '\d+',
-        'integer' => '\d+',
-        'uuid' => '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}',
-    ];
     private const URI_FIXERS = [
         '[]' => '',
         '[/]' => '',
@@ -52,9 +47,7 @@ final class UriHandler
     public function __construct(
         private readonly UriFactoryInterface $uriFactory,
         SlugifyInterface $slugify = null,
-        private readonly ?RoutePatternRegistryInterface $patternRegistry = new DefaultPatternRegistry(
-            self::SEGMENT_TYPES
-        )
+        private readonly ?RoutePatternRegistryInterface $patternRegistry = new DefaultPatternRegistry()
     ) {
         $this->slugify = $slugify ?? new Slugify();
     }

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -47,7 +47,7 @@ final class UriHandler
     public function __construct(
         private readonly UriFactoryInterface $uriFactory,
         SlugifyInterface $slugify = null,
-        private readonly ?RoutePatternRegistryInterface $patternRegistry = new DefaultPatternRegistry()
+        private readonly ?RoutePatternRegistryInterface $patternRegistry = new DefaultPatternRegistry(),
     ) {
         $this->slugify = $slugify ?? new Slugify();
     }

--- a/src/Router/tests/DefaultPatternRegistryTest.php
+++ b/src/Router/tests/DefaultPatternRegistryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spiral\Tests\Router;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Router\Registry\DefaultPatternRegistry;
+
+final class DefaultPatternRegistryTest extends TestCase
+{
+    private const DEFAULT_PATTERNS = [
+        'int' => '\d+',
+        'integer' => '\d+',
+        'uuid' => '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}',
+    ];
+
+    public function testAll(): void
+    {
+        $registry = new DefaultPatternRegistry();
+
+        $registry->register('foo', '\d+');
+        $registry->register('bar', '\d+');
+
+        $this->assertSame(
+            self::DEFAULT_PATTERNS + [
+                'foo' => '\d+',
+                'bar' => '\d+'
+            ],
+            $registry->all()
+        );
+    }
+}

--- a/src/Router/tests/Fixtures/InArrayPattern.php
+++ b/src/Router/tests/Fixtures/InArrayPattern.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spiral\Tests\Router\Fixtures;
+
+class InArrayPattern implements \Stringable
+{
+    public function __construct(
+        private readonly array $values
+    ) {
+    }
+
+    public function __toString()
+    {
+        return \sprintf('(%s)', \implode('|', $this->values));
+    }
+}

--- a/src/Router/tests/PatternsTests.php
+++ b/src/Router/tests/PatternsTests.php
@@ -7,9 +7,11 @@ namespace Spiral\Tests\Router;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Spiral\Router\Registry\DefaultPatternRegistry;
 use Spiral\Router\Route;
 use Spiral\Router\UriHandler;
 use Spiral\Tests\Router\Diactoros\UriFactory;
+use Spiral\Tests\Router\Fixtures\InArrayPattern;
 
 class PatternsTests extends TestCase
 {
@@ -27,7 +29,177 @@ class PatternsTests extends TestCase
         $this->assertSame([
             'moduleType' => '10',
             'moduleId' => '285',
-            'type' => '0'
+            'type' => '0',
+        ], $match->getMatches());
+    }
+
+    public function testIntPatternWithValidValue(): void
+    {
+        $route = new Route(
+            '/users/<int:int>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/1'))
+        );
+
+        $this->assertSame([
+            'int' => '1',
+        ], $match->getMatches());
+    }
+
+    public function testIntPatternWithInvalidValue(): void
+    {
+        $route = new Route(
+            '/users/<int:int>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/1b'))
+        );
+
+        $this->assertNull($match);
+    }
+
+    public function testIntegerPatternWithValidValue(): void
+    {
+        $route = new Route(
+            '/users/<integer:integer>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/1'))
+        );
+
+        $this->assertSame([
+            'integer' => '1',
+        ], $match->getMatches());
+    }
+
+    public function testIntegerPatternWithInvalidValue(): void
+    {
+        $route = new Route(
+            '/users/<integer:integer>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/1b'))
+        );
+
+        $this->assertNull($match);
+    }
+
+    public function testUuidPatternWithValidValue(): void
+    {
+        $route = new Route(
+            '/users/<uuid:uuid>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/34f7b660-7ad0-11ed-a1eb-0242ac120002'))
+        );
+
+        $this->assertSame([
+            'uuid' => '34f7b660-7ad0-11ed-a1eb-0242ac120002',
+        ], $match->getMatches());
+    }
+
+    public function testUuidPatternWithInvalidValue(): void
+    {
+        $route = new Route(
+            '/users/<uuid:uuid>',
+            'test'
+        );
+
+        $route = $route->withUriHandler(new UriHandler(new UriFactory()));
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/34f7b660-7ad0'))
+        );
+
+        $this->assertNull($match);
+    }
+
+    public function testCustomPattern(): void
+    {
+        $route = new Route(
+            '/users/<uuid:foo>',
+            'test'
+        );
+
+        $registry = new DefaultPatternRegistry();
+
+        $registry->register(
+            'foo',
+            '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
+        );
+        $registry->register(
+            'bar',
+            '[0-9]+'
+        );
+
+        $route = $route->withUriHandler(
+            new UriHandler(
+                new UriFactory(),
+                patternRegistry: $registry
+            )
+        );
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/34f7b660-7ad0-11ed-a1eb-0242ac222222'))
+        );
+
+        $this->assertSame([
+            'uuid' => '34f7b660-7ad0-11ed-a1eb-0242ac222222',
+        ], $match->getMatches());
+    }
+
+    public function testCustomStringablePattern(): void
+    {
+        $route = new Route(
+            '/users/<name:in_array>',
+            'test'
+        );
+
+        $registry = new DefaultPatternRegistry();
+
+        $registry->register(
+            'in_array',
+            new InArrayPattern(['foo', 'bar'])
+        );
+        $registry->register(
+            'foo',
+            '[0-9]+'
+        );
+
+        $route = $route->withUriHandler(
+            new UriHandler(
+                new UriFactory(),
+                patternRegistry: $registry
+            )
+        );
+
+        $match = $route->match(
+            new ServerRequest('GET', new Uri('http://site.com/users/foo'))
+        );
+
+        $this->assertSame([
+            'name' => 'foo',
         ], $match->getMatches());
     }
 }

--- a/src/Router/tests/Stub/InArrayPattern.php
+++ b/src/Router/tests/Stub/InArrayPattern.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spiral\Tests\Router\Fixtures;
+namespace Spiral\Tests\Router\Stub;
 
 class InArrayPattern implements \Stringable
 {

--- a/tests/Framework/Bootloader/Router/RouterBootloaderTest.php
+++ b/tests/Framework/Bootloader/Router/RouterBootloaderTest.php
@@ -13,6 +13,8 @@ use Spiral\Router\Loader\DelegatingLoader;
 use Spiral\Router\Loader\LoaderInterface;
 use Spiral\Router\Loader\LoaderRegistry;
 use Spiral\Router\Loader\LoaderRegistryInterface;
+use Spiral\Router\Registry\DefaultPatternRegistry;
+use Spiral\Router\Registry\RoutePatternRegistryInterface;
 use Spiral\Router\RouteInterface;
 use Spiral\Router\Router;
 use Spiral\Router\RouterInterface;
@@ -53,6 +55,11 @@ final class RouterBootloaderTest extends BaseTest
     public function testRoutingConfiguratorBinding(): void
     {
         $this->assertContainerBoundAsSingleton(RoutingConfigurator::class, RoutingConfigurator::class);
+    }
+
+    public function testRoutePatternRegistryBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(RoutePatternRegistryInterface::class, DefaultPatternRegistry::class);
     }
 
     public function testRouteInterfaceBinding(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

#### Patterns registration
```php
use Spiral\Router\Registry\RoutePatternRegistryInterface;

class AppBootloader extends Bootloader
{
   public function boot(RoutePatternRegistryInterface $patternRegistry) {
      $patternRegistry->register(
          'uuid', 
          '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}'
      );
   }
}
```

#### Using
```php
#Route(uri: 'blog/post/<post:uuid>')
public function show(string $post)
{ 
    \var_dum($post); // f403554a-e70f-479a-969b-3edc047912a3
}
```
