### PR TITLE
Improving PhpNamespace in the Reactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Unreleased
+- **Medium Impact Changes**
+  - [spiral/reactor] Method `removeClass` of `Spiral\Reactor\Partial\PhpNamespace` class is deprecated.
+    Use method `removeElement` instead.
+- **Other Features**
+  - [spiral/reactor] Added methods `removeElement`, `getElements`, `getEnums`, `getTraits`, `getInterfaces`, 
+    in the class `Spiral\Reactor\Partial\PhpNamespace`.
+
 ## 3.4.0 - 2022-12-08
 - **Medium Impact Changes**
   - [spiral/boot] Class `Spiral\Boot\BootloadManager\BootloadManager` is deprecated. Will be removed in version v4.0.

--- a/src/Reactor/src/Aggregator/Elements.php
+++ b/src/Reactor/src/Aggregator/Elements.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Reactor\Aggregator;
+
+use Spiral\Reactor\Aggregator;
+use Spiral\Reactor\ClassDeclaration;
+use Spiral\Reactor\EnumDeclaration;
+use Spiral\Reactor\InterfaceDeclaration;
+use Spiral\Reactor\TraitDeclaration;
+
+/**
+ * Enums aggregation.
+ *
+ * @extends Aggregator<ClassDeclaration|InterfaceDeclaration|TraitDeclaration|EnumDeclaration>
+ */
+final class Elements extends Aggregator
+{
+    public function __construct(array $elements)
+    {
+        parent::__construct([
+            ClassDeclaration::class,
+            InterfaceDeclaration::class,
+            TraitDeclaration::class,
+            EnumDeclaration::class
+        ], $elements);
+    }
+}

--- a/src/Reactor/src/Aggregator/Elements.php
+++ b/src/Reactor/src/Aggregator/Elements.php
@@ -11,7 +11,7 @@ use Spiral\Reactor\InterfaceDeclaration;
 use Spiral\Reactor\TraitDeclaration;
 
 /**
- * Enums aggregation.
+ * Classes, interfaces, traits, enums aggregation.
  *
  * @extends Aggregator<ClassDeclaration|InterfaceDeclaration|TraitDeclaration|EnumDeclaration>
  */

--- a/src/Reactor/src/Aggregator/Elements.php
+++ b/src/Reactor/src/Aggregator/Elements.php
@@ -23,7 +23,7 @@ final class Elements extends Aggregator
             ClassDeclaration::class,
             InterfaceDeclaration::class,
             TraitDeclaration::class,
-            EnumDeclaration::class
+            EnumDeclaration::class,
         ], $elements);
     }
 }

--- a/src/Reactor/src/Aggregator/Enums.php
+++ b/src/Reactor/src/Aggregator/Enums.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Reactor\Aggregator;
+
+use Spiral\Reactor\Aggregator;
+use Spiral\Reactor\EnumDeclaration;
+
+/**
+ * Enums aggregation.
+ *
+ * @extends Aggregator<EnumDeclaration>
+ */
+final class Enums extends Aggregator
+{
+    public function __construct(array $enums)
+    {
+        parent::__construct([EnumDeclaration::class], $enums);
+    }
+}

--- a/src/Reactor/src/Aggregator/Interfaces.php
+++ b/src/Reactor/src/Aggregator/Interfaces.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Reactor\Aggregator;
+
+use Spiral\Reactor\Aggregator;
+use Spiral\Reactor\InterfaceDeclaration;
+
+/**
+ * Interfaces aggregation.
+ *
+ * @extends Aggregator<InterfaceDeclaration>
+ */
+final class Interfaces extends Aggregator
+{
+    public function __construct(array $interfaces)
+    {
+        parent::__construct([InterfaceDeclaration::class], $interfaces);
+    }
+}

--- a/src/Reactor/src/Aggregator/Traits.php
+++ b/src/Reactor/src/Aggregator/Traits.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Reactor\Aggregator;
+
+use Spiral\Reactor\Aggregator;
+use Spiral\Reactor\TraitDeclaration;
+
+/**
+ * Traits aggregation.
+ *
+ * @extends Aggregator<TraitDeclaration>
+ */
+final class Traits extends Aggregator
+{
+    public function __construct(array $traits)
+    {
+        parent::__construct([TraitDeclaration::class], $traits);
+    }
+}

--- a/src/Reactor/src/EnumDeclaration.php
+++ b/src/Reactor/src/EnumDeclaration.php
@@ -13,7 +13,7 @@ use Spiral\Reactor\Partial\Method;
 use Spiral\Reactor\Partial\TraitUse;
 use Spiral\Reactor\Traits;
 
