### PR TITLE
Singleton objects creation with custom arguments

### DIFF
--- a/src/Core/tests/SingletonsTest.php
+++ b/src/Core/tests/SingletonsTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 use Spiral\Core\Container;
 use Spiral\Tests\Core\Fixtures\DeclarativeSingleton;
 use Spiral\Tests\Core\Fixtures\SampleClass;
+use stdClass;
+
+use function PHPUnit\Framework\assertFalse;
 
 class SingletonsTest extends TestCase
 {
@@ -84,6 +87,42 @@ class SingletonsTest extends TestCase
 
         $this->assertInstanceOf(SampleClass::class, $instance);
         $this->assertSame($instance, $container->get('sampleClass'));
+    }
+
+    /**
+     * @dataProvider SingletonWithCustomArgsProvider
+     */
+    public function testSingletonWithCustomArgs(string $alias, mixed $definition): void
+    {
+        $container = new Container();
+        $container->bindSingleton($alias, $definition);
+        $instance = $container->make($alias);
+
+        $this->assertSame($instance, $container->make($alias));
+        $this->assertSame($instance, $container->make($alias, []));
+        $this->assertNotSame($instance, $bar = $container->make($alias, ['bar']));
+        $this->assertNotSame($bar, $container->make($alias, ['bar']));
+        // The binding mustn't be rebound
+        $this->assertSame($instance, $container->make($alias));
+    }
+
+    public function SingletonWithCustomArgsProvider(): iterable
+    {
+        static $obj = new \stdClass();
+        yield 'array-factory' => ['sampleClass', [self::class, 'sampleClass']];
+        yield 'object' => ['sampleClass', self::class::sampleClass()];
+        yield 'class-name' => ['sampleClass', SampleClass::class];
+        yield 'reference-existing' => ['stdClass', \WeakReference::create($obj)];
+    }
+
+    public function testMakeResultWithCustomArgsWontBeStored(): void
+    {
+        $container = new Container();
+        $instance = $container->make(stdClass::class, ['foo' => 'bar']);
+
+        $this->assertFalse($container->hasInstance(stdClass::class));
+
+        $this->assertNotSame($instance, $container->get(stdClass::class));
     }
 
     public function testDelayedSingleton(): void

--- a/src/Core/tests/SingletonsTest.php
+++ b/src/Core/tests/SingletonsTest.php
@@ -118,11 +118,11 @@ class SingletonsTest extends TestCase
     public function testMakeResultWithCustomArgsWontBeStored(): void
     {
         $container = new Container();
-        $instance = $container->make(stdClass::class, ['foo' => 'bar']);
+        $instance = $container->make(DeclarativeSingleton::class, ['foo' => 'bar']);
 
-        $this->assertFalse($container->hasInstance(stdClass::class));
+        $this->assertFalse($container->hasInstance(DeclarativeSingleton::class));
 
-        $this->assertNotSame($instance, $container->get(stdClass::class));
+        $this->assertNotSame($instance, $container->get(DeclarativeSingleton::class));
     }
 
     public function testDelayedSingleton(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️

Once a Singletone has been created and stored in the Container, the next one (Singletone) will be created (not reused) if it is made with custom arguments.


```php
$service = new Service();
$container->bindSingleton(Service::class, $service);

$service === $container->make(Service::class);                   // true
$service === $container->make(Service::class, ['foo' => 'bar']); // false
```