### PR TITLE
Adding the ability to override Scaffolder config partially

### DIFF
--- a/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php
+++ b/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php
@@ -66,47 +66,51 @@ class ScaffolderBootloader extends Bootloader
              */
             'namespace' => $defaultNamespace,
 
+            'declarations' => [],
+
             /*
              * This is set of default settings to be used for your scaffolding commands.
              */
-            'declarations' => [
-                Declaration\BootloaderDeclaration::TYPE => [
-                    'namespace' => 'Bootloader',
-                    'postfix' => 'Bootloader',
-                    'class' => Declaration\BootloaderDeclaration::class,
-                ],
-                Declaration\ConfigDeclaration::TYPE => [
-                    'namespace' => 'Config',
-                    'postfix' => 'Config',
-                    'class' => Declaration\ConfigDeclaration::class,
-                    'options' => [
-                        'directory' => directory('config'),
+            'defaults' => [
+                'declarations' => [
+                    Declaration\BootloaderDeclaration::TYPE => [
+                        'namespace' => 'Bootloader',
+                        'postfix' => 'Bootloader',
+                        'class' => Declaration\BootloaderDeclaration::class,
                     ],
-                ],
-                Declaration\ControllerDeclaration::TYPE => [
-                    'namespace' => 'Controller',
-                    'postfix' => 'Controller',
-                    'class' => Declaration\ControllerDeclaration::class,
-                ],
-                Declaration\FilterDeclaration::TYPE => [
-                    'namespace' => 'Filter',
-                    'postfix' => 'Filter',
-                    'class' => Declaration\FilterDeclaration::class,
-                ],
-                Declaration\MiddlewareDeclaration::TYPE => [
-                    'namespace' => 'Middleware',
-                    'postfix' => '',
-                    'class' => Declaration\MiddlewareDeclaration::class,
-                ],
-                Declaration\CommandDeclaration::TYPE => [
-                    'namespace' => 'Command',
-                    'postfix' => 'Command',
-                    'class' => Declaration\CommandDeclaration::class,
-                ],
-                Declaration\JobHandlerDeclaration::TYPE => [
-                    'namespace' => 'Job',
-                    'postfix' => 'Job',
-                    'class' => Declaration\JobHandlerDeclaration::class,
+                    Declaration\ConfigDeclaration::TYPE => [
+                        'namespace' => 'Config',
+                        'postfix' => 'Config',
+                        'class' => Declaration\ConfigDeclaration::class,
+                        'options' => [
+                            'directory' => directory('config'),
+                        ],
+                    ],
+                    Declaration\ControllerDeclaration::TYPE => [
+                        'namespace' => 'Controller',
+                        'postfix' => 'Controller',
+                        'class' => Declaration\ControllerDeclaration::class,
+                    ],
+                    Declaration\FilterDeclaration::TYPE => [
+                        'namespace' => 'Filter',
+                        'postfix' => 'Filter',
+                        'class' => Declaration\FilterDeclaration::class,
+                    ],
+                    Declaration\MiddlewareDeclaration::TYPE => [
+                        'namespace' => 'Middleware',
+                        'postfix' => '',
+                        'class' => Declaration\MiddlewareDeclaration::class,
+                    ],
+                    Declaration\CommandDeclaration::TYPE => [
+                        'namespace' => 'Command',
+                        'postfix' => 'Command',
+                        'class' => Declaration\CommandDeclaration::class,
+                    ],
+                    Declaration\JobHandlerDeclaration::TYPE => [
+                        'namespace' => 'Job',
+                        'postfix' => 'Job',
+                        'class' => Declaration\JobHandlerDeclaration::class,
+                    ],
                 ],
             ],
         ]);
@@ -114,12 +118,14 @@ class ScaffolderBootloader extends Bootloader
 
     /**
      * Register new Scaffolder declaration.
+     *
+     * @param non-empty-string $name
      */
     public function addDeclaration(string $name, array $declaration): void
     {
         $this->config->modify(
             ScaffolderConfig::CONFIG,
-            new Append('declarations', $name, $declaration),
+            new Append('defaults.declarations', $name, $declaration),
         );
     }
 }

--- a/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
+++ b/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
@@ -6,6 +6,8 @@ namespace Spiral\Tests\Scaffolder\Config;
 
 use Spiral\Scaffolder\Bootloader\ScaffolderBootloader;
 use Spiral\Scaffolder\Config\ScaffolderConfig;
+use Spiral\Scaffolder\Declaration\BootloaderDeclaration;
+use Spiral\Scaffolder\Exception\ScaffolderException;
 use Spiral\Tests\Scaffolder\BaseTest;
 
 class ScaffolderConfigTest extends BaseTest
