### PR TITLE
Addeding the ability to specify a custom namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+- **Other Features**
+  - [spiral/scaffolder] Added the ability to specify a custom `namespace` in the 
+    `Spiral\Scaffolder\Command\BootloaderCommand`, `Spiral\Scaffolder\Command\CommandCommand`, 
+    `Spiral\Scaffolder\Command\ConfigCommand`, `Spiral\Scaffolder\Command\ControllerCommand`,
+    `Spiral\Scaffolder\Command\JobHandlerCommand`, `Spiral\Scaffolder\Command\MiddlewareCommand` console commands.
+
 ## 3.5.0 - 2022-12-23
 - **Medium Impact Changes**
   - [spiral/reactor] Method `removeClass` of `Spiral\Reactor\Partial\PhpNamespace` class is deprecated. Use method `removeElement` instead.

--- a/src/Scaffolder/src/Command/AbstractCommand.php
+++ b/src/Scaffolder/src/Command/AbstractCommand.php
@@ -36,8 +36,9 @@ abstract class AbstractCommand extends Command
         return $this->factory->make(
             $class,
             [
-                'name'    => (string) $this->argument('name'),
+                'name' => (string) $this->argument('name'),
                 'comment' => $this->option('comment'),
+                'namespace' => $this->option('namespace'),
             ] + $this->config->declarationOptions($class::TYPE)
         );
     }
