### PR TITLE
Adds the ability to specify a custom directory for specific declaration types in the [spiral/scaffolder] component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 - **Other Features**
-  - [spiral/scaffolder] Added a `directory` option for declarations defaults and declarations in configuration.
+  - [spiral/scaffolder] Added new public method `declarationDirectory` to the `Spiral\Scaffolder\Config\ScaffolderConfig` 
+    class that returns the directory path of the specified declaration, or default directory path if not specified.
+- **Medium Impact Changes**
+  - [spiral/scaffolder] Method `baseDirectory` of `Spiral\Scaffolder\Config\ScaffolderConfig` class is deprecated.
 
 ## 3.7.0 - 2023-04-13
 - **Medium Impact Changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+- **Other Features**
+  - [spiral/scaffolder] Added a `directory` option for declarations defaults and declarations in configuration.
+
 ## 3.7.0 - 2023-04-13
 - **Medium Impact Changes**
   - [spiral/queue] Added the ability to use mixed types as job payload.

--- a/src/Scaffolder/src/Config/ScaffolderConfig.php
+++ b/src/Scaffolder/src/Config/ScaffolderConfig.php
@@ -30,11 +30,20 @@ class ScaffolderConfig extends InjectableConfig
         return $this->config['header'];
     }
 
-    public function baseDirectory(?string $element = null): string
+    /**
+     * @deprecated since v3.8.0.
+     */
+    public function baseDirectory(): string
     {
-        if ($element === null || ($declaration = $this->getDeclaration($element)) === []) {
-            return $this->config['directory'];
-        }
+        return $this->config['directory'];
+    }
+
+    /**
+     * @param non-empty-string $element
+     */
+    public function declarationDirectory(string $element): string
+    {
+        $declaration = $this->getDeclaration($element);
 
         return !empty($declaration['directory']) ? $declaration['directory'] : $this->config['directory'];
     }
@@ -83,7 +92,7 @@ class ScaffolderConfig extends InjectableConfig
         $elementNamespace = \substr($elementNamespace, \strlen($this->baseNamespace($element)));
 
         return $this->joinPathChunks([
-            $this->baseDirectory($element),
+            $this->declarationDirectory($element),
             \str_replace('\\', '/', $elementNamespace),
             $this->className($element, $name) . '.php',
         ], '/');

--- a/src/Scaffolder/src/Config/ScaffolderConfig.php
+++ b/src/Scaffolder/src/Config/ScaffolderConfig.php
@@ -30,9 +30,13 @@ class ScaffolderConfig extends InjectableConfig
         return $this->config['header'];
     }
 
