### PR TITLE
Reverting mistakenly deleted phpdoc comment

### DIFF
--- a/src/Prototype/src/Traits/PrototypeTrait.php
+++ b/src/Prototype/src/Traits/PrototypeTrait.php
@@ -9,6 +9,9 @@ use Spiral\Core\Exception\ScopeException;
 use Spiral\Prototype\Exception\PrototypeException;
 use Spiral\Prototype\PrototypeRegistry;
 
+/**
+ * This DocComment is auto-generated, do not edit or commit this file to repository.
+ */
 trait PrototypeTrait
 {
     /**

--- a/src/Prototype/tests/Traits/PrototypeTraitTest.php
+++ b/src/Prototype/tests/Traits/PrototypeTraitTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Prototype\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Prototype\Traits\PrototypeTrait;
+
+final class PrototypeTraitTest extends TestCase
+{
+    public function testDocComment(): void
+    {
+        $trait = new \ReflectionClass(PrototypeTrait::class);
+
+        $this->assertStringContainsString(
+            'This DocComment is auto-generated, do not edit or commit this file to repository.',
+            (string) $trait->getDocComment()
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

See:
https://github.com/spiral/framework/blob/3.2.0/src/Prototype/src/Traits/PrototypeTrait.php#L13
