### PR TITLE
Adding the ability to guess option mode by property type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Unreleased
+- **High Impact Changes**
+- **Medium Impact Changes**
+- **Other Features**
+  - [spiral/console] Added the ability to guess **option mode**, unless it is explicitly passed in the 
+    `Spiral\Console\Attribute\Option` attribute.
+- **Bug Fixes**
+
 ## 3.6.1 - 2023-02-20
 - **Bug Fixes**
   - [spiral/scaffolder] Fixed the problem with namespace option in some scaffolder commands.

--- a/src/Console/src/Attribute/Option.php
+++ b/src/Console/src/Attribute/Option.php
@@ -14,14 +14,14 @@ final class Option
      * @param ?non-empty-string $name Option name. Property name by default
      * @param non-empty-string|array|null $shortcut Option shortcut
      * @param ?non-empty-string $description Option description
-     * @param positive-int $mode Option mode, {@see InputOption} constants
+     * @param ?positive-int $mode Option mode, {@see InputOption} constants
      * @param \Closure|array $suggestedValues Option suggested values
      */
     public function __construct(
         public readonly ?string $name = null,
         public readonly string|array|null $shortcut = null,
         public readonly ?string $description = null,
-        public readonly int $mode = InputOption::VALUE_NONE,
+        public readonly ?int $mode = null,
         public readonly \Closure|array $suggestedValues = []
     ) {
     }

--- a/src/Console/src/Configurator/Attribute/Parser.php
+++ b/src/Console/src/Configurator/Attribute/Parser.php
@@ -148,7 +148,7 @@ final class Parser
                 $mode = $this->guessOptionMode($type, $property);
             }
 
-            if ($mode === InputOption::VALUE_NONE || $attribute->mode === InputOption::VALUE_NEGATABLE) {
+            if ($mode === InputOption::VALUE_NONE || $mode === InputOption::VALUE_NEGATABLE) {
                 if ($type->getName() !== 'bool') {
                     throw new ConfiguratorException(
                         'Options properties with mode `VALUE_NONE` or `VALUE_NEGATABLE` must be bool!'

--- a/src/Console/src/Configurator/Attribute/Parser.php
+++ b/src/Console/src/Configurator/Attribute/Parser.php
@@ -141,8 +141,13 @@ final class Parser
             }
 
             $type = $this->getPropertyType($property);
+            $mode = $attribute->mode;
 
-            if ($attribute->mode === InputOption::VALUE_NONE || $attribute->mode === InputOption::VALUE_NEGATABLE) {
+            if ($mode === null) {
+                $mode = $this->guessOptionMode($type, $property);
+            }
+
+            if ($mode === InputOption::VALUE_NONE || $attribute->mode === InputOption::VALUE_NEGATABLE) {
                 if ($type->getName() !== 'bool') {
                     throw new ConfiguratorException(
                         'Options properties with mode `VALUE_NONE` or `VALUE_NEGATABLE` must be bool!'
@@ -155,7 +160,7 @@ final class Parser
             $result[] = new InputOption(
                 name: $attribute->name ?? $property->getName(),
                 shortcut: $attribute->shortcut,
-                mode: $attribute->mode,
+                mode: $mode,
                 description: (string) $attribute->description,
                 default: $hasDefaultValue ? $property->getDefaultValue() : null,
                 suggestedValues: $attribute->suggestedValues
@@ -205,10 +210,26 @@ final class Parser
             }
         }
 
-        if ($type instanceof \ReflectionNamedType && $type->isBuiltin()) {
+        if ($type instanceof \ReflectionNamedType && $type->isBuiltin() && $type->getName() !== 'object') {
             return $type;
         }
 
         throw new ConfiguratorException(\sprintf('Invalid type for the `%s` property.', $property->getName()));
+    }
+
+    /**
+     * @return positive-int
+     */
+    private function guessOptionMode(\ReflectionNamedType $type, \ReflectionProperty $property): int
+    {
+        $isOptional = $type->allowsNull() || $property->hasDefaultValue();
+
+        return match (true) {
+            $type->getName() === 'bool' => InputOption::VALUE_NEGATABLE,
+            $type->getName() === 'array' && $isOptional => InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            $type->getName() === 'array' && !$isOptional => InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            $type->allowsNull() || $property->hasDefaultValue() => InputOption::VALUE_OPTIONAL,
+            default => InputOption::VALUE_REQUIRED
+        };
     }
 }

--- a/src/Console/src/Configurator/Attribute/Parser.php
+++ b/src/Console/src/Configurator/Attribute/Parser.php
@@ -75,10 +75,11 @@ final class Parser
             }
 
             if ($input->hasOption($attribute->name ?? $property->getName())) {
-                $property->setValue(
-                    $command,
-                    $this->typecast($input->getOption($attribute->name ?? $property->getName()), $property)
-                );
+                $value = $this->typecast($input->getOption($attribute->name ?? $property->getName()), $property);
+
+                if ($value !== null || $this->getPropertyType($property)->allowsNull()) {
+                    $property->setValue($command, $value);
+                }
             }
         }
     }
@@ -174,7 +175,7 @@ final class Parser
     {
         $type = $property->hasType() ? $property->getType() : null;
 
-        if (!$type instanceof \ReflectionNamedType) {
+        if (!$type instanceof \ReflectionNamedType || $value === null) {
             return $value;
         }
 

--- a/src/Console/tests/Configurator/Attribute/ArgumentsTest.php
+++ b/src/Console/tests/Configurator/Attribute/ArgumentsTest.php
@@ -228,4 +228,15 @@ final class ArgumentsTest extends TestCase
             }
         ));
     }
