### PR TITLE
Adding the ability to configure a prefix in the storage alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     `Spiral\Scaffolder\Command\BootloaderCommand`, `Spiral\Scaffolder\Command\CommandCommand`, 
     `Spiral\Scaffolder\Command\ConfigCommand`, `Spiral\Scaffolder\Command\ControllerCommand`,
     `Spiral\Scaffolder\Command\JobHandlerCommand`, `Spiral\Scaffolder\Command\MiddlewareCommand` console commands.
+  - [spiral/cache] Added the ability to configure the prefix in the storage alias.
   - Added `defineInterceptors` method in `Spiral\Bootloader\DomainBootloader` class.  
 
 ## 3.5.0 - 2022-12-23

--- a/src/Cache/src/CacheManager.php
+++ b/src/Cache/src/CacheManager.php
@@ -35,11 +35,11 @@ class CacheManager implements CacheStorageProviderInterface, SingletonInterface
             $storage = $storage['storage'];
         }
 
-        if (isset($this->storages[$storage])) {
-            return new CacheRepository($this->storages[$storage], $this->dispatcher, $prefix);
+        if(!isset($this->storages[$storage])) {
+            $this->storages[$storage] = $this->resolve($storage);
         }
 
-        return new CacheRepository($this->storages[$storage] = $this->resolve($storage), $this->dispatcher, $prefix);
+        return new CacheRepository($this->storages[$storage], $this->dispatcher, $prefix);
     }
 
     private function resolve(?string $name): CacheInterface

--- a/src/Cache/src/CacheManager.php
+++ b/src/Cache/src/CacheManager.php
@@ -35,7 +35,7 @@ class CacheManager implements CacheStorageProviderInterface, SingletonInterface
             $storage = $storage['storage'];
         }
 
-        if(!isset($this->storages[$storage])) {
+        if (!isset($this->storages[$storage])) {
             $this->storages[$storage] = $this->resolve($storage);
         }
 

--- a/src/Cache/src/CacheManager.php
+++ b/src/Cache/src/CacheManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Cache;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\SimpleCache\CacheInterface;
 use Spiral\Cache\Config\CacheConfig;
 use Spiral\Core\Container\SingletonInterface;
@@ -16,7 +17,8 @@ class CacheManager implements CacheStorageProviderInterface, SingletonInterface
 
     public function __construct(
         private readonly CacheConfig $config,
-        private readonly FactoryInterface $factory
+        private readonly FactoryInterface $factory,
+        private readonly ?EventDispatcherInterface $dispatcher = null,
     ) {
     }
 
@@ -25,19 +27,25 @@ class CacheManager implements CacheStorageProviderInterface, SingletonInterface
         $name ??= $this->config->getDefaultStorage();
 
         // Replaces alias with real storage name
-        $name = $this->config->getAliases()[$name] ?? $name;
+        $storage = $this->config->getAliases()[$name] ?? $name;
 
-        if (isset($this->storages[$name])) {
-            return $this->storages[$name];
+        $prefix = null;
+        if (\is_array($storage)) {
+            $prefix = !empty($storage['prefix']) ? $storage['prefix'] : null;
+            $storage = $storage['storage'];
         }
 
-        return $this->storages[$name] = $this->resolve($name);
+        if (isset($this->storages[$storage])) {
+            return new CacheRepository($this->storages[$storage], $this->dispatcher, $prefix);
+        }
+
+        return new CacheRepository($this->storages[$storage] = $this->resolve($storage), $this->dispatcher, $prefix);
     }
 
     private function resolve(?string $name): CacheInterface
     {
         $config = $this->config->getStorageConfig($name);
 
-        return new CacheRepository($this->factory->make($config['type'], $config));
+        return $this->factory->make($config['type'], $config);
     }
 }

--- a/src/Cache/tests/CacheRepositoryTest.php
+++ b/src/Cache/tests/CacheRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Cache;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\SimpleCache\CacheInterface;
 use Spiral\Cache\CacheRepository;
 use Spiral\Cache\Event\CacheHit;
 use Spiral\Cache\Event\CacheMissed;
@@ -116,5 +117,132 @@ final class CacheRepositoryTest extends TestCase
 
         $repository->setMultiple(['test' => [], 'test2' => []]);
         $repository->deleteMultiple(['test', 'test2']);
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testGet(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('get')
+            ->with($expectedKey)
+            ->willReturn(null);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->get('data');
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testSet(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('set')
+            ->with($expectedKey, 'foo')
+            ->willReturn(true);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->set('data', 'foo');
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testDelete(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('delete')
+            ->with($expectedKey)
+            ->willReturn(true);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->delete('data');
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testGetMultiple(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('get')
+            ->with($expectedKey)
+            ->willReturn(null);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->getMultiple(['data']);
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testSetMultiple(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('set')
+            ->with($expectedKey, 'foo')
+            ->willReturn(true);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->setMultiple(['data' => 'foo']);
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testDeleteMultiple(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('delete')
+            ->with($expectedKey)
+            ->willReturn(true);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->deleteMultiple(['data']);
+    }
+
+    /**
+     * @dataProvider keysDataProvider
+     */
+    public function testHas(string $expectedKey, ?string $prefix = null): void
+    {
+        $storage = $this->createMock(CacheInterface::class);
+        $storage
+            ->expects($this->once())
+            ->method('has')
+            ->with($expectedKey)
+            ->willReturn(true);
+
+        $repository = new CacheRepository(storage: $storage, prefix: $prefix);
+
+        $repository->has('data');
+    }
+
+    public function keysDataProvider(): \Traversable
+    {
+        yield ['data'];
+        yield ['data', ''];
+        yield ['data', null];
+        yield ['user_data', 'user_'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added the ability to configure prefixes in the storage alias.

### app/config/cache.php

```php
use Spiral\Cache\Storage\ArrayStorage;

return [
    'aliases' => [
        'user-data' => 'localMemory',
        'blog-data' => [
            'storage' => 'localMemory',
            'prefix' => 'blog_'
        ],
    ],
    'storages' => [
        'localMemory' => [
            'type' => ArrayStorage::class,
        ],
    ],
];
```

### Setting data

```php
// CacheManager $cache
$cache->storage('user-data')->set('data', 'foo');
$cache->storage('blog-data')->set('data', 'bar');
```

### Result

```php
array:2 [
  "data" => array:2 [
    "value" => "foo"
    "timestamp" => 1677694480
  ]
  "blog_data" => array:2 [
    "value" => "bar"
    "timestamp" => 1677694480
  ]
]
```

### Bugfix

Added missed **EventDispatcher** when creating **CacheRepository** and the test for this case.

