### PR TITLE
Ignore exception handling for already silent errors

### DIFF
--- a/src/Exceptions/src/ExceptionHandler.php
+++ b/src/Exceptions/src/ExceptionHandler.php
@@ -129,17 +129,23 @@ class ExceptionHandler implements ExceptionHandlerInterface
      */
     protected function handleShutdown(): void
     {
-        if (!empty($error = \error_get_last())) {
-            $this->handleGlobalException(
-                new FatalException(
-                    $error['message'],
-                    $error['type'],
-                    0,
-                    $error['file'],
-                    $error['line']
-                )
-            );
+        if (empty($error = \error_get_last())) {
+            return;
         }
+
+        if ($error['type'] &~ \error_reporting()) {
+            return;
+        }
+
+        $this->handleGlobalException(
+            new FatalException(
+                $error['message'],
+                $error['type'],
+                0,
+                $error['file'],
+                $error['line']
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | NO <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->


## Problem

I want to temporary hide deprecated errors and I go to `app.php` to set custom error reporting:
```php
\error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
// or \error_reporting(E_ALL ^ E_DEPRECATED);
```

and then I ran my cli script again. I still got an error with deprication but wrapped by framework error handler.

## Solution

Don't handle PHP errors with the framework's error handler unless the developer wants to.