@@ -47,7 +48,11 @@ abstract class AbstractCommand extends Command
      */
     protected function writeDeclaration(DeclarationInterface $declaration): void
     {
-        $filename = $this->config->classFilename($declaration::TYPE, (string) $this->argument('name'));
+        $filename = $this->config->classFilename(
+            $declaration::TYPE,
+            (string) $this->argument('name'),
+            $this->option('namespace')
+        );
         $filename = $this->files->normalizePath($filename);
         $className = $declaration->getClass()->getName();
 

--- a/src/Scaffolder/src/Command/BootloaderCommand.php
+++ b/src/Scaffolder/src/Command/BootloaderCommand.php
@@ -22,6 +22,12 @@ class BootloaderCommand extends AbstractCommand
             InputOption::VALUE_OPTIONAL,
             'Optional comment to add as class header',
         ],
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
     ];
 
     /**

--- a/src/Scaffolder/src/Command/CommandCommand.php
+++ b/src/Scaffolder/src/Command/CommandCommand.php
@@ -29,6 +29,12 @@ class CommandCommand extends AbstractCommand
             InputOption::VALUE_OPTIONAL,
             'Optional comment to add as class header',
         ],
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
     ];
 
     /**

--- a/src/Scaffolder/src/Command/ConfigCommand.php
+++ b/src/Scaffolder/src/Command/ConfigCommand.php
@@ -33,6 +33,12 @@ class ConfigCommand extends AbstractCommand
             InputOption::VALUE_NONE,
             'Create config class based on a given config filename',
         ],
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
     ];
 
     /**

--- a/src/Scaffolder/src/Command/ControllerCommand.php
+++ b/src/Scaffolder/src/Command/ControllerCommand.php
@@ -34,6 +34,12 @@ class ControllerCommand extends AbstractCommand
             InputOption::VALUE_OPTIONAL,
             'Optional comment to add as class header',
         ],
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
     ];
 
     /**

--- a/src/Scaffolder/src/Command/JobHandlerCommand.php
+++ b/src/Scaffolder/src/Command/JobHandlerCommand.php
@@ -22,6 +22,12 @@ class JobHandlerCommand extends AbstractCommand
             InputOption::VALUE_OPTIONAL,
             'Optional comment to add as class header',
         ],
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
     ];
 
     /**

--- a/src/Scaffolder/src/Command/MiddlewareCommand.php
+++ b/src/Scaffolder/src/Command/MiddlewareCommand.php
@@ -22,6 +22,12 @@ class MiddlewareCommand extends AbstractCommand
             InputOption::VALUE_OPTIONAL,
             'Optional comment to add as class header',
         ],
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
     ];
 
     /**

--- a/src/Scaffolder/src/Config/ScaffolderConfig.php
+++ b/src/Scaffolder/src/Config/ScaffolderConfig.php
@@ -58,14 +58,14 @@ class ScaffolderConfig extends InjectableConfig
         return \trim($this->baseNamespace($element) . '\\' . $localNamespace, '\\');
     }
 
-    public function classFilename(string $element, string $name): string
+    public function classFilename(string $element, string $name, ?string $namespace = null): string
     {
-        $namespace = $this->classNamespace($element, $name);
-        $namespace = \substr($namespace, \strlen($this->baseNamespace($element)));
+        $elementNamespace = $namespace ?? $this->classNamespace($element, $name);
+        $elementNamespace = \substr($elementNamespace, \strlen($this->baseNamespace($element)));
 
         return $this->joinPathChunks([
             $this->baseDirectory(),
-            \str_replace('\\', '/', $namespace),
+            \str_replace('\\', '/', $elementNamespace),
             $this->className($element, $name) . '.php',
         ], '/');
     }

--- a/src/Scaffolder/src/Declaration/AbstractDeclaration.php
+++ b/src/Scaffolder/src/Declaration/AbstractDeclaration.php
@@ -18,9 +18,10 @@ abstract class AbstractDeclaration implements DeclarationInterface
     public function __construct(
         protected readonly ScaffolderConfig $config,
         string $name,
-        ?string $comment = null
+        ?string $comment = null,
+        ?string $namespace = null
     ) {
-        $this->namespace = new PhpNamespace($this->config->classNamespace(static::TYPE, $name));
+        $this->namespace = new PhpNamespace($namespace ?? $this->config->classNamespace(static::TYPE, $name));
 
         $this->class = $this->namespace
             ->addClass($this->config->className(static::TYPE, $name))

--- a/src/Scaffolder/src/Declaration/ConfigDeclaration.php
+++ b/src/Scaffolder/src/Declaration/ConfigDeclaration.php
@@ -101,9 +101,6 @@ class ConfigDeclaration extends AbstractDeclaration
         return \sprintf('@see \%s\%s', $namespace, $this->class->getName());
     }
 
-    /**
-     * @return double[]|float[]
-     */
     private function declareGetters(array $defaults): void
     {
         $getters = [];

--- a/src/Scaffolder/src/Declaration/ConfigDeclaration.php
+++ b/src/Scaffolder/src/Declaration/ConfigDeclaration.php
@@ -16,7 +16,6 @@ use Spiral\Scaffolder\Config\ScaffolderConfig;
 use Spiral\Scaffolder\Exception\ScaffolderException;
 
 use function Spiral\Scaffolder\defineArrayType;
-use function Spiral\Scaffolder\isAssociativeArray;
 
 class ConfigDeclaration extends AbstractDeclaration
 {
@@ -24,16 +23,17 @@ class ConfigDeclaration extends AbstractDeclaration
 
     public function __construct(
         ScaffolderConfig $config,
-        private readonly FilesInterface $files,
-        private readonly SlugifyInterface $slugify,
-        private readonly ConfigDeclaration\TypeAnnotations $typeAnnotations,
-        private readonly ConfigDeclaration\TypeHints $typeHints,
-        private readonly ConfigDeclaration\Defaults $defaultValues,
-        string $name,
-        ?string $comment = null,
-        private readonly string $directory = ''
+        protected readonly FilesInterface $files,
+        protected readonly SlugifyInterface $slugify,
+        protected readonly ConfigDeclaration\TypeAnnotations $typeAnnotations,
+        protected readonly ConfigDeclaration\TypeHints $typeHints,
+        protected readonly ConfigDeclaration\Defaults $defaultValues,
+        protected string $name,
+        protected ?string $comment = null,
+        private readonly string $directory = '',
+        ?string $namespace = null
     ) {
-        parent::__construct($config, $name, $comment);
+        parent::__construct($config, $name, $comment, $namespace);
     }
 
     public function create(bool $reverse, string $configName): void
@@ -104,9 +104,8 @@ class ConfigDeclaration extends AbstractDeclaration
     /**
      * @return double[]|float[]
      */
-    private function declareGetters(array $defaults): array
+    private function declareGetters(array $defaults): void
     {
-        $output = [];
         $getters = [];
         $gettersByKey = [];
 
@@ -135,8 +134,6 @@ class ConfigDeclaration extends AbstractDeclaration
                 $getters[] = $method->getName();
             }
         }
-
-        return $output;
     }
 
     private function declareGettersByKey(array $methodNames, string $key, array $value): ?Method
@@ -165,7 +162,7 @@ class ConfigDeclaration extends AbstractDeclaration
         }
 
         //Won't create for associated arrays