-    public function baseDirectory(): string
+    public function baseDirectory(?string $element = null): string
     {
-        return $this->config['directory'];
+        if ($element === null || ($declaration = $this->getDeclaration($element)) === []) {
+            return $this->config['directory'];
+        }
+
+        return !empty($declaration['directory']) ? $declaration['directory'] : $this->config['directory'];
     }
 
     /**
@@ -79,7 +83,7 @@ class ScaffolderConfig extends InjectableConfig
         $elementNamespace = \substr($elementNamespace, \strlen($this->baseNamespace($element)));
 
         return $this->joinPathChunks([
-            $this->baseDirectory(),
+            $this->baseDirectory($element),
             \str_replace('\\', '/', $elementNamespace),
             $this->className($element, $name) . '.php',
         ], '/');

--- a/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
+++ b/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
@@ -114,4 +114,158 @@ class ScaffolderConfigTest extends BaseTest
         $this->assertSame('Bootloader', $ref->invoke($config, BootloaderDeclaration::TYPE, 'postfix'));
         $this->assertSame(BootloaderDeclaration::class, $ref->invoke($config, BootloaderDeclaration::TYPE, 'class'));
     }
+
+    /**
+     * @dataProvider baseDirectoryDataProvider
+     */
+    public function testBaseDirectory(array $config, string $expected, ?string $element = null): void
+    {
+        $config = new ScaffolderConfig($config);
+
+        $this->assertSame($expected, $config->baseDirectory($element));
+    }
+
+    /**
+     * @dataProvider classFilenameDataProvider
+     */
+    public function testClassFilename(array $config, string $expected, string $namespace): void
+    {
+        $config = new ScaffolderConfig($config);
+
+        $this->assertSame($expected, $config->classFilename('foo', 'Test', $namespace));
+    }
+
+    public static function baseDirectoryDataProvider(): \Traversable
+    {
+        yield [['directory' => 'foo'], 'foo'];
+        yield [['directory' => 'foo'], 'foo', 'some'];
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['some' => []]
+                ]
+            ],
+            'foo',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['some' => ['directory' => null]]
+                ]
+            ],
+            'foo',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['some' => ['directory' => '']]
+                ]
+            ],
+            'foo',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['some' => ['directory' => 'bar']]
+                ]
+            ],
+            'bar',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'declarations' => ['some' => []]
+            ],
+            'foo',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'declarations' => ['some' => ['directory' => null]]
+            ],
+            'foo',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'declarations' => ['some' => ['directory' => '']]
+            ],
+            'foo',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'declarations' => ['some' => ['directory' => 'bar']]
+            ],
+            'bar',
+            'some'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'declarations' => ['some' => ['directory' => 'baz']],
+                'defaults' => [
+                    'declarations' => ['some' => ['directory' => 'bar']]
+                ]
+            ],
+            'baz',
+            'some'
+        ];
+    }
+
+    public static function classFilenameDataProvider(): \Traversable
+    {
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['foo' => ['class' => 'bar']]
+                ]
+            ],
+            'foo/App/Test/Test.php',
+            'App\\Test'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['foo' => ['postfix' => 'Controller']]
+                ]
+            ],
+            'foo/App/Test/TestController.php',
+            'App\\Test'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'defaults' => [
+                    'declarations' => ['foo' => ['postfix' => 'Controller', 'directory' => 'baz']]
+                ]
+            ],
+            'baz/App/Test/TestController.php',
+            'App\\Test'
+        ];
+        yield [
+            [
+                'directory' => 'foo',
+                'declarations' => ['foo' => ['postfix' => 'Controller', 'directory' => 'changed']],
+                'defaults' => [
+                    'declarations' => ['foo' => ['postfix' => 'Controller', 'directory' => 'baz']]
+                ]
+            ],
+            'changed/App/Test/TestController.php',
+            'App\\Test'
+        ];
+    }
 }

--- a/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
+++ b/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
@@ -116,13 +116,13 @@ class ScaffolderConfigTest extends BaseTest
     }
 
     /**
-     * @dataProvider baseDirectoryDataProvider
+     * @dataProvider declarationDirectoryDataProvider
      */
