### PR TITLE
Adds custom transports registrar for SendIt component

### DIFF
--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -89,13 +89,14 @@ class MailerBootloader extends Bootloader
         );
     }
 
-    private function initTransportResolver(
+    protected function initTransportResolver(
         ?EventDispatcherInterface $dispatcher = null,
         ?LogsInterface $logs = null,
     ): TransportResolver {
         $defaultTransports = \iterator_to_array(Transport::getDefaultFactories(
-            dispatcher: $dispatcher,
-            logger: $logs?->getLogger('mailer')
+            $dispatcher,
+            null,
+            $logs?->getLogger('mailer')
         ));
 
         return new TransportResolver(

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -81,6 +81,14 @@ class MailerBootloader extends Bootloader
         return $transports->resolve($config->getDSN());
     }
 
+    public function mailer(TransportInterface $transport, ?EventDispatcherInterface $dispatcher = null): SymfonyMailer
+    {
+        return new Mailer(
+            transport: $transport,
+            dispatcher: $dispatcher
+        );
+    }
+
     private function initTransportResolver(
         ?EventDispatcherInterface $dispatcher = null,
         ?LogsInterface $logs = null,
@@ -92,14 +100,6 @@ class MailerBootloader extends Bootloader
 
         return new TransportResolver(
             new Transport($defaultTransports)
-        );
-    }
-
-    public function mailer(TransportInterface $transport, ?EventDispatcherInterface $dispatcher = null): SymfonyMailer
-    {
-        return new Mailer(
-            transport: $transport,
-            dispatcher: $dispatcher
         );
     }
 }

--- a/src/SendIt/src/Bootloader/MailerBootloader.php
+++ b/src/SendIt/src/Bootloader/MailerBootloader.php
@@ -6,10 +6,12 @@ namespace Spiral\SendIt\Bootloader;
 
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Core\BinderInterface;
+use Spiral\Logger\LogsInterface;
 use Spiral\Mailer\MailerInterface;
 use Spiral\Queue\Bootloader\QueueBootloader;
 use Spiral\Queue\QueueConnectionProviderInterface;
@@ -17,6 +19,9 @@ use Spiral\Queue\QueueRegistry;
 use Spiral\SendIt\Config\MailerConfig;
 use Spiral\SendIt\MailJob;
 use Spiral\SendIt\MailQueue;
+use Spiral\SendIt\TransportRegistryInterface;
+use Spiral\SendIt\TransportResolver;
+use Spiral\SendIt\TransportResolverInterface;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface as SymfonyMailer;
 use Symfony\Component\Mailer\Transport;
@@ -35,6 +40,9 @@ class MailerBootloader extends Bootloader
     protected const SINGLETONS = [
         MailJob::class => MailJob::class,
         SymfonyMailer::class => [self::class, 'mailer'],
+        TransportResolver::class => [self::class, 'initTransportResolver'],
+        TransportResolverInterface::class => TransportResolver::class,
+        TransportRegistryInterface::class => TransportResolver::class,
         TransportInterface::class => [self::class, 'initTransport'],
     ];
 
@@ -68,9 +76,23 @@ class MailerBootloader extends Bootloader
         $registry->setHandler(MailQueue::JOB_NAME, MailJob::class);
     }
 
-    public function initTransport(MailerConfig $config): TransportInterface
+    public function initTransport(MailerConfig $config, TransportResolverInterface $transports): TransportInterface
     {
-        return Transport::fromDsn($config->getDSN());
+        return $transports->resolve($config->getDSN());
+    }
+
+    private function initTransportResolver(
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LogsInterface $logs = null,
+    ): TransportResolver {
+        $defaultTransports = \iterator_to_array(Transport::getDefaultFactories(
+            dispatcher: $dispatcher,
+            logger: $logs?->getLogger('mailer')
+        ));
+
+        return new TransportResolver(
+            new Transport($defaultTransports)
+        );
     }
 
     public function mailer(TransportInterface $transport, ?EventDispatcherInterface $dispatcher = null): SymfonyMailer

--- a/src/SendIt/src/TransportRegistryInterface.php
+++ b/src/SendIt/src/TransportRegistryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\SendIt;
+
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+interface TransportRegistryInterface
+{
+    /**
+     * Register a custom mail transport factory.
+     */
+    public function registerTransport(TransportFactoryInterface $factory): void;
+
+    /**
+     * @return TransportFactoryInterface[]
+     */
+    public function getTransports(): array;
+}

