### PR TITLE
feat(console): add method to easily ask multiple choice questions

### DIFF
--- a/src/Console/src/Traits/HelpersTrait.php
+++ b/src/Console/src/Traits/HelpersTrait.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -83,6 +84,23 @@ trait HelpersTrait
     protected function ask(string $question, string $default = null): mixed
     {
         return $this->output->ask($question, $default);
+    }
+
+    /**
+     * Asks a multiple choice question.
+     */
+    protected function choiceQuestion(
+        string $question,
+        array $choices,
+        mixed $default = null,
+        int $attempts = null,
+        bool $multiselect = false
+    ): mixed {
+        $question = new ChoiceQuestion($question, $choices, $default);
+
+        $question->setMaxAttempts($attempts)->setMultiselect($multiselect);
+
+        return $this->output->askQuestion($question);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

The current implementation of the `Command` class does not provide a convenient method to ask multiple choice questions. I discovered this while playing around with the framework and thought it will be a good addition to the framework.

If this PR is accepted, I'll also make the accompanying contribution to the documentation.

**Usage examples**

1. Asking a multiple choice question. The `allowMultipleSelections` argument allows users to select multiple options when answering the question. `output` will be an array containing the selected options

```php
protected function perform(InputInterface $input, OutputInterface $output): int
{
    $question = 'Which of the following is a package manager';

    $options = ['composer', 'npm', 'symfony', 'express', 'django'];

    $output = $this->choiceQuestion(
        question: $question,
        choices: $options,
        allowMultipleSelections: true
    );

    return static::SUCCESS;
}
```

2. A default option can be provided using the `default` argument. In the example below, the default option on the prompt will be `symfony`

```php
protected function perform(InputInterface $input, OutputInterface $output): int
{
    $question = 'Which of the following is a package manager';

    $options = ['composer', 'npm', 'symfony', 'express', 'django'];

    $output = $this->choiceQuestion(
        question: $question,
        choices: $options,
        default: 2
    );

   // since allowMultipleSelections is false by default, output will be a string 

    return static::SUCCESS;
}
```

3. The maximum number of attempts can be provided using the `attempts` argument. In the example below, a `Symfony\Component\Console\Exception\InvalidArgumentException` will be thrown if the user makes an invalid selection after 2 tries

```php
protected function perform(InputInterface $input, OutputInterface $output): int
{
    $question = 'Which of the following is a package manager';

    $options = ['composer', 'npm', 'symfony', 'express', 'django'];

    $output = $this->choiceQuestion(
        question: $question,
        choices: $options,
        attempts: 2
    );

    return static::SUCCESS;
}
```