@@ -42,5 +44,74 @@ class ScaffolderConfigTest extends BaseTest
         $this->assertSame('', $ref->invoke($config, 'null-namespace'));
         $this->assertSame('', $ref->invoke($config, 'empty-namespace'));
         $this->assertSame('Test', $ref->invoke($config, 'overridden-namespace'));
+    }
+
+    public function testUndefinedDeclarationException(): void
+    {
+        /** @var ScaffolderConfig $config */
+        $config = $this->app->get(ScaffolderConfig::class);
+        $ref = new \ReflectionMethod($config, 'getOption');
+
+        $this->expectException(ScaffolderException::class);
+        $this->expectExceptionMessage('Undefined declaration \'undefined\'.');
+        $ref->invoke($config, 'undefined', 'namespace');
+    }
+
+    public function testOverrideDefaultDeclaration(): void
+    {
+        $this->app->getContainer()->bind(ScaffolderConfig::class, new ScaffolderConfig([
+            'declarations' => [
+                BootloaderDeclaration::TYPE => [
+                    'namespace' => 'ChangedNamespace',
+                    'postfix' => 'CustomPostfix',
+                    'class' => 'OtherClass',
+                ],
+            ],
+            'defaults' => [
+                'declarations' => [
+                    BootloaderDeclaration::TYPE => [
+                        'namespace' => 'Bootloader',
+                        'postfix' => 'Bootloader',
+                        'class' => BootloaderDeclaration::class,
+                    ],
+                ],
+            ]
+        ]));
+
+        /** @var ScaffolderConfig $config */
+        $config = $this->app->get(ScaffolderConfig::class);
+        $ref = new \ReflectionMethod($config, 'getOption');
+
+        $this->assertSame('ChangedNamespace', $ref->invoke($config, BootloaderDeclaration::TYPE, 'namespace'));
+        $this->assertSame('CustomPostfix', $ref->invoke($config, BootloaderDeclaration::TYPE, 'postfix'));
+        $this->assertSame('OtherClass', $ref->invoke($config, BootloaderDeclaration::TYPE, 'class'));
+    }
+
+    public function testPartialOverrideDefaultDeclaration(): void
+    {
+        $this->app->getContainer()->bind(ScaffolderConfig::class, new ScaffolderConfig([
+            'declarations' => [
+                BootloaderDeclaration::TYPE => [
+                    'namespace' => 'ChangedNamespace',
+                ],
+            ],
+            'defaults' => [
+                'declarations' => [
+                    BootloaderDeclaration::TYPE => [
+                        'namespace' => 'Bootloader',
+                        'postfix' => 'Bootloader',
+                        'class' => BootloaderDeclaration::class,
+                    ],
+                ],
+            ]
+        ]));
+
+        /** @var ScaffolderConfig $config */
+        $config = $this->app->get(ScaffolderConfig::class);
+        $ref = new \ReflectionMethod($config, 'getOption');
+
+        $this->assertSame('ChangedNamespace', $ref->invoke($config, BootloaderDeclaration::TYPE, 'namespace'));
+        $this->assertSame('Bootloader', $ref->invoke($config, BootloaderDeclaration::TYPE, 'postfix'));
+        $this->assertSame(BootloaderDeclaration::class, $ref->invoke($config, BootloaderDeclaration::TYPE, 'class'));
     }
 }

--- a/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
+++ b/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
@@ -6,10 +6,12 @@ namespace Framework\Bootloader\Scaffolder;
 
 use Cocur\Slugify\Slugify;
 use Cocur\Slugify\SlugifyInterface;
+use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\KernelInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;
 use Spiral\Scaffolder\Bootloader\ScaffolderBootloader;
+use Spiral\Scaffolder\Declaration;
 use Spiral\Scaffolder\Config\ScaffolderConfig;
 use Spiral\Tests\Framework\BaseTest;
 