--- a/src/SendIt/src/TransportResolver.php
+++ b/src/SendIt/src/TransportResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\SendIt;
+
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+final class TransportResolver implements TransportResolverInterface, TransportRegistryInterface
+{
+    /** @var TransportFactoryInterface[] */
+    private array $transports = [];
+
+    public function __construct(
+        private readonly Transport $transport,
+    ) {
+    }
+
+    public function registerTransport(TransportFactoryInterface $factory): void
+    {
+        $this->transports[] = $factory;
+    }
+
+    public function resolve(string $dsn): TransportInterface
+    {
+        $dsnDto = Dsn::fromString($dsn);
+        foreach ($this->transports as $transport) {
+            if ($transport->supports($dsnDto)) {
+                return $transport->create($dsnDto);
+            }
+        }
+
+        return $this->transport->fromString($dsn);
+    }
+
+    public function getTransports(): array
+    {
+        return $this->transports;
+    }
+}

--- a/src/SendIt/src/TransportResolverInterface.php
+++ b/src/SendIt/src/TransportResolverInterface.php
@@ -12,7 +12,7 @@ interface TransportResolverInterface
     /**
      * Resolve a mail transport from a DSN string.
      *
-     * @param string $dsn The DSN string to resolve, in the format of smtp://user:pass@smtp.example.com:25.
+     * @param string $dsn The DSN string to resolve, in the format of `smtp://user:pass@smtp.example.com:25`.
      * @throws UnsupportedSchemeException If the DSN string is not supported.
      */
     public function resolve(string $dsn): TransportInterface;

--- a/src/SendIt/src/TransportResolverInterface.php
+++ b/src/SendIt/src/TransportResolverInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\SendIt;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+interface TransportResolverInterface
+{
+    /**
+     * Resolve a mail transport from a DSN string.
+     *
+     * @param string $dsn The DSN string to resolve, in the format of smtp://user:pass@smtp.example.com:25.
+     * @throws UnsupportedSchemeException If the DSN string is not supported.
+     */
+    public function resolve(string $dsn): TransportInterface;
+}

--- a/src/SendIt/tests/TransportResolverTest.php
+++ b/src/SendIt/tests/TransportResolverTest.php
@@ -41,7 +41,7 @@ final class TransportResolverTest extends TestCase
         $this->assertSame($transport, $transportResolver->resolve('smtp://localhost'));
     }
 
