### PR TITLE
Fixes problem when paginator doesn't calculate `countPages` correctly in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.7.1 - 2023-04-21
 - **Bug Fixes**
   - [spiral/filters] Fixed InputScope to allow retrieval of non-bag input sources
+  - [spiral/pagination] Fixed problem when paginator doesn't calculate `countPages` correctly in constructor
 
 ## 3.7.0 - 2023-04-13
 - **Medium Impact Changes**

--- a/src/Pagination/src/Paginator.php
+++ b/src/Pagination/src/Paginator.php
@@ -11,12 +11,14 @@ final class Paginator implements PaginatorInterface, \Countable
 {
     private int $pageNumber = 1;
     private int $countPages = 1;
+    private int $count;
 
     public function __construct(
         private int $limit = 25,
-        private int $count = 0,
-        private readonly ?string $parameter = null
+        int $count = 0,
+        private readonly ?string $parameter = null,
     ) {
+        $this->setCount($count);
     }
 
     /**
@@ -129,7 +131,7 @@ final class Paginator implements PaginatorInterface, \Countable
     private function setCount(int $count): self
     {
         $this->count = \max($count, 0);
-        $this->countPages = $this->count > 0 ? (int) \ceil($this->count / $this->limit) : 1;
+        $this->countPages = $this->count > 0 ? (int)\ceil($this->count / $this->limit) : 1;
 
         return $this;
     }

--- a/src/Pagination/tests/PaginatorTest.php
+++ b/src/Pagination/tests/PaginatorTest.php
@@ -12,20 +12,20 @@ class PaginatorTest extends TestCase
 {
     public function testInterfaces()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
 
         $this->assertInstanceOf(PaginatorInterface::class, $paginator);
     }
 
     public function testParameterTracking()
     {
-        $paginator = new Paginator(25, 0, 'request:page');
+        $paginator = new Paginator(limit: 25, count: 0, parameter: 'request:page');
         $this->assertSame('request:page', $paginator->getParameter());
     }
 
     public function testLimit()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
 
         $this->assertSame(25, $paginator->getLimit());
         $newPaginator = $paginator->withLimit(50);
@@ -33,9 +33,17 @@ class PaginatorTest extends TestCase
         $this->assertSame(50, $newPaginator->getLimit());
     }
 
+    public function testLimitWithCounts()
+    {
+        $paginator = new Paginator(limit: 25, count: 100);
+
+        $this->assertSame(100, $paginator->count());
+        $this->assertSame(4, $paginator->countPages());
+    }
+
     public function testCountsAndPages()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
 
         $this->assertSame(0, $paginator->count());
         $this->assertSame($paginator->count(), $paginator->count());
@@ -49,7 +57,7 @@ class PaginatorTest extends TestCase
 
     public function testFirstPage()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(100);
 
         $this->assertSame(1, $paginator->getPage());
@@ -66,10 +74,9 @@ class PaginatorTest extends TestCase
         $this->assertSame(25, $paginator->countDisplayed());
     }
 
-
     public function testSecondPage()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(110);
 
         $this->assertSame(110, $paginator->count());
@@ -91,7 +98,7 @@ class PaginatorTest extends TestCase
 
     public function testLastPage()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(100);
 
         $this->assertSame(1, $paginator->getPage());
@@ -116,7 +123,7 @@ class PaginatorTest extends TestCase
 
     public function testNegativePage()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(100);
         $paginator = $paginator->withPage(-1);
 
@@ -129,7 +136,7 @@ class PaginatorTest extends TestCase
 
     public function testNegativeCount()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(-100);
 
         $paginator = $paginator->withPage(-10);
@@ -146,7 +153,7 @@ class PaginatorTest extends TestCase
 
     public function testLastPageNumber()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(110);
 
         $this->assertSame(110, $paginator->count());
@@ -166,7 +173,7 @@ class PaginatorTest extends TestCase
 
     public function testIsRequired()
     {
-        $paginator = new Paginator(25);
+        $paginator = new Paginator(limit: 25);
 
         $paginator = $paginator->withCount(24);
         $this->assertFalse($paginator->isRequired());

--- a/src/Pagination/tests/PaginatorTest.php
+++ b/src/Pagination/tests/PaginatorTest.php
@@ -10,20 +10,20 @@ use Spiral\Pagination\PaginatorInterface;
 
 class PaginatorTest extends TestCase
 {
-    public function testInterfaces()
+    public function testInterfaces(): void
     {
         $paginator = new Paginator(limit: 25);
 
         $this->assertInstanceOf(PaginatorInterface::class, $paginator);
     }
 
-    public function testParameterTracking()
+    public function testParameterTracking(): void
     {
         $paginator = new Paginator(limit: 25, count: 0, parameter: 'request:page');
         $this->assertSame('request:page', $paginator->getParameter());
     }
 
-    public function testLimit()
+    public function testLimit(): void
     {
         $paginator = new Paginator(limit: 25);
 
@@ -33,7 +33,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(50, $newPaginator->getLimit());
     }
 
-    public function testLimitWithCounts()
+    public function testLimitWithCounts(): void
     {
         $paginator = new Paginator(limit: 25, count: 100);
 
@@ -41,7 +41,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(4, $paginator->countPages());
     }
 
-    public function testCountsAndPages()
+    public function testCountsAndPages(): void
     {
         $paginator = new Paginator(limit: 25);
 
@@ -55,7 +55,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(0, $paginator->countDisplayed());
     }
 
-    public function testFirstPage()
+    public function testFirstPage(): void
     {
         $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(100);
@@ -74,7 +74,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(25, $paginator->countDisplayed());
     }
 
-    public function testSecondPage()
+    public function testSecondPage(): void
     {
         $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(110);
@@ -96,7 +96,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(25, $paginator->countDisplayed());
     }
 
-    public function testLastPage()
+    public function testLastPage(): void
     {
         $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(100);
@@ -121,7 +121,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(25, $paginator->countDisplayed());
     }
 
-    public function testNegativePage()
+    public function testNegativePage(): void
     {
         $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(100);
@@ -134,7 +134,7 @@ class PaginatorTest extends TestCase
         $this->assertSame($paginator->count(), count($paginator));
     }
 
-    public function testNegativeCount()
+    public function testNegativeCount(): void
     {
         $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(-100);
@@ -151,7 +151,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(0, $paginator->countDisplayed());
     }
 
-    public function testLastPageNumber()
+    public function testLastPageNumber(): void
     {
         $paginator = new Paginator(limit: 25);
         $paginator = $paginator->withCount(110);
@@ -171,7 +171,7 @@ class PaginatorTest extends TestCase
         $this->assertSame(10, $paginator->countDisplayed());
     }
 
-    public function testIsRequired()
+    public function testIsRequired(): void
     {
         $paginator = new Paginator(limit: 25);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | #900

The current implementation of the `Paginator` class  has an issue in the constructor when we pass the `$count` argument. The problem is with the `$countPages` property which should be calculated based on the `$count` property, but it doesn't. This can cause incorrect pagination calculations. To solve this issue, I have updated the `Paginator` constructor to invoke the `setCount` method with the `$count` argument, ensuring that the `$countPages` property is recalculated correctly.


