### PR TITLE
Add exceptions proxying in Fibers during Scoped run

### DIFF
--- a/src/Core/src/ContainerScope.php
+++ b/src/Core/src/ContainerScope.php
@@ -44,7 +44,13 @@ final class ContainerScope
             $value = $fiber->start();
             while (!$fiber->isTerminated()) {
                 self::$container = $previous;
-                $resume = Fiber::suspend($value);
+                try {
+                    $resume = Fiber::suspend($value);
+                } catch (Throwable $e) {
+                    self::$container = $container;
+                    $value = $fiber->throw($e);
+                    continue;
+                }
                 self::$container = $container;
                 $value = $fiber->resume($resume);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

Container Scope now will proxy exceptions through Fibers