-    public function testCanResolveRegisteredDefaultTransport()
+    public function testCanResolveRegisteredDefaultTransport(): void
     {
         $transportFactory = m::mock(TransportFactoryInterface::class);
         $arg = fn(Transport\Dsn $dsn) => $dsn->getHost() === 'localhost' and $dsn->getScheme() === 'smtp';

--- a/src/SendIt/tests/TransportResolverTest.php
+++ b/src/SendIt/tests/TransportResolverTest.php
@@ -16,7 +16,7 @@ final class TransportResolverTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function testCanRegisterTransport()
+    public function testCanRegisterTransport(): void
     {
         $transportFactory = m::mock(TransportFactoryInterface::class);
         $transportResolver = new TransportResolver(new Transport([]));

--- a/src/SendIt/tests/TransportResolverTest.php
+++ b/src/SendIt/tests/TransportResolverTest.php
@@ -25,7 +25,7 @@ final class TransportResolverTest extends TestCase
         $this->assertCount(1, $transportResolver->getTransports());
     }
 
-    public function testCanResolveRegisteredTransport()
+    public function testCanResolveRegisteredTransport(): void
     {
         $transportFactory = m::mock(TransportFactoryInterface::class);
         $arg = fn(Transport\Dsn $dsn) => $dsn->getHost() === 'localhost' and $dsn->getScheme() === 'smtp';

--- a/src/SendIt/tests/TransportResolverTest.php
+++ b/src/SendIt/tests/TransportResolverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\SendIt;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use Spiral\SendIt\TransportResolver;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+final class TransportResolverTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testCanRegisterTransport()
+    {
+        $transportFactory = m::mock(TransportFactoryInterface::class);
+        $transportResolver = new TransportResolver(new Transport([]));
+
+        $transportResolver->registerTransport($transportFactory);
+        $this->assertCount(1, $transportResolver->getTransports());
+    }
+
+    public function testCanResolveRegisteredTransport()
+    {
+        $transportFactory = m::mock(TransportFactoryInterface::class);
+        $arg = fn(Transport\Dsn $dsn) => $dsn->getHost() === 'localhost' and $dsn->getScheme() === 'smtp';
+
+        $transportFactory->shouldReceive('supports')->once()->withArgs($arg)->andReturn(true);
+        $transportFactory->shouldReceive('create')->once()->withArgs($arg)
+            ->andReturn($transport = m::mock(Transport\TransportInterface::class));
+
+        $transportResolver = new TransportResolver(new Transport([]));
+
+        $transportResolver->registerTransport($transportFactory);
+
+        $this->assertSame($transport, $transportResolver->resolve('smtp://localhost'));
+    }
+
+    public function testCanResolveRegisteredDefaultTransport()
+    {
+        $transportFactory = m::mock(TransportFactoryInterface::class);
+        $arg = fn(Transport\Dsn $dsn) => $dsn->getHost() === 'localhost' and $dsn->getScheme() === 'smtp';
+
+        $transportFactory->shouldReceive('supports')->once()->withArgs($arg)->andReturn(true);
+        $transportFactory->shouldReceive('create')->once()->withArgs($arg)
+            ->andReturn($transport = m::mock(Transport\TransportInterface::class));
+
+        $transportResolver = new TransportResolver(new Transport([$transportFactory]));
+
+        $this->assertSame($transport, $transportResolver->resolve('smtp://localhost'));
+    }
+
+    public function testNotRegisteredTransportShouldTrowAnException()
+    {
+        $this->expectException(UnsupportedSchemeException::class);
+        $this->expectErrorMessage('The "smtp" scheme is not supported.');
+        $transportFactory = m::mock(TransportFactoryInterface::class);
+
+        $transportFactory->shouldReceive('supports')->once()->andReturn(false);
+        $transportResolver = new TransportResolver(new Transport([]));
+        $transportResolver->registerTransport($transportFactory);
+        $transportResolver->resolve('smtp://localhost');
+    }
+}

--- a/src/SendIt/tests/TransportResolverTest.php
+++ b/src/SendIt/tests/TransportResolverTest.php
@@ -55,7 +55,7 @@ final class TransportResolverTest extends TestCase
         $this->assertSame($transport, $transportResolver->resolve('smtp://localhost'));
     }
 
-    public function testNotRegisteredTransportShouldTrowAnException()
+    public function testNotRegisteredTransportShouldTrowAnException(): void
     {
         $this->expectException(UnsupportedSchemeException::class);
         $this->expectErrorMessage('The "smtp" scheme is not supported.');

--- a/tests/Framework/Bootloader/SendIt/MailerBootloaderTest.php
+++ b/tests/Framework/Bootloader/SendIt/MailerBootloaderTest.php
@@ -9,6 +9,9 @@ use Spiral\SendIt\Bootloader\MailerBootloader;
 use Spiral\SendIt\Config\MailerConfig;
 use Spiral\SendIt\MailJob;
 use Spiral\SendIt\MailQueue;
+use Spiral\SendIt\TransportRegistryInterface;
+use Spiral\SendIt\TransportResolver;
+use Spiral\SendIt\TransportResolverInterface;
 use Spiral\Tests\Framework\BaseTest;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface as SymfonyMailer;
@@ -32,6 +35,13 @@ final class MailerBootloaderTest extends BaseTest
          * {@see https://github.com/spiral/framework/pull/683}
          */
         $this->assertFalse($class->isFinal(), 'MailerBootloader should not be final.');
+    }
+
+    public function testTransportResolverBindings(): void
+    {
+        $this->assertContainerBoundAsSingleton(TransportResolver::class, TransportResolver::class);
+        $this->assertContainerBoundAsSingleton(TransportResolverInterface::class, TransportResolver::class);
+        $this->assertContainerBoundAsSingleton(TransportRegistryInterface::class, TransportResolver::class);
     }
 
     public function testMailJobBinding(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

In some cases, you may need to use custom mail transports that are not provided by the symfony/mailer component, In this case, you can register a custom transport by using the  `Spiral\SendIt\TransportRegistryInterface`  interface.

```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\SendIt\TransportRegistryInterface;
use Symfony\Component\Mailer\Transport\c;

class AppBootloader extends Bootloader 
{
    public function boot(TransportRegistryInterface $registry): void
    {
        $registry->registerTransport(new SendmailTransportFactory(...));
    }
}
```


Closes #855