-        if ($this->typeAnnotations->mapType($keyType) === 'int' && !isAssociativeArray($value)) {
+        if ($this->typeAnnotations->mapType($keyType) === 'int' && \array_is_list($value)) {
             return null;
         }
 

--- a/src/Scaffolder/src/helpers.php
+++ b/src/Scaffolder/src/helpers.php
@@ -16,29 +16,6 @@ if (!\function_exists('trimPostfix')) {
     }
 }
 
-if (!\function_exists('isAssociativeArray')) {
-    /**
-     * @internal
-     */
-    function isAssociativeArray(array $array): bool
-    {
-        $keys = [];
-        foreach ($array as $key => $_) {
-            if (!\is_int($key)) {
-                return true;
-            }
-
-            if ($key !== \count($keys)) {
-                return true;
-            }
-
-            $keys[] = $key;
-        }
-
-        return false;
-    }
-}
-
 if (!\function_exists('defineArrayType')) {
     /**
      * @internal

--- a/src/Scaffolder/tests/Command/BootloaderTest.php
+++ b/src/Scaffolder/tests/Command/BootloaderTest.php
@@ -56,7 +56,6 @@ class BootloaderTest extends AbstractCommandTest
 
         $this->console()->run('create:bootloader', [
             'name' => 'sample',
-            '--comment' => 'Sample Bootloader',
             '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Bootloader'
         ]);
 

--- a/src/Scaffolder/tests/Command/BootloaderTest.php
+++ b/src/Scaffolder/tests/Command/BootloaderTest.php
@@ -66,7 +66,10 @@ class BootloaderTest extends AbstractCommandTest
         $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('App\Custom\Bootloader\SampleBootloader.php', $reflection->getFileName());
+        $this->assertStringContainsString(
+            'App/Custom/Bootloader/SampleBootloader.php',
+            \str_replace('\\', '/', $reflection->getFileName())
+        );
         $this->assertStringContainsString('App\Custom\Bootloader', $content);
 
         $this->deleteDeclaration($class);

--- a/src/Scaffolder/tests/Command/BootloaderTest.php
+++ b/src/Scaffolder/tests/Command/BootloaderTest.php
@@ -10,28 +10,23 @@ use Throwable;
 
 class BootloaderTest extends AbstractCommandTest
 {
-    private const CLASS_NAME = '\\Spiral\\Tests\\Scaffolder\\App\\Bootloader\\SampleBootloader';
-
-    public function tearDown(): void
-    {
-        $this->deleteDeclaration(self::CLASS_NAME);
-    }
-
     /**
      * @throws ReflectionException
      * @throws Throwable
      */
     public function testScaffold(): void
     {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Bootloader\\SampleBootloader';
+
         $this->console()->run('create:bootloader', [
-            'name'      => 'sample',
+            'name' => 'sample',
             '--comment' => 'Sample Bootloader'
         ]);
 
         clearstatcache();
-        $this->assertTrue(class_exists(self::CLASS_NAME));
+        $this->assertTrue(\class_exists($class));
 
-        $reflection = new ReflectionClass(self::CLASS_NAME);
+        $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
         $this->assertStringContainsString('strict_types=1', $content);
@@ -47,5 +42,33 @@ class BootloaderTest extends AbstractCommandTest
         $this->assertEquals([], $reflection->getReflectionConstant('BINDINGS')->getValue());
         $this->assertEquals([], $reflection->getReflectionConstant('SINGLETONS')->getValue());
         $this->assertEquals([], $reflection->getReflectionConstant('DEPENDENCIES')->getValue());
+
+        $this->deleteDeclaration($class);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    public function testScaffoldWithCustomNamespace(): void
+    {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Custom\\Bootloader\\SampleBootloader';
+
+        $this->console()->run('create:bootloader', [
+            'name' => 'sample',
+            '--comment' => 'Sample Bootloader',
+            '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Bootloader'
+        ]);
+
+        clearstatcache();
+        $this->assertTrue(\class_exists($class));
+
+        $reflection = new ReflectionClass($class);
+        $content = $this->files()->read($reflection->getFileName());
+
+        $this->assertStringContainsString('App\Custom\Bootloader\SampleBootloader.php', $reflection->getFileName());
+        $this->assertStringContainsString('App\Custom\Bootloader', $content);
+
+        $this->deleteDeclaration($class);
     }
 }

--- a/src/Scaffolder/tests/Command/CommandTest.php
+++ b/src/Scaffolder/tests/Command/CommandTest.php
@@ -53,6 +53,27 @@ class CommandTest extends AbstractCommandTest
         $this->deleteDeclaration($className);
     }
 
