### PR TITLE
LoggerReporter error level = critical

### DIFF
--- a/src/Exceptions/src/Reporter/LoggerReporter.php
+++ b/src/Exceptions/src/Reporter/LoggerReporter.php
@@ -17,7 +17,7 @@ class LoggerReporter implements ExceptionReporterInterface
 
     public function report(\Throwable $exception): void
     {
-        $this->logger->error(\sprintf(
+        $this->logger->critical(\sprintf(
             '%s: %s in %s at line %s',
             $exception::class,
             $exception->getMessage(),

--- a/src/Exceptions/tests/Reporter/LoggerReporterTest.php
+++ b/src/Exceptions/tests/Reporter/LoggerReporterTest.php
@@ -22,7 +22,7 @@ final class LoggerReporterTest extends TestCase
         $exception = new \Exception();
 
         $logger = m::mock(LoggerInterface::class);
-        $logger->shouldReceive('error')->withArgs([\sprintf(
+        $logger->shouldReceive('critical')->withArgs([\sprintf(
             '%s: %s in %s at line %s',
             $exception::class,
             $exception->getMessage(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->

Hello. I guess we use ExceptionReporter for emergencies. level `error` serves for more expected errors. 
