### PR TITLE
Scaffolder improvements

### DIFF
--- a/src/Scaffolder/src/Command/AbstractCommand.php
+++ b/src/Scaffolder/src/Command/AbstractCommand.php
@@ -31,7 +31,7 @@ abstract class AbstractCommand extends Command
      * @param class-string<TClass> $class
      * @return TClass
      */
-    protected function createDeclaration(string $class): DeclarationInterface
+    protected function createDeclaration(string $class, array $params = []): DeclarationInterface
     {
         return $this->factory->make(
             $class,
@@ -39,7 +39,7 @@ abstract class AbstractCommand extends Command
                 'name' => (string)$this->argument('name'),
                 'comment' => $this->getComment(),
                 'namespace' => $this->getNamespace(),
-            ] + $this->config->declarationOptions($class::TYPE),
+            ] + $params + $this->config->declarationOptions($class::TYPE),
         );
     }
 

--- a/src/Scaffolder/src/Command/BootloaderCommand.php
+++ b/src/Scaffolder/src/Command/BootloaderCommand.php
@@ -4,43 +4,36 @@ declare(strict_types=1);
 
 namespace Spiral\Scaffolder\Command;
 
+use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\Option;
 use Spiral\Console\Attribute\Question;
 use Spiral\Scaffolder\Declaration\BootloaderDeclaration;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
-#[Question(
-    question: 'What would you like to name the Bootloader?',
-    argument: 'name'
-)]
+#[AsCommand(name: 'create:bootloader', description: 'Create bootloader declaration')]
 class BootloaderCommand extends AbstractCommand
 {
-    protected const NAME        = 'create:bootloader';
-    protected const DESCRIPTION = 'Create bootloader declaration';
-    protected const ARGUMENTS   = [
-        ['name', InputArgument::REQUIRED, 'bootloader name'],
-    ];
-    protected const OPTIONS     = [
-        [
-            'comment',
-            'c',
-            InputOption::VALUE_OPTIONAL,
-            'Optional comment to add as class header',
-        ],
-        [
-            'namespace',
-            null,
-            InputOption::VALUE_OPTIONAL,
-            'Optional, specify a custom namespace',
-        ],
-    ];
+    #[Argument(description: 'Bootloader name')]
+    #[Question(question: 'What would you like to name the Bootloader?')]
+    private string $name;
+
+    #[Option(shortcut: 'c', description: 'Optional comment to add as class header')]
+    private ?string $comment = null;
+
+    #[Option(name: 'domain', shortcut: 'd', description: 'Mark as domain bootloader')]
+    private bool $isDomain = false;
+
+    #[Option(description: 'Optional, specify a custom namespace')]
+    private ?string $namespace = null;
 
     /**
      * Create bootloader declaration.
      */
     public function perform(): int
     {
-        $declaration = $this->createDeclaration(BootloaderDeclaration::class);
+        $declaration = $this->createDeclaration(BootloaderDeclaration::class, [
+            'isDomain' => $this->isDomain,
+        ]);
 
         $this->writeDeclaration($declaration);
 

--- a/src/Scaffolder/src/Declaration/BootloaderDeclaration.php
+++ b/src/Scaffolder/src/Declaration/BootloaderDeclaration.php
@@ -4,25 +4,50 @@ declare(strict_types=1);
 
 namespace Spiral\Scaffolder\Declaration;
 
+use Nette\PhpGenerator\Literal;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\BootloadManager\Methods;
+use Spiral\Bootloader\DomainBootloader;
+use Spiral\Core\CoreInterface;
+use Spiral\Scaffolder\Config\ScaffolderConfig;
 
 class BootloaderDeclaration extends AbstractDeclaration
 {
     public const TYPE = 'bootloader';
+
+    public function __construct(
+        ScaffolderConfig $config,
+        string $name,
+        ?string $comment = null,
+        ?string $namespace = null,
+        private readonly bool $isDomain = false,
+    ) {
+        parent::__construct($config, $name, $comment, $namespace);
+    }
 
     /**
      * Declare constants and boot method.
      */
     public function declare(): void
     {
-        $this->namespace->addUse(Bootloader::class);
+        $extends = $this->isDomain ? DomainBootloader::class : Bootloader::class;
 
-        $this->class->setExtends(Bootloader::class);
+        $this->namespace->addUse($extends);
+        $this->class->setExtends($extends);
+
+        $this->class->setFinal();
 
         $this->class->addConstant('BINDINGS', [])->setProtected();
         $this->class->addConstant('SINGLETONS', [])->setProtected();
         $this->class->addConstant('DEPENDENCIES', [])->setProtected();
+
+        if ($this->isDomain) {
+            $this->class->addConstant('INTERCEPTORS', [])->setProtected();
+            $this->namespace->addUse(CoreInterface::class);
+            $this->class->getConstant('SINGLETONS')->setValue([
+                new Literal('CoreInterface::class => [self::class, \'domainCore\']')
+            ]);
+        }
 
         $this->class->addMethod(Methods::INIT->value)->setReturnType('void');
         $this->class->addMethod(Methods::BOOT->value)->setReturnType('void');

--- a/src/Scaffolder/src/Declaration/BootloaderDeclaration.php
+++ b/src/Scaffolder/src/Declaration/BootloaderDeclaration.php
@@ -45,7 +45,7 @@ class BootloaderDeclaration extends AbstractDeclaration
             $this->class->addConstant('INTERCEPTORS', [])->setProtected();
             $this->namespace->addUse(CoreInterface::class);
             $this->class->getConstant('SINGLETONS')->setValue([
-                new Literal('CoreInterface::class => [self::class, \'domainCore\']')
+                new Literal('CoreInterface::class => [self::class, \'domainCore\']'),
             ]);
         }
 


### PR DESCRIPTION
### Improves create:bootloader command
- Adds final for class
- Adds an ability to create domain bootloader with interceptors using `-d` option
- Uses PHP attributes for command definition

```bash
// Generate domain bootloader
php app.php create:bootloader AppBootloader -d
```