-class EnumDeclaration extends AbstractDeclaration
+class EnumDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;
     use Traits\MethodsAware;

--- a/src/Reactor/src/InterfaceDeclaration.php
+++ b/src/Reactor/src/InterfaceDeclaration.php
@@ -9,7 +9,7 @@ use Spiral\Reactor\Partial\Constant;
 use Spiral\Reactor\Partial\Method;
 use Spiral\Reactor\Traits;
 
-class InterfaceDeclaration extends AbstractDeclaration
+class InterfaceDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;
     use Traits\MethodsAware;

--- a/src/Reactor/src/TraitDeclaration.php
+++ b/src/Reactor/src/TraitDeclaration.php
@@ -11,7 +11,7 @@ use Spiral\Reactor\Partial\Property;
 use Spiral\Reactor\Partial\TraitUse;
 use Spiral\Reactor\Traits;
 
-class TraitDeclaration extends AbstractDeclaration
+class TraitDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;
     use Traits\MethodsAware;

--- a/src/Reactor/tests/AggregatorsTest.php
+++ b/src/Reactor/tests/AggregatorsTest.php
@@ -8,17 +8,24 @@ use PHPUnit\Framework\TestCase;
 use Spiral\Reactor\Aggregator;
 use Spiral\Reactor\Aggregator\Classes;
 use Spiral\Reactor\Aggregator\Constants;
+use Spiral\Reactor\Aggregator\Elements;
 use Spiral\Reactor\Aggregator\EnumCases;
+use Spiral\Reactor\Aggregator\Enums;
 use Spiral\Reactor\Aggregator\Functions;
+use Spiral\Reactor\Aggregator\Interfaces;
 use Spiral\Reactor\Aggregator\Methods;
 use Spiral\Reactor\Aggregator\Namespaces;
 use Spiral\Reactor\Aggregator\Parameters;
 use Spiral\Reactor\Aggregator\Properties;
+use Spiral\Reactor\Aggregator\Traits;
 use Spiral\Reactor\Aggregator\TraitUses;
 use Spiral\Reactor\ClassDeclaration;
+use Spiral\Reactor\EnumDeclaration;
 use Spiral\Reactor\Exception\ReactorException;
 use Spiral\Reactor\FunctionDeclaration;
+use Spiral\Reactor\InterfaceDeclaration;
 use Spiral\Reactor\Partial;
+use Spiral\Reactor\TraitDeclaration;
 
 final class AggregatorsTest extends TestCase
 {
@@ -128,6 +135,70 @@ final class AggregatorsTest extends TestCase
         $aggr->add($uses);
         $this->assertTrue($aggr->has('test'));
         $this->assertSame($uses, $aggr->get('test'));
+    }
+
+    public function testElements(): void
+    {
+        $aggr = new Elements([]);
+        $this->assertFalse($aggr->has('c'));
+        $this->assertFalse($aggr->has('i'));
+        $this->assertFalse($aggr->has('t'));
+        $this->assertFalse($aggr->has('e'));
+
+        $class = new ClassDeclaration('c');
+        $interface = new InterfaceDeclaration('i');
+        $trait = new TraitDeclaration('t');
+        $enum = new EnumDeclaration('e');
+
+        $aggr->add($class);
+        $aggr->add($interface);
+        $aggr->add($trait);
+        $aggr->add($enum);
+
+        $this->assertTrue($aggr->has('c'));
+        $this->assertSame($class, $aggr->get('c'));
+        $this->assertTrue($aggr->has('i'));
+        $this->assertSame($interface, $aggr->get('i'));
+        $this->assertTrue($aggr->has('t'));
+        $this->assertSame($trait, $aggr->get('t'));
+        $this->assertTrue($aggr->has('e'));
+        $this->assertSame($enum, $aggr->get('e'));
+    }
+
+    public function testEnums(): void
+    {
+        $aggr = new Enums([]);
+        $this->assertFalse($aggr->has('test'));
+
+        $enum = new EnumDeclaration('test');
+
+        $aggr->add($enum);
+        $this->assertTrue($aggr->has('test'));
+        $this->assertSame($enum, $aggr->get('test'));
+    }
+
+    public function testInterfaces(): void
+    {
+        $aggr = new Interfaces([]);
+        $this->assertFalse($aggr->has('test'));
+
+        $interface = new InterfaceDeclaration('test');
+
+        $aggr->add($interface);
+        $this->assertTrue($aggr->has('test'));
+        $this->assertSame($interface, $aggr->get('test'));
+    }
+
+    public function testTraits(): void
+    {
+        $aggr = new Traits([]);
+        $this->assertFalse($aggr->has('test'));
+
+        $trait = new TraitDeclaration('test');
+
+        $aggr->add($trait);
+        $this->assertTrue($aggr->has('test'));
+        $this->assertSame($trait, $aggr->get('test'));
     }
 
     public function testAggregator(): void

