### PR TITLE
Fixes scaffolder command namespace and comment options

### DIFF
--- a/src/Scaffolder/src/Command/AbstractCommand.php
+++ b/src/Scaffolder/src/Command/AbstractCommand.php
@@ -18,7 +18,7 @@ abstract class AbstractCommand extends Command
         protected ScaffolderConfig $config,
         protected FilesInterface $files,
         ContainerInterface $container,
-        private readonly FactoryInterface $factory
+        private readonly FactoryInterface $factory,
     ) {
         $this->setContainer($container);
 
@@ -36,10 +36,10 @@ abstract class AbstractCommand extends Command
         return $this->factory->make(
             $class,
             [
-                'name' => (string) $this->argument('name'),
+                'name' => (string)$this->argument('name'),
                 'comment' => $this->option('comment'),
-                'namespace' => $this->option('namespace'),
-            ] + $this->config->declarationOptions($class::TYPE)
+                'namespace' => $this->getNamespace(),
+            ] + $this->config->declarationOptions($class::TYPE),
         );
     }
 
@@ -50,8 +50,8 @@ abstract class AbstractCommand extends Command
     {
         $filename = $this->config->classFilename(
             $declaration::TYPE,
-            (string) $this->argument('name'),
-            $this->option('namespace')
+            (string)$this->argument('name'),
+            $this->getNamespace(),
         );
         $filename = $this->files->normalizePath($filename);
         $className = $declaration->getClass()->getName();
@@ -59,7 +59,7 @@ abstract class AbstractCommand extends Command
         if ($this->files->exists($filename)) {
             $this->writeln(
                 \sprintf("<fg=red>Unable to create '<comment>%s</comment>' declaration, ", $className)
-                . \sprintf("file '<comment>%s</comment>' already exists.</fg=red>", $filename)
+                . \sprintf("file '<comment>%s</comment>' already exists.</fg=red>", $filename),
             );
 
             return;
@@ -70,7 +70,12 @@ abstract class AbstractCommand extends Command
 
         $this->writeln(
             \sprintf("Declaration of '<info>%s</info>' ", $className)
-            . \sprintf("has been successfully written into '<comment>%s</comment>'.", $filename)
+            . \sprintf("has been successfully written into '<comment>%s</comment>'.", $filename),
         );
+    }
+
+    protected function getNamespace(): ?string
+    {
+        return $this->hasOption('namespace') ? $this->option('namespace') : null;
     }
 }

--- a/src/Scaffolder/src/Command/AbstractCommand.php
+++ b/src/Scaffolder/src/Command/AbstractCommand.php
@@ -37,7 +37,7 @@ abstract class AbstractCommand extends Command
             $class,
             [
                 'name' => (string)$this->argument('name'),
-                'comment' => $this->option('comment'),
+                'comment' => $this->getComment(),
                 'namespace' => $this->getNamespace(),
             ] + $this->config->declarationOptions($class::TYPE),
         );
@@ -77,5 +77,10 @@ abstract class AbstractCommand extends Command
     protected function getNamespace(): ?string
     {
         return $this->hasOption('namespace') ? $this->option('namespace') : null;
+    }
+
+    protected function getComment(): ?string
+    {
+        return $this->hasOption('comment') ? $this->option('comment') : null;
     }
 }

