### PR TITLE
[spiral/router] Fix issue with default parameter values

### DIFF
--- a/src/Core/tests/Internal/Resolver/CommonCasesTest.php
+++ b/src/Core/tests/Internal/Resolver/CommonCasesTest.php
@@ -32,7 +32,7 @@ final class CommonCasesTest extends BaseTestCase
         $this->assertInstanceOf(EngineMarkTwo::class, $result[0]);
     }
 
-    public function testAutowreArgumentByPosition(): void
+    public function testAutowireArgumentByPosition(): void
     {
         $result = $this->resolveClosure(
             static fn(string $foo = 'foo', ?EngineInterface $engine = null) => null,

--- a/src/Hmvc/src/AbstractCore.php
+++ b/src/Hmvc/src/AbstractCore.php
@@ -49,14 +49,7 @@ abstract class AbstractCore implements CoreInterface
         }
 
         try {
-            foreach ($method->getParameters() as $parameter) {
-                if (($parameters[$parameter->getName()] ?? null) === null && $parameter->isDefaultValueAvailable()) {
-                    $parameters[$parameter->getName()] = $parameter->getDefaultValue();
-                }
-            }
-
-            // getting the set of arguments should be sent to requested method
-            $args = $this->resolver->resolveArguments($method, $parameters, validate: true);
+            $args = $this->resolveArguments($method, $parameters);
         } catch (ArgumentResolvingException|InvalidArgumentException $e) {
             throw new ControllerException(
                 \sprintf('Missing/invalid parameter %s of `%s`->`%s`', $e->getParameter(), $controller, $action),
@@ -76,5 +69,22 @@ abstract class AbstractCore implements CoreInterface
             $container,
             static fn () => $method->invokeArgs($container->get($controller), $args)
         );
+    }
+
+    protected function resolveArguments(\ReflectionMethod $method, array $parameters): array
+    {
+        foreach ($method->getParameters() as $parameter) {
+            $name = $parameter->getName();
+            if (
+                \array_key_exists($name, $parameters) &&
+                $parameters[$name] === null &&
+                $parameter->isDefaultValueAvailable()
+            ) {
+                $parameters[$name] = $parameter->getDefaultValue();
+            }
+        }
+
+        // getting the set of arguments should be sent to requested method
+        return $this->resolver->resolveArguments($method, $parameters, validate: true);
     }
 }

--- a/src/Hmvc/src/AbstractCore.php
+++ b/src/Hmvc/src/AbstractCore.php
@@ -49,6 +49,12 @@ abstract class AbstractCore implements CoreInterface
         }
 
         try {
+            foreach ($method->getParameters() as $parameter) {
+                if (($parameters[$parameter->getName()] ?? null) === null && $parameter->isDefaultValueAvailable()) {
+                    $parameters[$parameter->getName()] = $parameter->getDefaultValue();
+                }
+            }
+
             // getting the set of arguments should be sent to requested method
             $args = $this->resolver->resolveArguments($method, $parameters, validate: true);
         } catch (ArgumentResolvingException|InvalidArgumentException $e) {

--- a/src/Router/tests/ControllerTest.php
+++ b/src/Router/tests/ControllerTest.php
@@ -7,6 +7,7 @@ namespace Spiral\Tests\Router;
 use Spiral\Http\Exception\ClientException\NotFoundException;
 use Spiral\Router\Exception\UndefinedRouteException;
 use Spiral\Router\Route;
+use Spiral\Router\Target\Action;
 use Spiral\Router\Target\Controller;
 use Spiral\Tests\Router\Fixtures\TestController;
 use Nyholm\Psr7\ServerRequest;
@@ -46,6 +47,40 @@ class ControllerTest extends BaseTestCase
         $response = $router->handle(new ServerRequest('GET', new Uri('/id/888')));
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('888', (string)$response->getBody());
+    }
+
+    public function testOptionalParam(): void
+    {
+        $router = $this->makeRouter();
+        $router->setRoute(
+            'action',
+            new Route('/default[/<id>]', new Action(TestController::class, 'default'))
+        );
+
+        $response = $router->handle(new ServerRequest('GET', new Uri('/default')));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('default', (string)$response->getBody());
+
+        $response = $router->handle(new ServerRequest('GET', new Uri('/default/123')));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('123', (string)$response->getBody());
+    }
+
+    public function testOptionalParamWithDefaultInt(): void
+    {
+        $router = $this->makeRouter();
+        $router->setRoute(
+            'action',
+            new Route('/defaultInt[/<id>]', new Action(TestController::class, 'defaultInt'))
+        );
+
+        $response = $router->handle(new ServerRequest('GET', new Uri('/defaultInt')));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('int: 1', (string)$response->getBody());
+
+        $response = $router->handle(new ServerRequest('GET', new Uri('/defaultInt/123')));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('string: 123', (string)$response->getBody());
     }
 
     public function testUriGeneration(): void

--- a/src/Router/tests/Fixtures/TestController.php
+++ b/src/Router/tests/Fixtures/TestController.php
@@ -9,19 +9,31 @@ use Nyholm\Psr7\Response;
 
 class TestController
 {
-    public function index()
+    public function index(): string
     {
         return 'hello world';
     }
 
-    public function test()
+    public function test(): string
     {
         return 'hello world';
     }
 
-    public function id(string $id)
+    public function id(string $id): string
     {
         return $id;
+    }
+
+    public function default(string $id = 'default'): string
+    {
+        return $id;
+    }
+
+    public function defaultInt(string|int $id = 1): string
+    {
+        $result = \is_int($id) ? 'int: ' : 'string: ';
+
+        return $result . $id;
     }
 
     public function echo(): void
@@ -35,7 +47,7 @@ class TestController
         throw new \Error('error.controller');
     }
 
-    public function rsp()
+    public function rsp(): Response
     {
         $r = new Response();
         $r->getBody()->write('rsp');
@@ -45,7 +57,7 @@ class TestController
         return $r;
     }
 
-    public function json()
+    public function json(): array
     {
         return [
             'status' => 301,
@@ -68,12 +80,12 @@ class TestController
         throw new ControllerException('', 99);
     }
 
-    public function postTarget()
+    public function postTarget(): string
     {
         return 'POST';
     }
 
-    public function deleteTarget()
+    public function deleteTarget(): string
     {
         return 'DELETE';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

This PR resolves an issue with the `spiral/router` component, where a controller action with an optional parameter that has a default value would result in an error when the optional parameter is not included in the route. 

```php
#[Route('/news/category[/<name>]')]
public function byCategory(string $name = 'root'): mixed
{
    // ...
}
```

Specifically, when `null` values were passed from the router to the resolver, an `InvalidArgumentException` would be thrown if the optional parameter was not nullable but had a default value.

```
Spiral\Core\Exception\Resolver\InvalidArgumentException: Invalid argument value type for the `id` parameter when validating arguments for `NewsController::byCategory`.
```

When the optional parameter is not present in the route, the `AbstractCore` class passes `null` to the resolver, as shown in this line of code: https://github.com/spiral/framework/blob/master/src/Hmvc/src/AbstractCore.php#L53. 

This `null` value would cause an error if the corresponding controller action parameter was not nullable but had a default value defined.

To address this issue, we added a new functionality to the `AbstractCore` class to detect optional parameters with default values that are not nullable, and to replace `null` values passed from the router with the default value provided in the controller action's parameter definition.