--- a/src/Reactor/tests/Partial/PhpNamespaceTest.php
+++ b/src/Reactor/tests/Partial/PhpNamespaceTest.php
@@ -6,6 +6,11 @@ namespace Spiral\Tests\Reactor\Partial;
 
 use PHPUnit\Framework\TestCase;
 use Nette\PhpGenerator\PhpNamespace as NettePhpNamespace;
+use Spiral\Reactor\Aggregator\Classes;
+use Spiral\Reactor\Aggregator\Elements;
+use Spiral\Reactor\Aggregator\Enums;
+use Spiral\Reactor\Aggregator\Interfaces;
+use Spiral\Reactor\Aggregator\Traits;
 use Spiral\Reactor\ClassDeclaration;
 use Spiral\Reactor\EnumDeclaration;
 use Spiral\Reactor\FileDeclaration;
@@ -95,7 +100,7 @@ final class PhpNamespaceTest extends TestCase
         $this->assertCount(1, $namespace->getClasses());
         $this->assertTrue($namespace->getClasses()->has('Test'));
 
-        $namespace->removeClass('Test');
+        $namespace->removeElement('Test');
         $this->assertCount(0, $namespace->getClasses());
         $this->assertFalse($namespace->getClasses()->has('Test'));
     }
@@ -151,5 +156,186 @@ final class PhpNamespaceTest extends TestCase
 
         $this->assertInstanceOf(NettePhpNamespace::class, $element);
         $this->assertSame('Foo\\Bar', $element->getName());