+
+    public function testArgumentWithObjectType(): void
+    {
+        $this->expectException(ConfiguratorException::class);
+        $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Argument]
+                private object $arg;
+            }
+        ));
+    }
 }

--- a/src/Console/tests/Configurator/Attribute/FillPropertiesTest.php
+++ b/src/Console/tests/Configurator/Attribute/FillPropertiesTest.php
@@ -128,7 +128,7 @@ final class FillPropertiesTest extends TestCase
         $this->assertTrue($command->otherBoolVal);
     }
 
-    public function testSkipPropertyIfOptionNotPassed(): void
+    public function testSkipPropertyIfOptionNotDefined(): void
     {
         $input = $this->createMock(InputInterface::class);
         $input
@@ -149,5 +149,52 @@ final class FillPropertiesTest extends TestCase
         $this->parser->fillProperties($command, $input);
 
         $this->assertFalse((new \ReflectionProperty($command, 'option'))->isInitialized($command));
+    }
+
+    public function testSkipPropertyIfOptionNotPassed(): void
+    {
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->expects($this->once())
+            ->method('hasOption')
+            ->with('option')
+            ->willReturn(true);
+
+        $input
+            ->expects($this->once())
+            ->method('getOption')
+            ->willReturn(null);
+
+        $command = new #[AsCommand('foo')] class extends Command {
+            #[Option(mode: InputOption::VALUE_REQUIRED)]
+            public int $option;
+        };
+
+        $this->parser->fillProperties($command, $input);
+
+        $this->assertFalse((new \ReflectionProperty($command, 'option'))->isInitialized($command));
+    }
+
+    public function testNullShouldPassWithoutTypecasting(): void
+    {
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->expects($this->once())
+            ->method('hasOption')
+            ->willReturn(true);
+
+        $input
+            ->expects($this->once())
+            ->method('getOption')
+            ->willReturn(null);
+
+        $command = new #[AsCommand('foo')] class extends Command {
+            #[Option(mode: InputOption::VALUE_REQUIRED)]
+            public ?int $intVal;
+        };
+
+        $this->parser->fillProperties($command, $input);
+
+        $this->assertNull($command->intVal);
     }
 }

--- a/src/Console/tests/Configurator/Attribute/OptionsTest.php
+++ b/src/Console/tests/Configurator/Attribute/OptionsTest.php
@@ -203,6 +203,140 @@ final class OptionsTest extends TestCase
         $this->assertFalse($result->options[0]->getDefault());
     }
 
