### PR TITLE
Makes Setter attribute for the spiral/filters component repeatable.

### DIFF
--- a/src/Filters/src/Attribute/Setter.php
+++ b/src/Filters/src/Attribute/Setter.php
@@ -16,18 +16,20 @@ use Spiral\Attributes\NamedArgumentConstructor;
  * Example 2:
  * #[\Spiral\Filters\Attribute\Setter(filter: [Foo::class, 'bar'])]
  */
-#[Attribute(Attribute::TARGET_PROPERTY), NamedArgumentConstructor]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE), NamedArgumentConstructor]
 final class Setter
 {
     public readonly \Closure $filter;
+    private array $args;
 
-    public function __construct(callable $filter)
+    public function __construct(callable $filter, mixed ...$args)
     {
         $this->filter = $filter(...);
+        $this->args = $args;
     }
 
     public function updateValue(mixed $value): mixed
     {
-        return ($this->filter)($value);
+        return ($this->filter)($value, ...$this->args);
     }
 }

--- a/src/Filters/src/Model/Schema/AttributeMapper.php
+++ b/src/Filters/src/Model/Schema/AttributeMapper.php
@@ -85,13 +85,13 @@ final class AttributeMapper
 
     private function setValue(FilterInterface $filter, \ReflectionProperty $property, mixed $value): void
     {
-        $setter = $this->reader->firstPropertyMetadata($property, Setter::class);
-
         if ($value === null) {
             return;
         }
 
-        if ($setter) {
+        $setters = $this->reader->getPropertyMetadata($property, Setter::class);
+
+        foreach ($setters as $setter) {
             $value = $setter->updateValue($value);
         }
 

--- a/tests/Framework/Filter/Model/FilterWithSettersTest.php
+++ b/tests/Framework/Filter/Model/FilterWithSettersTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Filter\Model;
+
+use Spiral\App\Request\FilterWithSetters;
+use Spiral\Tests\Framework\Filter\FilterTestCase;
+
+final class FilterWithSettersTest extends FilterTestCase
+{
+    public function testSetters(): void
+    {
+        $filter = $this->getFilter(FilterWithSetters::class, [
+            'integer' => '1',
+            'string' => new class implements \Stringable {
+                public function __toString()
+                {
+                    return '--<b>"test"</b>  ';
+                }
+            },
+        ]);
+
+        $this->assertInstanceOf(FilterWithSetters::class, $filter);
+
+        $this->assertSame(1, $filter->integer);
+        $this->assertSame('&lt;b&gt;&quot;test&quot;&lt;/b&gt;', $filter->string);
+    }
+}

--- a/tests/app/src/Request/FilterWithSetters.php
+++ b/tests/app/src/Request/FilterWithSetters.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\Setter;
+use Spiral\Filters\Model\Filter;
+
+class FilterWithSetters extends Filter
+{
+    #[Post]
+    #[Setter(filter: 'intval')]
+    public int $integer;
+
+    #[Post]
+    #[Setter(filter: 'strval')]
+    #[Setter('ltrim', '-')]
+    #[Setter('rtrim', ' ')]
+    #[Setter('htmlspecialchars')]
+    public string $string;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #859

It allows to define multiple `#[Setter]` attributes on filter class

```php
class StoreUserFilter extends Filter
{
    #[Post]
    #[Setter(filter: 'strval')]
    #[Setter('ltrim', '-')]
    #[Setter('rtrim', ' ')]
    #[Setter('htmlspecialchars')]
    public string $name;
}
```