--- a/src/Scaffolder/tests/App/Command/CommandWithNamespace.php
+++ b/src/Scaffolder/tests/App/Command/CommandWithNamespace.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Scaffolder\App\Command;
+
+use Spiral\Scaffolder\Command\AbstractCommand;
+use Spiral\Scaffolder\Declaration\CommandDeclaration;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+final class CommandWithNamespace extends AbstractCommand
+{
+    protected const NAME = 'create:command-with-namespace';
+
+    protected const ARGUMENTS   = [
+        ['name', InputArgument::REQUIRED, 'Command name'],
+        ['alias', InputArgument::OPTIONAL, 'Command id/alias'],
+    ];
+
+    protected const OPTIONS     = [
+        [
+            'namespace',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional, specify a custom namespace',
+        ],
+        [
+            'comment',
+            'c',
+            InputOption::VALUE_OPTIONAL,
+            'Optional comment to add as class header',
+        ],
+    ];
+
+    public function __invoke(): int
+    {
+        $declaration = $this->createDeclaration(CommandDeclaration::class);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Scaffolder/tests/App/Command/CommandWithoutNamespace.php
+++ b/src/Scaffolder/tests/App/Command/CommandWithoutNamespace.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Scaffolder\App\Command;
+
+use Spiral\Scaffolder\Command\AbstractCommand;
+use Spiral\Scaffolder\Declaration\CommandDeclaration;
+use Symfony\Component\Console\Input\InputArgument;
+
+final class CommandWithoutNamespace extends AbstractCommand
+{
+    protected const NAME = 'create:command-without-namespace';
+
+    protected const ARGUMENTS   = [
+        ['name', InputArgument::REQUIRED, 'Command name'],
+        ['alias', InputArgument::OPTIONAL, 'Command id/alias'],
+    ];
+
+    public function __invoke(): int
+    {
+        $declaration = $this->createDeclaration(CommandDeclaration::class);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Scaffolder/tests/App/TestApp.php
+++ b/src/Scaffolder/tests/App/TestApp.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Scaffolder\App;
 
 use Spiral\Boot;
+use Spiral\Core\Container;
 use Spiral\Scaffolder;
 use Throwable;
 
@@ -22,6 +23,11 @@ class TestApp extends Boot\AbstractKernel
     public function get(string $target)
     {
         return $this->container->get($target);
+    }
+
+    public function getContainer(): Container
+    {
+        return $this->container;
     }
 
     /**

--- a/src/Scaffolder/tests/Command/CommandNamespaceTest.php
+++ b/src/Scaffolder/tests/Command/CommandNamespaceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Scaffolder\Command;
+
+use Mockery as m;
+use Spiral\Console\Command;
+use Spiral\Core\FactoryInterface;
+use Spiral\Scaffolder\Declaration\CommandDeclaration;
+use Spiral\Scaffolder\Declaration\DeclarationInterface;
+
+final class CommandNamespaceTest extends AbstractCommandTest
+{
+    public function testCommandWithoutNamespaceOption(): void
+    {
+        $this->app->getContainer()->bind(
+            FactoryInterface::class,
+            $factory = m::mock(FactoryInterface::class),
+        );
+
+        $factory->shouldReceive('make')
+            ->once()
+            ->with(CommandDeclaration::class, [
+                'name' => 'foo',
+                'comment' => null,
+                'namespace' => null,
+            ])
+            ->andReturn(m::mock(DeclarationInterface::class));
+
+        $output = $this->console()->run('create:command-without-namespace', [
+            'name' => 'foo',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $output->getCode());
+    }
+
+    public function testCommandWithNamespaceOption(): void
+    {
+        $this->app->getContainer()->bind(
+            FactoryInterface::class,
+            $factory = m::mock(FactoryInterface::class),
+        );
+
+        $factory->shouldReceive('make')
+            ->once()
+            ->with(CommandDeclaration::class, [
+                'name' => 'foo',
+                'comment' => null,
+                'namespace' => 'App\Command',
+            ])
+            ->andReturn(m::mock(DeclarationInterface::class));
+
+        $output = $this->console()->run('create:command-with-namespace', [
+            'name' => 'foo',
+            '--namespace' => 'App\Command'
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $output->getCode());
+    }
+
+    public function testCommandWithCommentOption(): void
+    {
+        $this->app->getContainer()->bind(
+            FactoryInterface::class,
+            $factory = m::mock(FactoryInterface::class),
+        );
+
+        $factory->shouldReceive('make')
+            ->once()
+            ->with(CommandDeclaration::class, [
+                'name' => 'foo',
+                'comment' => 'Some command',
+                'namespace' => null,
+            ])
+            ->andReturn(m::mock(DeclarationInterface::class));
+
+        $output = $this->console()->run('create:command-with-namespace', [
+            'name' => 'foo',
+            '--comment' => 'Some command'
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $output->getCode());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| Issues        | #882


Some scaffolder commands don't support `namespace` and `comment` options. In this case we should ignore them.