@@ -23,11 +25,69 @@ final class ScaffolderBootloaderTest extends BaseTest
     public function testAddDeclaration(): void
     {
         $configs = new ConfigManager($this->createMock(LoaderInterface::class));
-        $configs->setDefaults(ScaffolderConfig::CONFIG, ['declarations' => []]);
+        $configs->setDefaults(ScaffolderConfig::CONFIG, ['defaults' => ['declarations' => []]]);
 
         $bootloader = new ScaffolderBootloader($configs, $this->createMock(KernelInterface::class));
         $bootloader->addDeclaration('foo', ['bar' => 'baz']);
 
-        $this->assertSame(['foo' => ['bar' => 'baz']], $configs->getConfig(ScaffolderConfig::CONFIG)['declarations']);
+        $this->assertSame(
+            ['foo' => ['bar' => 'baz']],
+            $configs->getConfig(ScaffolderConfig::CONFIG)['defaults']['declarations']
+        );
+    }
+
+    public function testDefaultConfig(): void
+    {
+        $config = $this->getConfig(ScaffolderConfig::CONFIG);
+        $dirs = $this->getContainer()->get(DirectoriesInterface::class);
+
+        $this->assertSame([
+            'header' => [],
+            'directory' => $dirs->get('app') . 'src/',
+            'namespace' => 'Spiral\\App',
+            'declarations' => [],
+            'defaults' => [
+                'declarations' => [
+                    Declaration\BootloaderDeclaration::TYPE => [
+                        'namespace' => 'Bootloader',
+                        'postfix' => 'Bootloader',
+                        'class' => Declaration\BootloaderDeclaration::class,
+                    ],
+                    Declaration\ConfigDeclaration::TYPE => [
+                        'namespace' => 'Config',
+                        'postfix' => 'Config',
+                        'class' => Declaration\ConfigDeclaration::class,
+                        'options' => [
+                            'directory' => $dirs->get('config'),
+                        ],
+                    ],
+                    Declaration\ControllerDeclaration::TYPE => [
+                        'namespace' => 'Controller',
+                        'postfix' => 'Controller',
+                        'class' => Declaration\ControllerDeclaration::class,
+                    ],
+                    Declaration\FilterDeclaration::TYPE => [
+                        'namespace' => 'Filter',
+                        'postfix' => 'Filter',
+                        'class' => Declaration\FilterDeclaration::class,
+                    ],
+                    Declaration\MiddlewareDeclaration::TYPE => [
+                        'namespace' => 'Middleware',
+                        'postfix' => '',
+                        'class' => Declaration\MiddlewareDeclaration::class,
+                    ],
+                    Declaration\CommandDeclaration::TYPE => [
+                        'namespace' => 'Command',
+                        'postfix' => 'Command',
+                        'class' => Declaration\CommandDeclaration::class,
+                    ],
+                    Declaration\JobHandlerDeclaration::TYPE => [
+                        'namespace' => 'Job',
+                        'postfix' => 'Job',
+                        'class' => Declaration\JobHandlerDeclaration::class,
+                    ],
+                ],
+            ]
+        ], $config);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### Bugfix

The scaffolder config **located in the App** fully overrides the **default declarations** config.

For example, we have the config `app/app/config/scaffolder.php`:

```php
return [
    'namespace' => 'App',

    'declarations' => [
        Declaration\BootloaderDeclaration::TYPE => [
            'namespace' => 'Application\Bootloader',
            'postfix' => 'Bootloader',
            'class' => Declaration\BootloaderDeclaration::class,
        ],
        Declaration\ConfigDeclaration::TYPE => [
            'namespace' => 'Application\Config',
            'postfix' => 'Config',
            'class' => Declaration\ConfigDeclaration::class,
            'options' => [
                'directory' => directory('config'),
            ],
        ],
        Declaration\ControllerDeclaration::TYPE => [
            'namespace' => 'Endpoint\Web',
            'postfix' => 'Controller',
            'class' => Declaration\ControllerDeclaration::class,
        ],
        Declaration\MiddlewareDeclaration::TYPE => [
            'namespace' => 'Application\Http\Middleware',
            'postfix' => '',
            'class' => Declaration\MiddlewareDeclaration::class,
        ],
        Declaration\CommandDeclaration::TYPE => [
            'namespace' => 'Endpoint\Console',
            'postfix' => 'Command',
            'class' => Declaration\CommandDeclaration::class,
        ],
        Declaration\JobHandlerDeclaration::TYPE => [
            'namespace' => 'Endpoint\Job',
            'postfix' => 'Job',
            'class' => Declaration\JobHandlerDeclaration::class,
        ],
    ],
];
```

**This config doesn't contain a declaration for the `filter`.**

Run:

```bash
php app.php create:filter
```

Error occurs:

```bash
[Spiral\Scaffolder\Exception\ScaffolderException]
Undefined declaration 'filter'.
```

After these changes, the configuration for the Filter from the bootloader will be used:
https://github.com/spiral/framework/blob/master/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php#L91

### Feature

Added the ability to override only certain values in the declaration config. If you need to change the namespace, the config can be shortened to this example:

```php
return [
    'namespace' => 'App',

    'declarations' => [
        Declaration\BootloaderDeclaration::TYPE => [
            'namespace' => 'Application\Bootloader',
        ],
        Declaration\ConfigDeclaration::TYPE => [
            'namespace' => 'Application\Config',
        ],
        Declaration\ControllerDeclaration::TYPE => [
            'namespace' => 'Endpoint\Web',
        ],
        Declaration\MiddlewareDeclaration::TYPE => [
            'namespace' => 'Application\Http\Middleware',
        ],
        Declaration\CommandDeclaration::TYPE => [
            'namespace' => 'Endpoint\Console',
        ],
        Declaration\JobHandlerDeclaration::TYPE => [
            'namespace' => 'Endpoint\Job',
        ],
    ],
];
```