+    public function testScaffoldWithCustomNamespace(): void
+    {
+        $className = '\\Spiral\\Tests\\Scaffolder\\App\\Custom\\Command\\SampleCommand';
+
+        $this->console()->run('create:command', [
+            'name' => 'sample',
+            '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Command',
+        ]);
+
+        clearstatcache();
+        $this->assertTrue(class_exists($className));
+
+        $reflection = new ReflectionClass($className);
+        $content = $this->files()->read($reflection->getFileName());
+
+        $this->assertStringContainsString('App\Custom\Command\SampleCommand.php', $reflection->getFileName());
+        $this->assertStringContainsString('App\Custom\Command', $content);
+
+        $this->deleteDeclaration($className);
+    }
+
     public function commandDataProvider(): array
     {
         return [

--- a/src/Scaffolder/tests/Command/CommandTest.php
+++ b/src/Scaffolder/tests/Command/CommandTest.php
@@ -68,7 +68,10 @@ class CommandTest extends AbstractCommandTest
         $reflection = new ReflectionClass($className);
         $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('App\Custom\Command\SampleCommand.php', $reflection->getFileName());
+        $this->assertStringContainsString(
+            'App/Custom/Command/SampleCommand.php',
+            \str_replace('\\', '/', $reflection->getFileName())
+        );
         $this->assertStringContainsString('App\Custom\Command', $content);
 
         $this->deleteDeclaration($className);

--- a/src/Scaffolder/tests/Command/ConfigTest.php
+++ b/src/Scaffolder/tests/Command/ConfigTest.php
@@ -11,28 +11,23 @@ use Throwable;
 
 class ConfigTest extends AbstractCommandTest
 {
-    private const CLASS_NAME = '\\Spiral\\Tests\\Scaffolder\\App\\Config\\SampleConfig';
-
-    public function tearDown(): void
-    {
-        $this->deleteDeclaration(self::CLASS_NAME);
-    }
-
     /**
      * @throws ReflectionException
      * @throws Throwable
      */
     public function testScaffold(): void
     {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Config\\SampleConfig';
+
         $this->console()->run('create:config', [
             'name'      => 'sample',
             '--comment' => 'Sample Config'
         ]);
 
         clearstatcache();
-        $this->assertTrue(class_exists(self::CLASS_NAME));
+        $this->assertTrue(class_exists($class));
 
-        $reflection = new ReflectionClass(self::CLASS_NAME);
+        $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
         $this->assertStringContainsString('strict_types=1', $content);
@@ -45,6 +40,33 @@ class ConfigTest extends AbstractCommandTest
 
         $this->assertIsString($reflection->getReflectionConstant('CONFIG')->getValue());
         $this->assertEquals([], $reflection->getDefaultProperties()['config']);
+
+        $this->deleteDeclaration($class);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    public function testScaffoldWithCustomNamespace(): void
+    {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Custom\\Config\\SampleConfig';
+
+        $this->console()->run('create:config', [
+            'name' => 'sample',
+            '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Config'
+        ]);
+
+        clearstatcache();
+        $this->assertTrue(class_exists($class));
+
+        $reflection = new ReflectionClass($class);
+        $content = $this->files()->read($reflection->getFileName());
+
+        $this->assertStringContainsString('App\Custom\Config\SampleConfig.php', $reflection->getFileName());
+        $this->assertStringContainsString('App\Custom\Config', $content);
+
+        $this->deleteDeclaration($class);
     }
 
     /**

--- a/src/Scaffolder/tests/Command/ConfigTest.php
+++ b/src/Scaffolder/tests/Command/ConfigTest.php
@@ -63,7 +63,10 @@ class ConfigTest extends AbstractCommandTest
         $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('App\Custom\Config\SampleConfig.php', $reflection->getFileName());
+        $this->assertStringContainsString(
+            'App/Custom/Config/SampleConfig.php',
+            \str_replace('\\', '/', $reflection->getFileName())
+        );
         $this->assertStringContainsString('App\Custom\Config', $content);
 
         $this->deleteDeclaration($class);

--- a/src/Scaffolder/tests/Command/ControllerTest.php
+++ b/src/Scaffolder/tests/Command/ControllerTest.php
@@ -49,6 +49,30 @@ class ControllerTest extends AbstractCommandTest
      * @throws ReflectionException
      * @throws Throwable
      */
+    public function testScaffoldWithCustomNamespace(): void
+    {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Custom\\Controller\\SampleController';
+        $this->console()->run('create:controller', [
+            'name' => 'sample',
+            '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Controller'
+        ]);
+
+        clearstatcache();
+        $this->assertTrue(class_exists($class));
+
+        $reflection = new ReflectionClass($class);
+        $content = $this->files()->read($reflection->getFileName());
+
+        $this->assertStringContainsString('App\Custom\Controller\SampleController.php', $reflection->getFileName());
+        $this->assertStringContainsString('App\Custom\Controller', $content);
+
+        $this->deleteDeclaration($class);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws Throwable
+     */
     public function testPrototypeTrait(): void
     {
         $class = '\\Spiral\\Tests\\Scaffolder\\App\\Controller\\Sample2Controller';

--- a/src/Scaffolder/tests/Command/ControllerTest.php
+++ b/src/Scaffolder/tests/Command/ControllerTest.php
@@ -63,7 +63,10 @@ class ControllerTest extends AbstractCommandTest
         $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('App\Custom\Controller\SampleController.php', $reflection->getFileName());
+        $this->assertStringContainsString(
+            'App/Custom/Controller/SampleController.php',
+            \str_replace('\\', '/', $reflection->getFileName())
+        );
         $this->assertStringContainsString('App\Custom\Controller', $content);
 
         $this->deleteDeclaration($class);

--- a/src/Scaffolder/tests/Command/JobHandlerTest.php
+++ b/src/Scaffolder/tests/Command/JobHandlerTest.php
@@ -57,7 +57,10 @@ class JobHandlerTest extends AbstractCommandTest
         $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('App\Custom\Job\SampleJob.php', $reflection->getFileName());
+        $this->assertStringContainsString(
+            'App/Custom/Job/SampleJob.php',
+            \str_replace('\\', '/', $reflection->getFileName())
+        );
         $this->assertStringContainsString('App\Custom\Job', $content);
 
         $this->deleteDeclaration($class);

--- a/src/Scaffolder/tests/Command/JobHandlerTest.php
+++ b/src/Scaffolder/tests/Command/JobHandlerTest.php
@@ -10,28 +10,23 @@ use Throwable;
 
 class JobHandlerTest extends AbstractCommandTest
 {
-    private const CLASS_NAME = '\\Spiral\\Tests\\Scaffolder\\App\\Job\\SampleJob';
-
-    public function tearDown(): void
-    {
-        $this->deleteDeclaration(self::CLASS_NAME);
-    }
-
     /**
      * @throws ReflectionException
      * @throws Throwable
      */
     public function testScaffold(): void
     {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Job\\SampleJob';
+
         $this->console()->run('create:jobHandler', [
             'name'      => 'sample',
             '--comment' => 'Sample Job Handler'
         ]);
 
         clearstatcache();
-        $this->assertTrue(class_exists(self::CLASS_NAME));
+        $this->assertTrue(class_exists($class));
 
-        $reflection = new ReflectionClass(self::CLASS_NAME);
+        $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
         $this->assertStringContainsString('strict_types=1', $content);
@@ -39,5 +34,32 @@ class JobHandlerTest extends AbstractCommandTest
         $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertStringContainsString('Sample Job Handler', $reflection->getDocComment());
         $this->assertTrue($reflection->hasMethod('invoke'));
+
+        $this->deleteDeclaration($class);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    public function testScaffoldWithCustomNamespace(): void
+    {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Custom\\Job\\SampleJob';
+
+        $this->console()->run('create:jobHandler', [
+            'name' => 'sample',
+            '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Job'
+        ]);
+
+        clearstatcache();
+        $this->assertTrue(\class_exists($class));
+
+        $reflection = new ReflectionClass($class);
+        $content = $this->files()->read($reflection->getFileName());
+
+        $this->assertStringContainsString('App\Custom\Job\SampleJob.php', $reflection->getFileName());
+        $this->assertStringContainsString('App\Custom\Job', $content);
+
+        $this->deleteDeclaration($class);
     }
 }

--- a/src/Scaffolder/tests/Command/MiddlewareTest.php
+++ b/src/Scaffolder/tests/Command/MiddlewareTest.php
@@ -57,7 +57,10 @@ class MiddlewareTest extends AbstractCommandTest
         $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('App\Custom\Middleware\SampleMiddleware.php', $reflection->getFileName());
+        $this->assertStringContainsString(
+            'App/Custom/Middleware/SampleMiddleware.php',
+            \str_replace('\\', '/', $reflection->getFileName())
+        );
         $this->assertStringContainsString('App\Custom\Middleware', $content);
 
         $this->deleteDeclaration($class);

--- a/src/Scaffolder/tests/Command/MiddlewareTest.php
+++ b/src/Scaffolder/tests/Command/MiddlewareTest.php
@@ -10,28 +10,23 @@ use Throwable;
 
 class MiddlewareTest extends AbstractCommandTest
 {
-    private const CLASS_NAME = '\\Spiral\\Tests\\Scaffolder\\App\\Middleware\\SampleMiddleware';
-
-    public function tearDown(): void
-    {
-        $this->deleteDeclaration(self::CLASS_NAME);
-    }
-
     /**
      * @throws ReflectionException
      * @throws Throwable
      */
     public function testScaffold(): void
     {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Middleware\\SampleMiddleware';
+
         $this->console()->run('create:middleware', [
             'name'      => 'sample-middleware',
             '--comment' => 'Sample Middleware'
         ]);
 
         clearstatcache();
-        $this->assertTrue(class_exists(self::CLASS_NAME));
+        $this->assertTrue(\class_exists($class));
 
-        $reflection = new ReflectionClass(self::CLASS_NAME);
+        $reflection = new ReflectionClass($class);
         $content = $this->files()->read($reflection->getFileName());
 
         $this->assertStringContainsString('strict_types=1', $content);
@@ -39,5 +34,32 @@ class MiddlewareTest extends AbstractCommandTest
         $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertStringContainsString('Sample Middleware', $reflection->getDocComment());
         $this->assertTrue($reflection->hasMethod('process'));
+
+        $this->deleteDeclaration($class);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    public function testScaffoldWithCustomNamespace(): void
+    {
+        $class = '\\Spiral\\Tests\\Scaffolder\\App\\Custom\\Middleware\\SampleMiddleware';
+
+        $this->console()->run('create:middleware', [
+            'name' => 'sample-middleware',
+            '--namespace' => 'Spiral\\Tests\\Scaffolder\\App\\Custom\\Middleware'
+        ]);
+
+        clearstatcache();
+        $this->assertTrue(\class_exists($class));
+
+        $reflection = new ReflectionClass($class);
+        $content = $this->files()->read($reflection->getFileName());
+
+        $this->assertStringContainsString('App\Custom\Middleware\SampleMiddleware.php', $reflection->getFileName());
+        $this->assertStringContainsString('App\Custom\Middleware', $content);
+
+        $this->deleteDeclaration($class);
     }
 }

--- a/src/Scaffolder/tests/FunctionsTest.php
+++ b/src/Scaffolder/tests/FunctionsTest.php
@@ -7,34 +7,9 @@ namespace Spiral\Tests\Scaffolder;
 use PHPUnit\Framework\TestCase;
 
 use function Spiral\Scaffolder\defineArrayType;
-use function Spiral\Scaffolder\isAssociativeArray;
 
 class FunctionsTest extends TestCase
 {
-    /**
-     * @dataProvider associativeProvider
-     * @param bool  $expected
-     * @param array $array
-     */
-    public function testIsAssociativeArray(bool $expected, array $array): void
-    {
-        $this->assertEquals($expected, isAssociativeArray($array));
-    }
-
-    /**
-     * @return array
-     */
-    public function associativeProvider(): array
-    {
-        return [
-            [true, ['k' => 'v', 2, 3]],
-            [true, [2, 3, 'k' => 'v']],
-            [true, [1 => 1, 0 => 0, 2 => 2]],
-            [false, [0 => 0, 1 => 1, 2 => 2]],
-            [false, [0, 1, 2]],
-        ];
-    }
-
     /**
      * @dataProvider defineProvider
      * @param mixed       $expected


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added the ability to specify a custom `namespace` in the Scaffolder console commands.

For example:

```bash
php app.php create:bootloader Test --namespace=App\Module\EmptyModule\Application
```

The bootloader will be created with namespace `App\Module\EmptyModule\Application` and written into `src/Module/EmptyModule/Application/TestBootloader.php` (App - is the base namespace for src)