+    public function testGuessedRequiredOption(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private int $int;
+
+                #[Option]
+                private float $float;
+
+                #[Option]
+                private string $string;
+            }
+        ));
+
+        $this->assertTrue($result->options[0]->isValueRequired());
+        $this->assertFalse($result->options[0]->isArray());
+        $this->assertTrue($result->options[0]->acceptValue());
+
+        $this->assertTrue($result->options[1]->isValueRequired());
+        $this->assertFalse($result->options[1]->isArray());
+        $this->assertTrue($result->options[1]->acceptValue());
+
+        $this->assertTrue($result->options[2]->isValueRequired());
+        $this->assertFalse($result->options[2]->isArray());
+        $this->assertTrue($result->options[2]->acceptValue());
+    }
+
+    public function testGuessedOptionalOption(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private ?int $int;
+
+                #[Option]
+                private ?float $float;
+
+                #[Option]
+                private ?string $string;
+            }
+        ));
+
+        $this->assertFalse($result->options[0]->isValueRequired());
+        $this->assertFalse($result->options[0]->isArray());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertNull($result->options[0]->getDefault());
+
+        $this->assertFalse($result->options[1]->isValueRequired());
+        $this->assertFalse($result->options[1]->isArray());
+        $this->assertTrue($result->options[1]->acceptValue());
+        $this->assertNull($result->options[1]->getDefault());
+
+        $this->assertFalse($result->options[2]->isValueRequired());
+        $this->assertFalse($result->options[2]->isArray());
+        $this->assertTrue($result->options[2]->acceptValue());
+        $this->assertNull($result->options[2]->getDefault());
+    }
+
+    public function testGuessedOptionalOptionFromPropertiesWithDefaultValue(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private int $int = 1;
+
+                #[Option]
+                private float $float = 2.0;
+
+                #[Option]
+                private string $string = 'foo';
+            }
+        ));
+
+        $this->assertFalse($result->options[0]->isValueRequired());
+        $this->assertFalse($result->options[0]->isArray());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertSame(1, $result->options[0]->getDefault());
+
+        $this->assertFalse($result->options[1]->isValueRequired());
+        $this->assertFalse($result->options[1]->isArray());
+        $this->assertTrue($result->options[1]->acceptValue());
+        $this->assertSame(2.0, $result->options[1]->getDefault());
+
+        $this->assertFalse($result->options[2]->isValueRequired());
+        $this->assertFalse($result->options[2]->isArray());
+        $this->assertTrue($result->options[2]->acceptValue());
+        $this->assertSame('foo', $result->options[2]->getDefault());
+    }
+
+    public function testGuessedArrayOption(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private array $array;
+            }
+        ));
+
+        $this->assertTrue($result->options[0]->isValueRequired());
+        $this->assertTrue($result->options[0]->isArray());
+        $this->assertTrue($result->options[0]->acceptValue());
+    }
+
+    public function testGuessedOptionalArrayOption(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private ?array $array;
+            }
+        ));
+
+        $this->assertFalse($result->options[0]->isValueRequired());
+        $this->assertTrue($result->options[0]->isArray());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertSame([], $result->options[0]->getDefault());
+    }
+
+    public function testGuessedOptionalArrayOptionFromPropertyWithDefaultValue(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private array $array = [];
+            }
+        ));
+
+        $this->assertFalse($result->options[0]->isValueRequired());
+        $this->assertTrue($result->options[0]->isArray());
+        $this->assertTrue($result->options[0]->acceptValue());
+        $this->assertSame([], $result->options[0]->getDefault());
+    }
+
     public function testWithSuggestedValue(): void
     {
         $result = $this->parser->parse(new \ReflectionClass(
@@ -265,6 +399,17 @@ final class OptionsTest extends TestCase
             new #[AsCommand(name: 'foo')] class {
                 #[Option]
                 private \stdClass&\Traversable $option;
+            }
+        ));
+    }
+
+    public function testOptionWithObjectType(): void
+    {
+        $this->expectException(ConfiguratorException::class);
+        $this->parser->parse(new \ReflectionClass(
+            new #[AsCommand(name: 'foo')] class {
+                #[Option]
+                private object $object;
             }
         ));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### Feature description

Removed default `mode` value from the `Spiral\Console\Attribute\Option`.
Now the value of mode can be guessed from the **type of the property** (if it is not explicitly passed to the **Option** attribute).

### Example

```php
namespace App\Endpoint\Console;

use Spiral\Console\Attribute\AsCommand;
use Spiral\Console\Attribute\Option;
use Spiral\Console\Command;

#[AsCommand(name: 'create:user', description: 'Create a new user')]
class CreateUserCommand extends Command
{
    #[Option]
    private bool $active; // InputOption::VALUE_NEGATABLE

    #[Option]
    private int $age; // InputOption::VALUE_REQUIRED

    #[Option]
    private int $friends = 0; // InputOption::VALUE_OPTIONAL (property have a default value)

    #[Option]
    private ?string $address = null; // InputOption::VALUE_OPTIONAL (nullable property)

    #[Option]
    private array $groups; // InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY

    #[Option]
    private array $phones = []; // InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY

    #[Option]
    private ?array $emails; // InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY

    public function __invoke(): int
    {
        // ...
    }
}
```
