### PR TITLE
Fixes problem with validation nested filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "spiral/code-style": "^1.1",
         "spiral/nyholm-bridge": "^1.2",
         "spiral/testing": "^2.2",
+        "spiral/validator": "^1.2",
         "symplify/monorepo-builder": "^10.2.7",
         "vimeo/psalm": "^4.27"
     },

--- a/src/Filters/src/Model/Interceptor/ValidateFilterInterceptor.php
+++ b/src/Filters/src/Model/Interceptor/ValidateFilterInterceptor.php
@@ -66,6 +66,8 @@ final class ValidateFilterInterceptor implements CoreInterceptorInterface
                     $errorMapper->mapErrors(\array_merge($errors, $validator->getErrors())),
                     $context
                 );
+            } elseif ($errors !== []) {
+                throw new ValidationException($errorMapper->mapErrors($errors), $context);
             }
         }
     }

--- a/src/Filters/src/Model/Schema/AttributeMapper.php
+++ b/src/Filters/src/Model/Schema/AttributeMapper.php
@@ -42,21 +42,16 @@ final class AttributeMapper
                     $this->setValue($filter, $property, $attribute->getValue($input, $property));
                     $schema[$property->getName()] = $attribute->getSchema($property);
                 } elseif ($attribute instanceof NestedFilter) {
+                    $prefix = $attribute->prefix ?? $property->name;
                     try {
                         $value = $this->provider->createFilter(
                             $attribute->class,
-                            $attribute->prefix ?
-                                $input->withPrefix($attribute->prefix) :
-                                $input->withPrefix($property->name)
+                            $input->withPrefix($prefix)
                         );
 
                         $this->setValue($filter, $property, $value);
                     } catch (ValidationException $e) {
-                        if ($attribute->prefix) {
-                            $errors[$attribute->prefix] = $e->errors;
-                        } else {
-                            $errors = \array_merge($errors, $e->errors);
-                        }
+                        $errors[$prefix] = $e->errors;
                     }
 
                     $schema[$property->getName()] = $attribute->getSchema($property);

--- a/src/Filters/tests/Model/Schema/AttributeMapperTest.php
+++ b/src/Filters/tests/Model/Schema/AttributeMapperTest.php
@@ -185,7 +185,9 @@ final class AttributeMapperTest extends BaseTest
         ], $schema);
 
         $this->assertSame([
-            'fooFilter' => 'Error',
+            'fooFilter' => [
+                'fooFilter' => 'Error'
+            ],
             'bazFilter' => [
                 'second' => [
                     'field' => 'Error',

--- a/tests/Framework/BaseTest.php
+++ b/tests/Framework/BaseTest.php
@@ -11,7 +11,7 @@ abstract class BaseTest extends \Spiral\Testing\TestCase
 {
     public function rootDirectory(): string
     {
-        return __DIR__.'/../';
+        return \realpath(__DIR__.'/../');
     }
 
     public function createAppInstance(Container $container = new Container()): TestApp

--- a/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
@@ -55,6 +55,7 @@ final class TokenizerBootloaderTest extends BaseTest
                 'debug' => false,
                 'directories' => [
                     $this->getDirectoryByAlias('app'),
+                    \realpath($this->getDirectoryByAlias('root') . '../vendor/spiral/validator/src'),
                 ],
                 'exclude' => [
                     $this->getDirectoryByAlias('resources'),

--- a/tests/Framework/Bootloader/Validation/ValidationBootloaderTest.php
+++ b/tests/Framework/Bootloader/Validation/ValidationBootloaderTest.php
@@ -36,6 +36,9 @@ final class ValidationBootloaderTest extends BaseTest
 
     public function testValidatorIsNotConfigured(): void
     {
+        $this->getConfigurator()
+            ->modify(ValidationConfig::CONFIG, new Set('defaultValidator', null));
+
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Default Validator is not configured.');
         $this->getContainer()->get(ValidationInterface::class);
@@ -43,6 +46,10 @@ final class ValidationBootloaderTest extends BaseTest
 
     public function testSetDefaultValidator(): void
     {
+        // Clear state from previous tests
+        $this->getConfigurator()
+            ->modify(ValidationConfig::CONFIG, new Set('defaultValidator', null));
+
         $validator = $this->createValidator();
         $this->getContainer()
             ->get(ValidationProviderInterface::class)
@@ -51,7 +58,7 @@ final class ValidationBootloaderTest extends BaseTest
         $bootloader = $this->getContainer()->get(ValidationBootloader::class);
         $bootloader->setDefaultValidator('bar');
 
-        $this->assertContainerBoundAsSingleton(ValidationInterface::class, $validator::class);
+        $this->assertConfigHasFragments(ValidationConfig::CONFIG, ['defaultValidator' => 'bar']);
     }
 
     public function testSetDefaultValidatorNotOverrideValueInConfig(): void

--- a/tests/Framework/Filter/FilterTestCase.php
+++ b/tests/Framework/Filter/FilterTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Filter;
+
+use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
+use Spiral\Filter\InputScope;
+use Spiral\Filters\Model\FilterInterface;
+use Spiral\Filters\Model\FilterProviderInterface;
+use Spiral\Tests\Framework\BaseTest;
+
+abstract class FilterTestCase extends BaseTest
+{
+    /**
+     * @param class-string<FilterInterface> $filter
+     */
+    public function getFilter(
+        string $filter,
+        array $post = [],
+        array $query = [],
+        array $headers = []
+    ): FilterInterface {
+        $request = new ServerRequest('POST', '/');
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        $this->getContainer()->bind(
+            ServerRequestInterface::class,
+            $request->withParsedBody($post)->withQueryParams($query)
+        );
+
+        $input = $this->getContainer()->get(InputScope::class);
+
+        return $this->getContainer()->get(FilterProviderInterface::class)
+            ->createFilter($filter, $input);
+    }
+}

--- a/tests/Framework/Filter/Model/NestedArrayFiltersTest.php
+++ b/tests/Framework/Filter/Model/NestedArrayFiltersTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Filter\Model;
+
+use Spiral\App\Request\AddressFilter;
+use Spiral\App\Request\MultipleAddressesFilter;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Tests\Framework\Filter\FilterTestCase;
+
+final class NestedArrayFiltersTest extends FilterTestCase
+{
+    public function testGetsNestedFilter(): void
+    {
+        $filter = $this->getFilter(MultipleAddressesFilter::class, post: [
+            'name' => 'John Doe',
+            'addresses' => [
+                [
+                    'city' => 'New York',
+                    'address' => 'Wall Street',
+                ],
+                [
+                    'city' => 'Los Angeles',
+                    'address' => 'Hollywood',
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(MultipleAddressesFilter::class, $filter);
+        $this->assertInstanceOf(AddressFilter::class, $filter->addresses[0]);
+        $this->assertInstanceOf(AddressFilter::class, $filter->addresses[1]);
+
+        $this->assertSame('John Doe', $filter->name);
+
+        $this->assertSame('New York', $filter->addresses[0]->city);
+        $this->assertSame('Wall Street', $filter->addresses[0]->address);
+
+        $this->assertSame('Los Angeles', $filter->addresses[1]->city);
+        $this->assertSame('Hollywood', $filter->addresses[1]->address);
+    }
+
+    /**
+     * @dataProvider provideInvalidData
+     */
+    public function testDataShouldBeValidated(array $data, array $expectedErrors): void
+    {
+        if ($expectedErrors !== []) {
+            $this->expectException(ValidationException::class);
+            $this->expectErrorMessage('The given data was invalid.');
+        }
+
+        try {
+            $filter = $this->getFilter(MultipleAddressesFilter::class, $data);
+            $this->assertSame('John Doe', $filter->name);
+        } catch (ValidationException $e) {
+            $this->assertSame($expectedErrors, $e->errors);
+            throw $e;
+        }
+    }
+
+    public function provideInvalidData(): \Generator
+    {
+        yield 'empty' => [
+            [],
+            [
+                'name' => 'This value is required.',
+            ],
+        ];
+
+        yield 'With name' => [
+            ['name' => 'John Doe'],
+            [],
+        ];
+
+        yield 'Without city' => [
+            [
+                'name' => 'John Doe',
+                'addresses' => [
+                    [
+                        'address' => 'Wall Street',
+                    ],
+                    [
+                        'address' => 'Hollywood',
+                    ],
+                ],
+            ],
+            [
+                'addresses' => [
+                    [
+                        'city' => 'This value is required.'
+                    ],
+                    [
+                        'city' => 'This value is required.'
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'Without city - 1' => [
+            [
+                'name' => 'John Doe',
+                'addresses' => [
+                    [
+                        'city' => 'New York',
+                        'address' => 'Wall Street',
+                    ],
+                    [
+                        'address' => 'Hollywood',
+                    ],
+                ],
+            ],
+            [
+                'addresses' => [
+                    1 => [
+                        'city' => 'This value is required.'
+                    ],
+                ],
+            ],
+        ];
+    }
+}
+

--- a/tests/Framework/Filter/Model/NestedFilterTest.php
+++ b/tests/Framework/Filter/Model/NestedFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Filter\Model;
+
+use Spiral\App\Request\AddressFilter;
+use Spiral\App\Request\ProfileFilter;
+use Spiral\App\Request\ProfileFilterWithPrefix;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Tests\Framework\Filter\FilterTestCase;
+
+final class NestedFilterTest extends FilterTestCase
+{
+    public function testGetsNestedFilter(): void
+    {
+        $filter = $this->getFilter(ProfileFilter::class, [
+            'name' => 'John Doe',
+            'address' => [
+                'city' => 'New York',
+                'address' => 'Wall Street',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ProfileFilter::class, $filter);
+        $this->assertInstanceOf(AddressFilter::class, $filter->address);
+
+        $this->assertSame('John Doe', $filter->name);
+        $this->assertSame('New York', $filter->address->city);
+        $this->assertSame('Wall Street', $filter->address->address);
+    }
+
+    public function testGetsNestedFilterWithCustomPrefix(): void
+    {
+        $filter = $this->getFilter(ProfileFilterWithPrefix::class, [
+            'name' => 'John Doe',
+            'addr' => [
+                'city' => 'New York',
+                'address' => 'Wall Street',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ProfileFilterWithPrefix::class, $filter);
+        $this->assertInstanceOf(AddressFilter::class, $filter->address);
+
+        $this->assertSame('John Doe', $filter->name);
+        $this->assertSame('New York', $filter->address->city);
+        $this->assertSame('Wall Street', $filter->address->address);
+    }
+
+    /**
+     * @dataProvider provideInvalidData
+     */
+    public function testDataShouldBeValidated(array $data, array $expectedErrors): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectErrorMessage('The given data was invalid.');
+
+        try {
+            $this->getFilter(ProfileFilter::class, $data);
+        } catch (ValidationException $e) {
+            $this->assertSame($expectedErrors, $e->errors);
+            throw $e;
+        }
+    }
+
+    public function provideInvalidData(): \Generator
+    {
+        yield 'empty' => [
+            [],
+            [
+                'address' => [
+                    'city' => 'This value is required.',
+                    'address' => 'This value is required.',
+                ],
+                'name' => 'This value is required.',
+            ],
+        ];
+
+        yield 'only-address' => [
+            [
+                'address' => [
+                    'city' => 'New York',
+                    'address' => 'Wall Street',
+                ],
+            ],
+            [
+                'name' => 'This value is required.',
+            ],
+        ];
+
+        yield 'only-name' => [
+            [
+                'name' => 'John Doe',
+            ],
+            [
+                'address' => [
+                    'city' => 'This value is required.',
+                    'address' => 'This value is required.',
+                ],
+            ],
+        ];
+
+        yield 'name and city' => [
+            [
+                'name' => 'John Doe',
+                'address' => [
+                    'city' => 'New York',
+                ],
+            ],
+            [
+                'address' => [
+                    'address' => 'This value is required.',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/app/src/Request/AddressFilter.php
+++ b/tests/app/src/Request/AddressFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+class AddressFilter extends Filter implements HasFilterDefinition
+{
+    #[Post]
+    public string $city;
+
+    #[Post]
+    public string $address;
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition(validationRules: [
+            'city' => ['required', 'string'],
+            'address' => ['required', 'string'],
+        ]);
+    }
+}

--- a/tests/app/src/Request/MultipleAddressesFilter.php
+++ b/tests/app/src/Request/MultipleAddressesFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\NestedArray;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+final class MultipleAddressesFilter extends Filter implements HasFilterDefinition
+{
+    #[Post]
+    public string $name;
+
+    #[NestedArray(class: AddressFilter::class, input: new Post('addresses'))]
+    public array $addresses;
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition(validationRules: [
+            'name' => ['required', 'string'],
+        ]);
+    }
+}

--- a/tests/app/src/Request/ProfileFilter.php
+++ b/tests/app/src/Request/ProfileFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\NestedFilter;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+class ProfileFilter extends Filter implements HasFilterDefinition
+{
+    #[Post]
+    public string $name;
+
+    #[NestedFilter(class: AddressFilter::class)]
+    public AddressFilter $address;
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition(validationRules: [
+            'name' => ['required', 'string'],
+        ]);
+    }
+}

--- a/tests/app/src/Request/ProfileFilterWithPrefix.php
+++ b/tests/app/src/Request/ProfileFilterWithPrefix.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\NestedFilter;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+final class ProfileFilterWithPrefix extends Filter implements HasFilterDefinition
+{
+    #[Post]
+    public string $name;
+
+    #[NestedFilter(class: AddressFilter::class, prefix: 'addr')]
+    public AddressFilter $address;
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition(validationRules: [
+            'name' => ['required', 'string'],
+        ]);
+    }
+}

--- a/tests/app/src/TestApp.php
+++ b/tests/app/src/TestApp.php
@@ -29,6 +29,7 @@ class TestApp extends Kernel implements \Spiral\Testing\TestableKernelInterface
         // Validation, filtration, security
         Bootloader\Security\EncrypterBootloader::class,
         \Spiral\Validation\Bootloader\ValidationBootloader::class,
+        \Spiral\Validator\Bootloader\ValidatorBootloader::class,
         Bootloader\Security\FiltersBootloader::class,
         Bootloader\Security\GuardBootloader::class,
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌

This pull request fixes two issues with the NestedFilter class:

1. When a `prefix` was not provided for NestedFilter, the validation error key was incorrect.
2. When nested values were invalid but the parent values were valid, a validation exception was not being thrown.

```php
// ProfileFilter 
class ProfileFilter extends Filter implements HasFilterDefinition
{
    #[Post]
    public string $name;

    #[NestedFilter(class: AddressFilter::class)]
    public AddressFilter $address;

    public function filterDefinition(): FilterDefinitionInterface
    {
        return new FilterDefinition(validationRules: [
            'name' => ['required', 'string'],
        ]);
    }
}

// AddressFilter 
class AddressFilter extends Filter implements HasFilterDefinition
{
    #[Post]
    public string $city;

    #[Post]
    public string $address;

    public function filterDefinition(): FilterDefinitionInterface
    {
        return new FilterDefinition(validationRules: [
            'city' => ['required', 'string'],
            'address' => ['required', 'string'],
        ]);
    }
}
```

`ProfileFilter` request with the given data will be valid request, but in fact it has invalid address

```json
{"name": "'ohn Doe"}
```