+    }
+
+    /**
+     * @dataProvider classesDataProvider
+     */
+    public function testGetClasses(PhpNamespace $namespace, Classes $expected): void
+    {
+        $this->assertEquals($namespace->getClasses(), $expected);
+    }
+
+    /**
+     * @dataProvider interfacesDataProvider
+     */
+    public function testGetInterfaces(PhpNamespace $namespace, Interfaces $expected): void
+    {
+        $this->assertEquals($namespace->getInterfaces(), $expected);
+    }
+
+    /**
+     * @dataProvider traitsDataProvider
+     */
+    public function testGetTraits(PhpNamespace $namespace, Traits $expected): void
+    {
+        $this->assertEquals($namespace->getTraits(), $expected);
+    }
+
+    /**
+     * @dataProvider enumsDataProvider
+     */
+    public function testGetEnums(PhpNamespace $namespace, Enums $expected): void
+    {
+        $this->assertEquals($namespace->getEnums(), $expected);
+    }
+
+    /**
+     * @dataProvider elementsDataProvider
+     */
+    public function testGetElements(PhpNamespace $namespace, Elements $expected): void
+    {
+        $this->assertEquals($namespace->getElements(), $expected);
+    }
+
+    public function classesDataProvider(): \Traversable
+    {
+        $withoutClasses = new PhpNamespace('a');
+        $withoutClasses->addInterface('b');
+        $withoutClasses->addTrait('c');
+        $withoutClasses->addEnum('d');
+
+        $onlyOneClass = new PhpNamespace('b');
+        $a = $onlyOneClass->addClass('a');
+
+        $onlyClasses = new PhpNamespace('c');
+        $b = $onlyClasses->addClass('b');
+        $c = $onlyClasses->addClass('c');
+
+        $withOtherElements = new PhpNamespace('d');
+        $d = $withOtherElements->addClass('d');
+        $withOtherElements->addInterface('b');
+        $withOtherElements->addTrait('c');
+        $withOtherElements->addEnum('l');
+
+        yield [new PhpNamespace('a'), new Classes([])];
+        yield [$withoutClasses, new Classes([])];
+        yield [$onlyOneClass, new Classes(['a' => $a])];
+        yield [$onlyClasses, new Classes(['b' => $b, 'c' => $c])];
+        yield [$withOtherElements, new Classes(['d' => $d])];
+    }
+
+    public function interfacesDataProvider(): \Traversable
+    {
+        $withoutInterfaces = new PhpNamespace('a');
+        $withoutInterfaces->addClass('b');
+        $withoutInterfaces->addTrait('c');
+        $withoutInterfaces->addEnum('d');
+
+        $onlyOneInterface = new PhpNamespace('b');
+        $a = $onlyOneInterface->addInterface('a');
+
+        $onlyInterfaces = new PhpNamespace('c');
+        $b = $onlyInterfaces->addInterface('b');
+        $c = $onlyInterfaces->addInterface('c');
+
+        $withOtherElements = new PhpNamespace('d');
+        $withOtherElements->addClass('j');
+        $d = $withOtherElements->addInterface('d');
+        $withOtherElements->addTrait('l');
+        $withOtherElements->addEnum('k');
+
+        yield [new PhpNamespace('a'), new Interfaces([])];
+        yield [$withoutInterfaces, new Interfaces([])];
+        yield [$onlyOneInterface, new Interfaces(['a' => $a])];
+        yield [$onlyInterfaces, new Interfaces(['b' => $b, 'c' => $c])];
+        yield [$withOtherElements, new Interfaces(['d' => $d])];
+    }
+
+    public function traitsDataProvider(): \Traversable
+    {
+        $withoutTraits = new PhpNamespace('a');
+        $withoutTraits->addClass('b');
+        $withoutTraits->addInterface('c');
+        $withoutTraits->addEnum('d');
+
+        $onlyOneTrait = new PhpNamespace('b');
+        $a = $onlyOneTrait->addTrait('a');
+
+        $onlyTraits = new PhpNamespace('c');
+        $b = $onlyTraits->addTrait('b');
+        $c = $onlyTraits->addTrait('c');
+
+        $withOtherElements = new PhpNamespace('d');
+        $withOtherElements->addClass('a');
+        $withOtherElements->addInterface('f');
+        $d = $withOtherElements->addTrait('d');
+        $withOtherElements->addEnum('l');
+
+        yield [new PhpNamespace('a'), new Traits([])];
+        yield [$withoutTraits, new Traits([])];
+        yield [$onlyOneTrait, new Traits(['a' => $a])];
+        yield [$onlyTraits, new Traits(['b' => $b, 'c' => $c])];
+        yield [$withOtherElements, new Traits(['d' => $d])];
+    }
+
+    public function enumsDataProvider(): \Traversable
+    {
+        $withoutEnums = new PhpNamespace('a');
+        $withoutEnums->addClass('b');
+        $withoutEnums->addInterface('c');
+        $withoutEnums->addTrait('d');
+
+        $onlyOneEnum = new PhpNamespace('b');
+        $a = $onlyOneEnum->addEnum('a');
+
+        $onlyEnums = new PhpNamespace('c');
+        $b = $onlyEnums->addEnum('b');
+        $c = $onlyEnums->addEnum('c');
+
+        $withOtherElements = new PhpNamespace('d');
+        $withOtherElements->addClass('a');
+        $withOtherElements->addInterface('b');
+        $withOtherElements->addTrait('c');
+        $d = $withOtherElements->addEnum('d');
+
+        yield [new PhpNamespace('a'), new Enums([])];
+        yield [$withoutEnums, new Enums([])];
+        yield [$onlyOneEnum, new Enums(['a' => $a])];
+        yield [$onlyEnums, new Enums(['b' => $b, 'c' => $c])];
+        yield [$withOtherElements, new Enums(['d' => $d])];
+    }
+
+    public function elementsDataProvider(): \Traversable
+    {
+        $class = new PhpNamespace('a');
+        $a = $class->addClass('a');
+
+        $interface = new PhpNamespace('a');
+        $b = $interface->addInterface('b');
+
+        $trait = new PhpNamespace('a');
+        $c = $trait->addTrait('c');
+
+        $enum = new PhpNamespace('a');
+        $d = $enum->addEnum('d');
+
+        $all = new PhpNamespace('a');
+        $e = $all->addEnum('e');
+        $f = $all->addClass('f');
+        $g = $all->addInterface('g');
+        $h = $all->addTrait('h');
+
+        yield [new PhpNamespace('a'), new Elements([])];
+        yield [$class, new Elements(['a' => $a])];
+        yield [$interface, new Elements(['b' => $b])];
+        yield [$trait, new Elements(['c' => $c])];
+        yield [$enum, new Elements(['d' => $d])];
+        yield [$all, new Elements([
+            'e' => $e,
+            'f' => $f,
+            'g' => $g,
+            'h' => $h
+        ])];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### Bugfix

The `getClasses` method in `Nette\PhpGenerator\PhpNamespace` can return the `Nette\PhpGenerator\ClassLike` interface:
https://github.com/nette/php-generator/blob/master/src/PhpGenerator/PhpNamespace.php#L327
This is not only a class, it can be a *class*, an *interface*, a *trait*, or an *enum*. We had strict typing for a `ClassType`. When returning a different type, a fatal error occurs. Added element filtering to return only classes.

### Feature

 Separately added methods `getEnums`, `getTraits`, `getInterfaces` to return the corresponding elements. And a `getElements` method to return all elements.