### PR TITLE
Added applying of setters to the filter data

### DIFF
--- a/src/Filters/src/Model/FilterProvider.php
+++ b/src/Filters/src/Model/FilterProvider.php
@@ -33,7 +33,7 @@ final class FilterProvider implements FilterProviderInterface
         \assert($attributeMapper instanceof AttributeMapper);
 
         $filter = $this->createFilterInstance($name);
-        [$mappingSchema, $errors] = $attributeMapper->map($filter, $input);
+        [$mappingSchema, $errors, $setters] = $attributeMapper->map($filter, $input);
 
         if ($filter instanceof HasFilterDefinition) {
             $mappingSchema = \array_merge(
@@ -50,7 +50,7 @@ final class FilterProvider implements FilterProviderInterface
 
         $schema = $schemaBuilder->makeSchema($name, $mappingSchema);
 
-        [$data, $inputErrors] = $inputMapper->map($schema, $input);
+        [$data, $inputErrors] = $inputMapper->map($schema, $input, $setters);
         $errors = \array_merge($errors, $inputErrors);
 
         $entity = new SchematicEntity($data, $schema);

--- a/src/Filters/src/Model/Schema/AttributeMapper.php
+++ b/src/Filters/src/Model/Schema/AttributeMapper.php
@@ -28,12 +28,13 @@ final class AttributeMapper
     /**
      * Map input data into filter properties with attributes
      *
-     * @return array{0: array, 1: array}
+     * @return array{0: array, 1: array, 2: array}
      */
     public function map(FilterInterface $filter, InputInterface $input): array
     {
         $errors = [];
         $schema = [];
+        $setters = [];
         $class = new \ReflectionClass($filter);
 
         foreach ($class->getProperties() as $property) {
@@ -76,11 +77,13 @@ final class AttributeMapper
 
                     $this->setValue($filter, $property, $propertyValues);
                     $schema[$property->getName()] = [$attribute->class, $prefix . '.*'];
+                } elseif ($attribute instanceof Setter) {
+                    $setters[$property->getName()][] = $attribute;
                 }
             }
         }
 
-        return [$schema, $errors];
+        return [$schema, $errors, $setters];
     }
 
     private function setValue(FilterInterface $filter, \ReflectionProperty $property, mixed $value): void

--- a/src/Filters/src/Model/Schema/InputMapper.php
+++ b/src/Filters/src/Model/Schema/InputMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Filters\Model\Schema;
 
+use Spiral\Filters\Attribute\Setter;
 use Spiral\Filters\Model\FilterProviderInterface;
 use Spiral\Filters\Exception\ValidationException;
 use Spiral\Filters\InputInterface;
@@ -15,7 +16,7 @@ final class InputMapper
     ) {
     }
 
-    public function map(array $mappingSchema, InputInterface $input): array
+    public function map(array $mappingSchema, InputInterface $input, array $setters = []): array
     {
         $errors = [];
         $result = [];
@@ -25,6 +26,11 @@ final class InputMapper
                 $value = $input->getValue($map[Builder::SCHEMA_SOURCE], $map[Builder::SCHEMA_ORIGIN]);
 
                 if ($value !== null) {
+                    /** @var Setter $setter */
+                    foreach ($setters[$field] ?? [] as $setter) {
+                        $value = $setter->updateValue($value);
+                    }
+
                     $result[$field] = $value;
                 }
                 continue;

--- a/tests/Framework/Filter/Model/FilterWithSettersTest.php
+++ b/tests/Framework/Filter/Model/FilterWithSettersTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Framework\Filter\Model;
 
 use Spiral\App\Request\FilterWithSetters;
+use Spiral\App\Request\PostFilter;
 use Spiral\Tests\Framework\Filter\FilterTestCase;
 
 final class FilterWithSettersTest extends FilterTestCase
@@ -25,5 +26,26 @@ final class FilterWithSettersTest extends FilterTestCase
 
         $this->assertSame(1, $filter->integer);
         $this->assertSame('&lt;b&gt;&quot;test&quot;&lt;/b&gt;', $filter->string);
+    }
+
+    public function testSettersWithValidation(): void
+    {
+        $filter = $this->getFilter(PostFilter::class, [
+            'body' => 'foo',
+            'revision' => '1',
+            'active' => '1',
+            'post_rating' => '0.9',
+            'author' => [
+                'id' => '3'
+            ]
+        ]);
+
+        $this->assertInstanceOf(PostFilter::class, $filter);
+
+        $this->assertSame('foo', $filter->body);
+        $this->assertSame(1, $filter->revision);
+        $this->assertTrue($filter->active);
+        $this->assertSame(0.9, $filter->postRating);
+        $this->assertSame(3, $filter->author->id);
     }
 }

--- a/tests/app/src/Request/AuthorFilter.php
+++ b/tests/app/src/Request/AuthorFilter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\Setter;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+final class AuthorFilter extends Filter implements HasFilterDefinition
+{
+    #[Post]
+    #[Setter('intval')]
+    public int $id;
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition([
+            'id' => ['integer', 'required'],
+        ]);
+    }
+}

--- a/tests/app/src/Request/PostFilter.php
+++ b/tests/app/src/Request/PostFilter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\NestedFilter;
+use Spiral\Filters\Attribute\Setter;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+final class PostFilter extends Filter implements HasFilterDefinition
+{
+    #[Post]
+    #[Setter('strval')]
+    public string $body;
+
+    #[Post]
+    #[Setter('intval')]
+    public int $revision;
+
+    #[Post]
+    #[Setter('boolval')]
+    public bool $active;
+
+    #[Post(key: 'post_rating')]
+    #[Setter('floatval')]
+    public float $postRating;
+
+    #[NestedFilter(AuthorFilter::class)]
+    public AuthorFilter $author;
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition([
+            'body' => ['string', 'required'],
+            'revision' => ['integer', 'required'],
+            'active' => ['boolean', 'required'],
+            'postRating' => ['float', 'required'],
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

### Description of the issue

Before these changes, setters were applied **only to the properties** of the filter object, while the `entity` property of the `Spiral\Filters\Model\FilterBag` object and the `data` property of the `Spiral\Filters\Model\Filter` object received data without applying setters.

Next, data without applying setters pass into validators.

And if you use data type validation in the filter, it doesn't work.

```php
use Spiral\Filters\Attribute\Input\Post;
use Spiral\Filters\Attribute\Setter;
use Spiral\Filters\Model\Filter;
use Spiral\Filters\Model\FilterDefinitionInterface;
use Spiral\Filters\Model\HasFilterDefinition;
use Spiral\Validator\FilterDefinition;

final class PostFilter extends Filter implements HasFilterDefinition
{
    #[Post]
    #[Setter('strval')]
    public string $body;

    #[Post]
    #[Setter('intval')]
    public int $revision;

    #[Post]
    #[Setter('boolval')]
    public bool $active;

    #[Post(key: 'post_rating')]
    #[Setter('floatval')]
    public float $postRating;

    public function filterDefinition(): FilterDefinitionInterface
    {
        return new FilterDefinition([
            'body' => ['string', 'required'],
            'revision' => ['integer', 'required'],
            'active' => ['boolean', 'required'],
            'postRating' => ['float', 'required'],
        ]);
    }
}
```

Errors:
```bash
["errors"]=>
  array(3) {
    ["revision"]=>
    string(39) "The condition `is_integer` was not met."
    ["active"]=>
    string(20) "Not a valid boolean."
    ["post_rating"]=>
    string(37) "The condition `is_float` was not met."
  }
```