### PR TITLE
Fixing Split Monorepo action

### DIFF
--- a/.github/workflows/split_monorepo.yml
+++ b/.github/workflows/split_monorepo.yml
@@ -119,7 +119,7 @@ jobs:
       # no tag
       - if: "!startsWith(github.ref, 'refs/tags/')"
         name: Monorepo Split of ${{ matrix.package }}
-        uses: "symplify/monorepo-split-github-action@2.1"
+        uses: danharrin/monorepo-split-github-action@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
@@ -133,7 +133,7 @@ jobs:
       # with tag
       - if: "startsWith(github.ref, 'refs/tags/')"
         name: Monorepo Tagged Split of ${{ matrix.package }}
-        uses: "symplify/monorepo-split-github-action@2.1"
+        uses: danharrin/monorepo-split-github-action@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->


The splitter started throwing an error:
```
[NOTE] Changing directory from "/github/workspace" to "/tmp/monorepo_split/build_directory"

fatal: detected dubious ownership in repository at '/tmp/monorepo_split/build_directory'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmp/monorepo_split/build_directory
fatal: detected dubious ownership in repository at '/tmp/monorepo_split/build_directory'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmp/monorepo_split/build_directory
```
The version of the gh action was changed to the one in which it was fixed:
https://github.com/danharrin/monorepo-split-github-action/pull/44