-    public function testBaseDirectory(array $config, string $expected, ?string $element = null): void
+    public function testDeclarationDirectory(array $config, string $expected): void
     {
         $config = new ScaffolderConfig($config);
 
-        $this->assertSame($expected, $config->baseDirectory($element));
+        $this->assertSame($expected, $config->declarationDirectory('some'));
     }
 
     /**
@@ -135,10 +135,9 @@ class ScaffolderConfigTest extends BaseTest
         $this->assertSame($expected, $config->classFilename('foo', 'Test', $namespace));
     }
 
-    public static function baseDirectoryDataProvider(): \Traversable
+    public static function declarationDirectoryDataProvider(): \Traversable
     {
         yield [['directory' => 'foo'], 'foo'];
-        yield [['directory' => 'foo'], 'foo', 'some'];
         yield [
             [
                 'directory' => 'foo',
@@ -146,8 +145,7 @@ class ScaffolderConfigTest extends BaseTest
                     'declarations' => ['some' => []]
                 ]
             ],
-            'foo',
-            'some'
+            'foo'
         ];
         yield [
             [
@@ -156,8 +154,7 @@ class ScaffolderConfigTest extends BaseTest
                     'declarations' => ['some' => ['directory' => null]]
                 ]
             ],
-            'foo',
-            'some'
+            'foo'
         ];
         yield [
             [
@@ -166,8 +163,7 @@ class ScaffolderConfigTest extends BaseTest
                     'declarations' => ['some' => ['directory' => '']]
                 ]
             ],
-            'foo',
-            'some'
+            'foo'
         ];
         yield [
             [
@@ -176,40 +172,35 @@ class ScaffolderConfigTest extends BaseTest
                     'declarations' => ['some' => ['directory' => 'bar']]
                 ]
             ],
-            'bar',
-            'some'
+            'bar'
         ];
         yield [
             [
                 'directory' => 'foo',
                 'declarations' => ['some' => []]
             ],
-            'foo',
-            'some'
+            'foo'
         ];
         yield [
             [
                 'directory' => 'foo',
                 'declarations' => ['some' => ['directory' => null]]
             ],
-            'foo',
-            'some'
+            'foo'
         ];
         yield [
             [
                 'directory' => 'foo',
                 'declarations' => ['some' => ['directory' => '']]
             ],
-            'foo',
-            'some'
+            'foo'
         ];
         yield [
             [
                 'directory' => 'foo',
                 'declarations' => ['some' => ['directory' => 'bar']]
             ],
-            'bar',
-            'some'
+            'bar'
         ];
         yield [
             [
@@ -219,8 +210,7 @@ class ScaffolderConfigTest extends BaseTest
                     'declarations' => ['some' => ['directory' => 'bar']]
                 ]
             ],
-            'baz',
-            'some'
+            'baz'
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

The `spiral/scaffolder` component provides the ability to generate various classes, such as bootloaders, HTTP controllers, console commands, request filters, and Cycle ORM entities. These generated classes are stored in a directory specified in the configuration file. However, there is currently no way to specify a custom directory for specific declaration types.

```php
return [
    'directory' => directory('app') . 'src/',

    'declarations' => [
        Declaration\BootloaderDeclaration::TYPE => [
            'namespace' => 'Application\Bootloader',
            'postfix' => 'Bootloader',
            'class' => Declaration\BootloaderDeclaration::class,
        ],
    ],
];
```

It would be useful to be able to override the base directory for specific declaration types, as it would allow for more flexibility in organizing the generated classes. For example, if a user wanted to keep all of their bootloaders in a separate directory from the other generated classes, they would currently have to move the bootloaders manually after they are generated. This could be a time-consuming and error-prone process.

This PR adds a new configuration option to the declarations array that allows for the specification of a custom directory for a specific declaration type. 

#### Using  `directory` in the `ScaffolderBootloader::addDeclaration` method:

```php
class ScaffolderBootloader extends Bootloader
{
    public const DEPENDENCIES = [
        ConfigurationBootloader::class,
        BaseScaffolderBootloader::class,
    ];

    public function boot(BaseScaffolderBootloader $scaffolder, DatabaseSeederConfig $config): void
    {
        $scaffolder->addDeclaration(Declaration\FactoryDeclaration::TYPE, [
            'namespace' => $config->getFactoriesNamespace(),
            'postfix' => 'Factory',
            'class' => Declaration\FactoryDeclaration::class,
            'baseNamespace' => 'Database',
            'directory' => $config->getFactoriesDirectory()
        ]);

        $scaffolder->addDeclaration(Declaration\SeederDeclaration::TYPE, [
            'namespace' => $config->getSeedersNamespace(),
            'postfix' => 'Seeder',
            'class' => Declaration\SeederDeclaration::class,
            'baseNamespace' => 'Database',
            'directory' => $config->getSeedersDirectory() // <=============
        ]);
    }
```

#### Via configuration file `app/config/scaffolder.php`

```php
return [
    'directory' => directory('app') . 'src/',

    'declarations' => [
        Declaration\BootloaderDeclaration::TYPE => [
            'namespace' => 'Application\Bootloader',
            'postfix' => 'Bootloader',
            'class' => Declaration\BootloaderDeclaration::class,
            'directory' => 'customPath' // <=============
        ],
    ],
];
```

This would allow users to customize the directory structure of their generated classes more easily, and would improve the overall flexibility of the scaffolder component.