### PR TITLE
Core: fix infinite recursion on using for class name binding to the same class name

### DIFF
--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -105,8 +105,10 @@ final class Factory implements FactoryInterface
             }
 
             if (\is_string($binding)) {
-                //Binding is pointing to something else
-                return $this->make($binding, $parameters, $context);
+                return $binding === $alias
+                    ? $this->autowire($alias, $parameters, $context)
+                    //Binding is pointing to something else
+                    : $this->make($binding, $parameters, $context);
             }
 
             unset($this->state->bindings[$alias]);

--- a/src/Core/tests/AutowireTest.php
+++ b/src/Core/tests/AutowireTest.php
@@ -9,7 +9,6 @@ use Spiral\Core\Container;
 use Spiral\Core\Exception\Container\ContainerException;
 use Spiral\Core\Exception\Container\NotFoundException;
 use Spiral\Core\Exception\Resolver\ArgumentResolvingException;
-use Spiral\Core\Exception\Resolver\InvalidArgumentException;
 use Spiral\Tests\Core\Fixtures\Bucket;
 use Spiral\Tests\Core\Fixtures\DependedClass;
 use Spiral\Tests\Core\Fixtures\ExtendedSample;
@@ -45,6 +44,14 @@ class AutowireTest extends TestCase
 
         $container->bind(SampleClass::class, ExtendedSample::class);
         $this->assertInstanceOf(ExtendedSample::class, $container->make(SampleClass::class, []));
+    }
+
+    public function testMakeFromClassNameBinding(): void
+    {
+        $container = new Container();
+
+        $container->bind(SampleClass::class, SampleClass::class);
+        $this->assertInstanceOf(SampleClass::class, $container->make(SampleClass::class, []));
     }
 
     public function testArgumentException(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️

That code makes infinite recursion 

```php
$container = new Container();
$container->bind(stdClass::class, stdClass::class);
$container->get(stdClass::class);
```

Fixed.