### PR TITLE
Fixed InputScope to allow retrieval of non-bag input sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+- **Bug Fixes**
+  - [spiral/filters] Fixed InputScope to allow retrieval of non-bag input sources
+
 ## 3.7.0 - 2023-04-13
 - **Medium Impact Changes**
   - [spiral/queue] Added the ability to use mixed types as job payload.

--- a/src/Framework/Filter/InputScope.php
+++ b/src/Framework/Filter/InputScope.php
@@ -14,7 +14,7 @@ use Spiral\Http\Request\InputManager;
 final class InputScope implements InputInterface
 {
     public function __construct(
-        private InputManager $input
+        private InputManager $input,
     ) {
     }
 
@@ -28,7 +28,7 @@ final class InputScope implements InputInterface
 
     public function getValue(string $source, mixed $name = null): mixed
     {
-        if ($source !== 'input' && !$this->input->hasBag($source)) {
+        if (!$this->input->hasBag($source) && !\method_exists($this->input, $source)) {
             throw new InputException(\sprintf('Undefined input source %s', $source));
         }
 

--- a/tests/Framework/Filter/FilterTestCase.php
+++ b/tests/Framework/Filter/FilterTestCase.php
@@ -14,15 +14,18 @@ use Spiral\Tests\Framework\BaseTest;
 abstract class FilterTestCase extends BaseTest
 {
     /**
-     * @param class-string<FilterInterface> $filter
+     * @template T of FilterInterface
+     * @param class-string<T> $filter
+     * @return T
      */
     public function getFilter(
         string $filter,
         array $post = [],
         array $query = [],
-        array $headers = []
+        array $headers = [],
+        string $method = 'POST'
     ): FilterInterface {
-        $request = new ServerRequest('POST', '/');
+        $request = new ServerRequest($method, '/');
 
         foreach ($headers as $name => $value) {
             $request = $request->withHeader($name, $value);

--- a/tests/Framework/Filter/InputScopeTest.php
+++ b/tests/Framework/Filter/InputScopeTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Filter;
+
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Spiral\Core\Container;
+use Spiral\Filter\InputScope;
+use Spiral\Http\Request\InputManager;
+
+final class InputScopeTest extends TestCase
+{
+    private InputScope $input;
+    private ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = new Container();
+        $request = new ServerRequest(
+            method: 'POST',
+            uri: 'https://site.com/users',
+            headers: [
+                'Authorization' => 'Bearer 123',
+                'X-Requested-With' => 'XMLHttpRequest',
+                'Accept' => 'application/json',
+            ],
+            body: 'name=John+Doe',
+            version: '1.1',
+            serverParams: [
+                'REMOTE_ADDR' => '123.123.123',
+            ]
+        );
+
+        $container->bind(
+            ServerRequestInterface::class,
+            $this->request = $request
+                ->withQueryParams(['foo' => 'bar'])
+                ->withCookieParams(['baz' => 'qux'])
+                ->withParsedBody(['quux' => 'corge'])
+                ->withAttribute('foz', 'baf'),
+        );
+
+        $this->input = new InputScope(new InputManager($container));
+    }
+
+    public function testGetsMethod(): void
+    {
+        $this->assertSame('POST', $this->input->getValue('method'));
+    }
+
+    public function testGetsPath(): void
+    {
+        $this->assertSame('/users', $this->input->getValue('path'));
+    }
+
+    public function testGetsUri(): void
+    {
+        $uri = $this->input->getValue('uri');
+        $this->assertInstanceOf(UriInterface::class, $uri);
+
+        $this->assertSame('https://site.com/users', (string)$uri);
+    }
+
+    public function testGetsRequest(): void
+    {
+        $this->assertSame($this->request, $this->input->getValue('request'));
+    }
+
+    public function testGetsBearerToken(): void
+    {
+        $this->assertSame('123', $this->input->getValue('bearerToken'));
+    }
+
+    public function testIsSecure(): void
+    {
+        $this->assertTrue($this->input->getValue('isSecure'));
+    }
+
+    public function testIsAjax(): void
+    {
+        $this->assertTrue($this->input->getValue('isAjax'));
+    }
+
+    public function testIsXmlHttpRequest(): void
+    {
+        $this->assertTrue($this->input->getValue('isXmlHttpRequest'));
+    }
+
+    public function testIsJsonExpected(): void
+    {
+        $this->assertTrue($this->input->getValue('isJsonExpected', true));
+    }
+
+    public function testGetsRemoteAddress(): void
+    {
+        $this->assertSame('123.123.123', $this->input->getValue('remoteAddress'));
+    }
+
+    /**
+     * @dataProvider InputBagsDataProvider
+     */
+    public function testGetsInputBag(string $source, string $name, mixed $expected): void
+    {
+        $this->assertSame($expected, $this->input->getValue($source, $name));
+    }
+
+    public static function InputBagsDataProvider(): \Traversable
+    {
+        yield 'headers' => ['headers', 'Authorization', 'Bearer 123'];
+        yield 'data' => ['data', 'quux', 'corge'];
+        yield 'query' => ['query', 'foo', 'bar'];
+        yield 'cookies' => ['cookies', 'baz', 'qux'];
+        yield 'server' => ['server', 'REMOTE_ADDR', '123.123.123'];
+        yield 'attributes' => ['attributes', 'foz', 'baf'];
+    }
+}

--- a/tests/Framework/Filter/Model/MethodAttributeTest.php
+++ b/tests/Framework/Filter/Model/MethodAttributeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Filter\Model;
+
+use Spiral\App\Request\TestRequest;
+use Spiral\Tests\Framework\Filter\FilterTestCase;
+
+final class MethodAttributeTest extends FilterTestCase
+{
+    public function testGetMethodValue(): void
+    {
+        $filter = $this->getFilter(TestRequest::class, method: 'GET');
+
+        $this->assertSame('GET', $filter->method);
+    }
+}

--- a/tests/app/src/Request/TestRequest.php
+++ b/tests/app/src/Request/TestRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\App\Request;
 
 use Spiral\Filters\Attribute\Input\Data;
+use Spiral\Filters\Attribute\Input\Method;
 use Spiral\Filters\Model\Filter;
 
 class TestRequest extends Filter
@@ -14,6 +15,9 @@ class TestRequest extends Filter
 
     #[Data(key: 'section.value')]
     public ?string $sectionValue = null;
+
+    #[Method]
+    public string $method;
 
     // TODO: add tests for validation
 //    public const VALIDATES = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #924 


Currently, the `getValue()` method in the `InputScope` class only allows retrieval of input sources that are associated with bags in the `InputManager` class. However, there are also input sources like `uri`, `path`, `method`, and `bearerToken` in `InputManager` that are not associated with bags.

This results in an `InputException` being thrown when trying to retrieve values from these non-bag input sources using `InputScope`. To fix this issue, we can add an additional check in `InputScope::getValue()` to allow retrieval of non-bag input sources.