### PR TITLE
Fixed the problem with using named parameters in class located by a tokenizer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+- **Medium Impact Changes**
+  - [spiral/queue] Added the ability to use mixed types as job payload.
+- **Bug Fixes**
+  - [spiral/console] Fixed the problem with commands description with signature definition.
+  - [spiral/tokenizer] Fixed the problem with using named parameters in class located by a tokenizer.
+
 ## 3.6.1 - 2023-02-20
 - **Bug Fixes**
   - [spiral/scaffolder] Fixed the problem with namespace option in some scaffolder commands.

--- a/src/Tokenizer/src/Reflection/ReflectionFile.php
+++ b/src/Tokenizer/src/Reflection/ReflectionFile.php
@@ -250,6 +250,11 @@ final class ReflectionFile
                         continue 2;
                     }
 
+                    if($this->isNamedParameter($tokenID)) {
+                        //PHP8.0 Named parameters
+                        continue 2;
+                    }
+
                     $this->registerDeclaration($tokenID, $token[self::TOKEN_TYPE]);
                     break;
 
@@ -395,14 +400,23 @@ final class ReflectionFile
 
     /**
      * Check if token ID represents `ClassName::class` constant statement.
-     *
-     *
      */
     private function isClassNameConst(int $tokenID): bool
     {
         return $this->tokens[$tokenID][self::TOKEN_TYPE] === T_CLASS
             && isset($this->tokens[$tokenID - 1])
             && $this->tokens[$tokenID - 1][self::TOKEN_TYPE] === T_PAAMAYIM_NEKUDOTAYIM;
+    }
+
+
+    /**
+     * Check if token ID represents named parameter with name `class`, e.g. `foo(class: SomeClass::name)`.
+     */
+    private function isNamedParameter(int|string $tokenID): bool
+    {
+        return $this->tokens[$tokenID][self::TOKEN_TYPE] === T_CLASS
+            && isset($this->tokens[$tokenID + 1])
+            && $this->tokens[$tokenID + 1][self::TOKEN_TYPE] === ':';
     }
 
     /**

--- a/src/Tokenizer/src/Reflection/ReflectionFile.php
+++ b/src/Tokenizer/src/Reflection/ReflectionFile.php
@@ -250,7 +250,7 @@ final class ReflectionFile
                         continue 2;
                     }
 
-                    if($this->isNamedParameter($tokenID)) {
+                    if ($this->isNamedParameter($tokenID)) {
                         //PHP8.0 Named parameters
                         continue 2;
                     }

--- a/src/Tokenizer/tests/Classes/ClassWithNamedParameter.php
+++ b/src/Tokenizer/tests/Classes/ClassWithNamedParameter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Tokenizer\Classes;
+
+use Spiral\Tests\Tokenizer\Classes\Inner\ClassD;
+
+class ClassWithNamedParameter
+{
+    public function __construct()
+    {
+        $this->foo(class: ClassD::class);
+    }
+
+    private function foo(string $class): void
+    {
+    }
+}

--- a/src/Tokenizer/tests/ReflectionFileTest.php
+++ b/src/Tokenizer/tests/ReflectionFileTest.php
@@ -51,6 +51,15 @@ class ReflectionFileTest extends TestCase
         $this->assertSame('123', $functionB->getArgument(1)->getValue());
     }
 
+    public function testReflectionFileWithNamedParameters(): void
+    {
+        $reflection = new ReflectionFile(__DIR__ . '/Classes/ClassWithNamedParameter.php');
+
+        $this->assertSame([
+            'Spiral\Tests\Tokenizer\Classes\ClassWithNamedParameter',
+        ], $reflection->getClasses());
+    }
+
     private function deadend()
     {
         $a = $b = null;
@@ -62,6 +71,7 @@ class ReflectionFileTest extends TestCase
 function hello()
 {
 }
+
 // phpcs:disable
 trait TestTrait
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌


The Tokenizer component had a bug that caused issues when trying to load a class and parse tokens. Specifically, the bug occurred when a class contained a `class` named parameter, as demonstrated in the example code below.

```php
namespace Spiral\Tests\Tokenizer\Classes;

use Spiral\Tests\Tokenizer\Classes\Inner\ClassD;

class ClassWithNamedParameter
{
    public function __construct()
    {
        $this->foo(class: ClassD::class);
    }

    private function foo(string $class): void
    {
    }
}
```

When the Tokenizer encountered this scenario, it incorrectly counted `ClassD` as part of `ClassWithNamedParameter` in the same namespace `Spiral\Tests\Tokenizer\Classes`.

Thanks to @gam6itko 