### PR TITLE
Fix inherited injection

### DIFF
--- a/src/Core/src/BinderInterface.php
+++ b/src/Core/src/BinderInterface.php
@@ -41,17 +41,22 @@ interface BinderInterface
     /**
      * Bind class or class interface to the injector source (InjectorInterface).
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param class-string<TClass> $class
      * @param class-string<InjectorInterface<TClass>> $injector
      */
     public function bindInjector(string $class, string $injector): void;
 
+    /**
+     * @param class-string $class
+     */
     public function removeInjector(string $class): void;
 
     /**
      * Check if class points to injector.
+     *
+     * @param class-string $class
      */
     public function hasInjector(string $class): bool;
 }

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract as ContextFunction;
 use Spiral\Core\Container\Autowire;
 use Spiral\Core\Container\InjectableInterface;
+use Spiral\Core\Container\InjectorInterface;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\Exception\Container\ContainerException;
 use Spiral\Core\Exception\LogicException;

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -130,10 +130,11 @@ final class Factory implements FactoryInterface
      */
     private function autowire(string $class, array $parameters, string $context = null): object
     {
-        if (!(\class_exists($class) || (\interface_exists($class)
+        if (!(\class_exists($class) || (
+            \interface_exists($class)
                 &&
                 (isset($this->state->injectors[$class]) || $this->binder->hasInjector($class))
-            ))
+        ))
         ) {
             throw new NotFoundException($this->tracer->combineTraceMessage(\sprintf(
                 'Can\'t resolve `%s`: undefined class or binding `%s`.',

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -130,7 +130,11 @@ final class Factory implements FactoryInterface
      */
     private function autowire(string $class, array $parameters, string $context = null): object
     {
-        if (!\class_exists($class) && !isset($this->state->injectors[$class])) {
+        if (!(\class_exists($class) || (\interface_exists($class)
+                &&
+                (isset($this->state->injectors[$class]) || $this->binder->hasInjector($class))
+            ))
+        ) {
             throw new NotFoundException($this->tracer->combineTraceMessage(\sprintf(
                 'Can\'t resolve `%s`: undefined class or binding `%s`.',
                 $this->tracer->getRootAlias(),

--- a/src/Core/tests/Fixtures/InjectableClassChildImplementation.php
+++ b/src/Core/tests/Fixtures/InjectableClassChildImplementation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Fixtures;
+
+class InjectableClassChildImplementation implements InjectableClassChildInterface
+{
+}

--- a/src/Core/tests/Fixtures/InjectableClassChildInterface.php
+++ b/src/Core/tests/Fixtures/InjectableClassChildInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Fixtures;
 
-interface InjectableClassInterface
+interface InjectableClassChildInterface extends InjectableClassInterface
 {
 }

--- a/src/Core/tests/Fixtures/InjectableClassImplementation.php
+++ b/src/Core/tests/Fixtures/InjectableClassImplementation.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Fixtures;
 
-class InjectableClassRealization implements InjectableClassInterface
+class InjectableClassImplementation implements InjectableClassInterface
 {
-
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| New feature?  | ✔️
| Docs PR       | 

Now container injector can inject a class that iplements an interface that was binded as injector.

