### PR TITLE
[spiral/core] Refactoring and Optimization of Spiral/Core Component - Improved Performance and Enhanced Container Functionality

### DIFF
--- a/src/Core/src/Attribute/Finalize.php
+++ b/src/Core/src/Attribute/Finalize.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Attribute;
 
+use Spiral\Core\Internal\Factory\Ctx;
+
 /**
  * Define a finalize method for the class.
  *
  * @internal We are testing this feature, it may be changed in the future.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class Finalize
+final class Finalize implements Plugin
 {
     public function __construct(
         public string $method,

--- a/src/Core/src/Attribute/Plugin.php
+++ b/src/Core/src/Attribute/Plugin.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Attribute;
+
+interface Plugin
+{
+}

--- a/src/Core/src/Attribute/Plugin.php
+++ b/src/Core/src/Attribute/Plugin.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Attribute;
 
+/**
+ * @internal
+ */
 interface Plugin
 {
 }

--- a/src/Core/src/Attribute/Scope.php
+++ b/src/Core/src/Attribute/Scope.php
@@ -10,7 +10,7 @@ namespace Spiral\Core\Attribute;
  * @internal We are testing this feature, it may be changed in the future.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class Scope
+final class Scope implements Plugin
 {
     public function __construct(
         public string $name,

--- a/src/Core/src/Attribute/Singleton.php
+++ b/src/Core/src/Attribute/Singleton.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Attribute;
 
+use Spiral\Core\Internal\Factory\Ctx;
+
 /**
  * Mark class as singleton.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class Singleton
+final class Singleton implements Plugin
 {
 }

--- a/src/Core/src/Config/Alias.php
+++ b/src/Core/src/Config/Alias.php
@@ -14,4 +14,9 @@ final class Alias extends Binding
         public readonly bool $singleton = false,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return sprintf('Alias to `%s`', $this->alias);
+    }
 }

--- a/src/Core/src/Config/Alias.php
+++ b/src/Core/src/Config/Alias.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * Links to another binding.
+ */
+final class Alias extends Binding
+{
+    public function __construct(
+        public readonly string $alias,
+        public readonly bool $singleton = false,
+    ) {
+    }
+}

--- a/src/Core/src/Config/Autowire.php
+++ b/src/Core/src/Config/Autowire.php
@@ -16,4 +16,9 @@ final class Autowire extends Binding
         public readonly bool $singleton = false,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return 'Autowire object';
+    }
 }

--- a/src/Core/src/Config/Autowire.php
+++ b/src/Core/src/Config/Autowire.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+use Spiral\Core\Container\Autowire as AutowireAlias;
+
+/**
+ * Wraps {@see AutowireAlias}.
+ */
+final class Autowire extends Binding
+{
+    public function __construct(
+        public readonly AutowireAlias $autowire,
+        public readonly bool $singleton = false,
+    ) { }
+}

--- a/src/Core/src/Config/Autowire.php
+++ b/src/Core/src/Config/Autowire.php
@@ -14,5 +14,6 @@ final class Autowire extends Binding
     public function __construct(
         public readonly AutowireAlias $autowire,
         public readonly bool $singleton = false,
-    ) { }
+    ) {
+    }
 }

--- a/src/Core/src/Config/Binding.php
+++ b/src/Core/src/Config/Binding.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * @internal
+ */
+abstract class Binding
+{
+}

--- a/src/Core/src/Config/Binding.php
+++ b/src/Core/src/Config/Binding.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Config;
 
+use Stringable;
+
 /**
  * @internal
  */
-abstract class Binding
+abstract class Binding implements Stringable
 {
 }

--- a/src/Core/src/Config/DeferredFactory.php
+++ b/src/Core/src/Config/DeferredFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * Factory that can be resolved later.
+ */
+final class DeferredFactory extends Binding
+{
+    /**
+     * @param array{0: object|non-empty-string, 1: non-empty-string, ...} $factory
+     */
+    public function __construct(
+        public readonly array $factory,
+        public readonly bool $singleton = false,
+    ) {
+    }
+}

--- a/src/Core/src/Config/DeferredFactory.php
+++ b/src/Core/src/Config/DeferredFactory.php
@@ -17,4 +17,13 @@ final class DeferredFactory extends Binding
         public readonly bool $singleton = false,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            "Deferred factory '%s'->%s()",
+            \is_string($this->factory[0]) ? $this->factory[0] : \get_debug_type($this->factory[0]),
+            $this->factory[1],
+        );
+    }
 }

--- a/src/Core/src/Config/Factory.php
+++ b/src/Core/src/Config/Factory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * Make a value using a closure.
+ */
+final class Factory extends Binding
+{
+    private int $parametersCount;
+
+    public function __construct(
+        public readonly \Closure $factory,
+        public readonly bool $singleton = false,
+    ) {
+        $this->parametersCount = (new \ReflectionFunction($factory))->getNumberOfParameters();
+    }
+
+    /**
+     * @return bool Returns {@see false} if the {@see self::$factory} doesn't require arguments.
+     */
+    public function hasParameters(): bool
+    {
+        return $this->parametersCount > 0;
+    }
+}

--- a/src/Core/src/Config/Factory.php
+++ b/src/Core/src/Config/Factory.php
@@ -18,11 +18,8 @@ final class Factory extends Binding
         $this->parametersCount = (new \ReflectionFunction($factory))->getNumberOfParameters();
     }
 
-    /**
-     * @return bool Returns {@see false} if the {@see self::$factory} doesn't require arguments.
-     */
-    public function hasParameters(): bool
+    public function getParametersCount(): int
     {
-        return $this->parametersCount > 0;
+        return $this->parametersCount;
     }
 }

--- a/src/Core/src/Config/Factory.php
+++ b/src/Core/src/Config/Factory.php
@@ -21,12 +21,13 @@ final class Factory extends Binding
     ) {
         $this->factory = $callable(...);
         $this->parametersCount = (new \ReflectionFunction($this->factory))->getNumberOfParameters();
+        /** @psalm-suppress TypeDoesNotContainType */
         $this->definition = match (true) {
             \is_string($callable) => $callable,
             \is_array($callable) => \sprintf(
                 '%s::%s()',
                 \is_object($callable[0]) ? $callable[0]::class : $callable[0],
-                $callable[1]
+                $callable[1],
             ),
             \is_object($callable) && $callable::class !== \Closure::class => 'object ' . $callable::class,
             default => null,

--- a/src/Core/src/Config/Inflector.php
+++ b/src/Core/src/Config/Inflector.php
@@ -22,6 +22,11 @@ final class Inflector extends Binding
         $this->parametersCount = (new \ReflectionFunction($inflector))->getNumberOfParameters();
     }
 
+    public function __toString(): string
+    {
+        return 'Inflector';
+    }
+
     public function getParametersCount(): int
     {
         return $this->parametersCount;

--- a/src/Core/src/Config/Inflector.php
+++ b/src/Core/src/Config/Inflector.php
@@ -10,6 +10,8 @@ namespace Spiral\Core\Config;
  */
 final class Inflector extends Binding
 {
+    private int $parametersCount;
+
     /**
      * @param \Closure $inflector The first closure argument is the object to be manipulated.
      *        Closure can return the new or the same object.
@@ -17,5 +19,11 @@ final class Inflector extends Binding
     public function __construct(
         public readonly \Closure $inflector,
     ) {
+        $this->parametersCount = (new \ReflectionFunction($inflector))->getNumberOfParameters();
+    }
+
+    public function getParametersCount(): int
+    {
+        return $this->parametersCount;
     }
 }

--- a/src/Core/src/Config/Inflector.php
+++ b/src/Core/src/Config/Inflector.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * Inflector allow to define the manipulation of an object of a specific type as the final step before
+ * it is returned by the container.
+ */
+final class Inflector extends Binding
+{
+    /**
+     * @param \Closure $inflector The first closure argument is the object to be manipulated.
+     *        Closure can return the new or the same object.
+     */
+    public function __construct(
+        public readonly \Closure $inflector,
+    ) {
+    }
+}

--- a/src/Core/src/Config/Injectable.php
+++ b/src/Core/src/Config/Injectable.php
@@ -20,4 +20,9 @@ final class Injectable extends Binding
         public readonly string|InjectorInterface $injector,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return sprintf('Injectable with %s', \is_string($this->injector) ? $this->injector : $this->injector::class);
+    }
 }

--- a/src/Core/src/Config/Injectable.php
+++ b/src/Core/src/Config/Injectable.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+use Spiral\Core\Container\InjectorInterface;
+
+/**
+ * Means that the value should be injected by an injector.
+ *
+ * @see InjectorInterface
+ */
+final class Injectable extends Binding
+{
+    /**
+     * @param string|InjectorInterface $injector Injector object or binding alias.
+     */
+    public function __construct(
+        public readonly string|InjectorInterface $injector,
+    ) {
+    }
+}

--- a/src/Core/src/Config/Scalar.php
+++ b/src/Core/src/Config/Scalar.php
@@ -10,4 +10,9 @@ final class Scalar extends Binding
         public readonly bool|int|string|float $value,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return sprintf('Scalar value (%s) %s', \gettype($this->value), \var_export($this->value, true));
+    }
 }

--- a/src/Core/src/Config/Scalar.php
+++ b/src/Core/src/Config/Scalar.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+final class Scalar extends Binding
+{
+    public function __construct(
+        public readonly bool|int|string|float $value,
+    ) {
+    }
+}

--- a/src/Core/src/Config/Shared.php
+++ b/src/Core/src/Config/Shared.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * Static permanent object
+ */
+final class Shared extends Binding
+{
+    public function __construct(
+        public readonly object $value,
+    ) {
+    }
+}

--- a/src/Core/src/Config/Shared.php
+++ b/src/Core/src/Config/Shared.php
@@ -13,4 +13,9 @@ final class Shared extends Binding
         public readonly object $value,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return 'Shared object of class ' . $this->value::class;
+    }
 }

--- a/src/Core/src/Config/WeakReference.php
+++ b/src/Core/src/Config/WeakReference.php
@@ -13,4 +13,9 @@ final class WeakReference extends Binding
         public \WeakReference $reference,
     ) {
     }
+
+    public function __toString(): string
+    {
+        return 'Weak reference';
+    }
 }

--- a/src/Core/src/Config/WeakReference.php
+++ b/src/Core/src/Config/WeakReference.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+/**
+ * A value will be returned as weak reference. It will be recreated automatically if the value is destroyed.
+ */
+final class WeakReference extends Binding
+{
+    public function __construct(
+        public \WeakReference $reference,
+    ) {
+    }
+}

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -6,6 +6,8 @@ namespace Spiral\Core;
 
 use Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract as ContextFunction;
+use Spiral\Core\Config\Alias;
+use Spiral\Core\Config\WeakReference;
 use Spiral\Core\Container\Autowire;
 use Spiral\Core\Container\InjectableInterface;
 use Spiral\Core\Container\SingletonInterface;
@@ -67,15 +69,16 @@ final class Container implements
         \assert(isset($this->state));
 
         // Bind himself
+        $shared = new Alias(self::class);
         $this->state->bindings = \array_merge($this->state->bindings, [
-            self::class => \WeakReference::create($this),
-            ContainerInterface::class => self::class,
-            BinderInterface::class => self::class,
-            FactoryInterface::class => self::class,
-            ContainerScopeInterface::class => self::class,
-            ScopeInterface::class => self::class,
-            ResolverInterface::class => self::class,
-            InvokerInterface::class => self::class,
+            self::class => new WeakReference(\WeakReference::create($this)),
+            ContainerInterface::class => $shared,
+            BinderInterface::class => $shared,
+            FactoryInterface::class => $shared,
+            ContainerScopeInterface::class => $shared,
+            ScopeInterface::class => $shared,
+            ResolverInterface::class => $shared,
+            InvokerInterface::class => $shared,
         ]);
     }
 
@@ -243,7 +246,7 @@ final class Container implements
      * for each method call), function array or Closure (executed every call). Only object resolvers
      * supported by this method.
      */
-    public function bind(string $alias, string|array|callable|object $resolver): void
+    public function bind(string $alias, mixed $resolver): void
     {
         $this->binder->bind($alias, $resolver);
     }

--- a/src/Core/src/Container/InjectorInterface.php
+++ b/src/Core/src/Container/InjectorInterface.php
@@ -7,9 +7,8 @@ namespace Spiral\Core\Container;
 use Spiral\Core\Exception\Container\ContainerException;
 
 /**
- * Magic spiral interface used to resolve dependencies based on their context . Container may
- * execute such method if INJECTOR constant found in requested class. Potentially changed to
- * lazy binding in spiral container (deprecated).
+ * Magic spiral interface used to resolve dependencies based on their context. Container may
+ * execute such method if INJECTOR constant found in requested class.
  *
  * @template TClass of object
  */
@@ -31,5 +30,5 @@ interface InjectorInterface
      *
      * @throws ContainerException
      */
-    public function createInjection(\ReflectionClass $class, string $context = null): object;
+    public function createInjection(\ReflectionClass $class, ?string $context = null): object;
 }

--- a/src/Core/src/ContainerScopeInterface.php
+++ b/src/Core/src/ContainerScopeInterface.php
@@ -13,7 +13,7 @@ use Psr\Container\ContainerInterface;
  *
  * @internal We are testing this feature, it may be changed in the future.
  */
-interface ContainerScopeInterface
+interface ContainerScopeInterface extends ContainerInterface
 {
     /**
      * Make a Binder proxy to configure bindings for a specific scope.

--- a/src/Core/src/Exception/Traits/ClosureRendererTrait.php
+++ b/src/Core/src/Exception/Traits/ClosureRendererTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Traits;
 
-use ReflectionFunction;
 use ReflectionNamedType;
 use ReflectionUnionType;
 

--- a/src/Core/src/Internal/Binder.php
+++ b/src/Core/src/Internal/Binder.php
@@ -31,6 +31,7 @@ final class Binder extends StateBinder
         if (!$this->container->has($alias)) {
             return false;
         }
+
         return parent::hasInstance($alias);
     }
 

--- a/src/Core/src/Internal/Config/StateBinder.php
+++ b/src/Core/src/Internal/Config/StateBinder.php
@@ -47,7 +47,7 @@ class StateBinder implements BinderInterface
         try {
             $config = $this->makeConfig($resolver, false);
         } catch (\Throwable $e) {
-            throw $this->invalidBindingException($alias, $resolver, $e);
+            throw $this->invalidBindingException($alias, $e);
         }
 
         $this->state->bindings[$alias] = $config;
@@ -61,7 +61,7 @@ class StateBinder implements BinderInterface
         try {
             $config = $this->makeConfig($resolver, true);
         } catch (\Throwable $e) {
-            throw $this->invalidBindingException($alias, $resolver, $e);
+            throw $this->invalidBindingException($alias, $e);
         }
 
         $this->state->bindings[$alias] = $config;
@@ -175,7 +175,7 @@ class StateBinder implements BinderInterface
         return new DeferredFactory($resolver, $singleton);
     }
 
-    private function invalidBindingException(string $alias, mixed $resolver, Throwable $previous): Throwable
+    private function invalidBindingException(string $alias, Throwable $previous): Throwable
     {
         return new ConfiguratorException(\sprintf(
             'Invalid binding for `%s`. %s',

--- a/src/Core/src/Internal/Config/StateBinder.php
+++ b/src/Core/src/Internal/Config/StateBinder.php
@@ -4,11 +4,23 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Internal\Config;
 
+use Exception;
+use InvalidArgumentException;
 use Spiral\Core\BinderInterface;
+use Spiral\Core\Config\Alias;
+use Spiral\Core\Config\Binding;
+use Spiral\Core\Config\Factory;
+use Spiral\Core\Config\Injectable;
+use Spiral\Core\Config\Scalar;
+use Spiral\Core\Config\Shared;
+use Spiral\Core\Config\DeferredFactory;
 use Spiral\Core\Container\Autowire;
 use Spiral\Core\Container\InjectableInterface;
+use Spiral\Core\Exception\ConfiguratorException;
 use Spiral\Core\Exception\Container\ContainerException;
 use Spiral\Core\Internal\State;
+use Throwable;
+use WeakReference;
 
 /**
  * @psalm-import-type TResolver from BinderInterface
@@ -24,40 +36,44 @@ class StateBinder implements BinderInterface
     /**
      * @param TResolver|object $resolver
      */
-    public function bind(string $alias, string|array|callable|object $resolver): void
+    public function bind(string $alias, mixed $resolver): void
     {
-        if (\is_array($resolver) || $resolver instanceof \Closure || $resolver instanceof Autowire) {
-            // array means = execute me, false = not singleton
-            $this->state->bindings[$alias] = [$resolver, false];
-
-            return;
+        try {
+            $config = $this->makeConfig($resolver, false);
+        } catch (\Throwable $e) {
+            throw $this->invalidBindingException($alias, $resolver, $e);
         }
 
-        $this->state->bindings[$alias] = $resolver;
+        $this->state->bindings[$alias] = $config;
     }
 
     /**
      * @param TResolver|object $resolver
      */
-    public function bindSingleton(string $alias, string|array|callable|object $resolver): void
+    public function bindSingleton(string $alias, mixed $resolver): void
     {
-        if (\is_object($resolver) && !$resolver instanceof \Closure && !$resolver instanceof Autowire) {
-            // direct binding to an instance
-            $this->state->bindings[$alias] = $resolver;
-
-            return;
+        try {
+            $config = $this->makeConfig($resolver, true);
+        } catch (\Throwable $e) {
+            throw $this->invalidBindingException($alias, $resolver, $e);
         }
 
-        $this->state->bindings[$alias] = [$resolver, true];
+        $this->state->bindings[$alias] = $config;
     }
 
     public function hasInstance(string $alias): bool
     {
         $bindings = &$this->state->bindings;
 
-        while (\is_string($bindings[$alias] ?? null)) {
+        $flags = [];
+        while ($binding = $bindings[$alias] ?? null and $binding::class === Alias::class) {
             //Checking alias tree
-            $alias = $bindings[$alias];
+            if ($flags[$binding->alias] ?? false) {
+                return $binding->alias === $alias ?: throw new Exception('Circular alias detected');
+            }
+
+            $flags[$binding->alias] = true;
+            $alias = $binding->alias;
         }
 
         return isset($bindings[$alias]) && \is_object($bindings[$alias]);
@@ -70,12 +86,17 @@ class StateBinder implements BinderInterface
 
     public function bindInjector(string $class, string $injector): void
     {
+        $this->state->bindings[$class] = new Injectable($injector);
         $this->state->injectors[$class] = $injector;
     }
 
     public function removeInjector(string $class): void
     {
         unset($this->state->injectors[$class]);
+        if (!isset($this->state->bindings[$class]) || $this->state->bindings[$class]::class !== Injectable::class) {
+            return;
+        }
+        unset($this->state->bindings[$class]);
     }
 
     public function hasInjector(string $class): bool
@@ -87,14 +108,15 @@ class StateBinder implements BinderInterface
         }
 
         if (\array_key_exists($class, $this->state->injectors)) {
-            return $this->state->injectors[$class] !== null;
+            return true;
         }
 
         if (
             $reflection->implementsInterface(InjectableInterface::class)
             && $reflection->hasConstant('INJECTOR')
         ) {
-            $this->state->injectors[$class] = $reflection->getConstant('INJECTOR');
+            $const = $reflection->getConstant('INJECTOR');
+            $this->bindInjector($class, $const);
 
             return true;
         }
@@ -102,24 +124,57 @@ class StateBinder implements BinderInterface
         // check interfaces
         foreach ($this->state->injectors as $target => $injector) {
             if (
-                \class_exists($target, true)
-                && $reflection->isSubclassOf($target)
+                (\class_exists($target, true) && $reflection->isSubclassOf($target))
+                ||
+                (\interface_exists($target, true) && $reflection->implementsInterface($target))
             ) {
-                $this->state->injectors[$class] = $injector;
-
-                return true;
-            }
-
-            if (
-                \interface_exists($target, true)
-                && $reflection->implementsInterface($target)
-            ) {
-                $this->state->injectors[$class] = $injector;
+                $this->state->bindings[$class] = new Injectable($injector);
 
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function makeConfig(mixed $resolver, bool $singleton): Binding
+    {
+        return match (true) {
+            $resolver instanceof Binding => $resolver,
+            $resolver instanceof \Closure => new Factory($resolver, $singleton),
+            $resolver instanceof Autowire => new \Spiral\Core\Config\Autowire($resolver, $singleton),
+            $resolver instanceof WeakReference => new \Spiral\Core\Config\WeakReference($resolver),
+            \is_string($resolver) => new Alias($resolver, $singleton),
+            \is_scalar($resolver) => new Scalar($resolver),
+            \is_object($resolver) => new Shared($resolver),
+            \is_array($resolver) => $this->makeConfigFromArray($resolver, $singleton),
+            default => throw new InvalidArgumentException('Unknown resolver type.'),
+        };
+    }
+
+    private function makeConfigFromArray(array $resolver, bool $singleton): Binding
+    {
+        if (\is_callable($resolver)) {
+            return new Factory($resolver(...), $singleton);
+        }
+
+        // Validate lazy invokable array
+        if (!isset($resolver[0]) || !isset($resolver[1]) || !\is_string($resolver[1]) || $resolver[1] === '') {
+            throw new InvalidArgumentException('Incompatible array declaration for resolver.');
+        }
+        if ((!\is_string($resolver[0]) && !\is_object($resolver[0])) || $resolver[0] === '') {
+            throw new InvalidArgumentException('Incompatible array declaration for resolver.');
+        }
+
+        return new DeferredFactory($resolver, $singleton);
+    }
+
+    private function invalidBindingException(string $alias, mixed $resolver, Throwable $previous): Throwable
+    {
+        return new ConfiguratorException(\sprintf(
+            'Invalid binding for `%s`. %s',
+            $alias,
+            $previous->getMessage(),
+        ), previous: $previous);
     }
 }

--- a/src/Core/src/Internal/Config/StateBinder.php
+++ b/src/Core/src/Internal/Config/StateBinder.php
@@ -161,7 +161,7 @@ class StateBinder implements BinderInterface
     private function makeConfigFromArray(array $resolver, bool $singleton): Binding
     {
         if (\is_callable($resolver)) {
-            return new Factory($resolver(...), $singleton);
+            return new Factory($resolver, $singleton);
         }
 
         // Validate lazy invokable array

--- a/src/Core/src/Internal/Config/StateBinder.php
+++ b/src/Core/src/Internal/Config/StateBinder.php
@@ -10,6 +10,7 @@ use Spiral\Core\BinderInterface;
 use Spiral\Core\Config\Alias;
 use Spiral\Core\Config\Binding;
 use Spiral\Core\Config\Factory;
+use Spiral\Core\Config\Inflector;
 use Spiral\Core\Config\Injectable;
 use Spiral\Core\Config\Scalar;
 use Spiral\Core\Config\Shared;
@@ -38,6 +39,11 @@ class StateBinder implements BinderInterface
      */
     public function bind(string $alias, mixed $resolver): void
     {
+        if ($resolver instanceof Inflector && (\interface_exists($alias) || \class_exists($alias))) {
+            $this->state->inflectors[$alias][] = $resolver;
+            return;
+        }
+
         try {
             $config = $this->makeConfig($resolver, false);
         } catch (\Throwable $e) {

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -10,6 +10,8 @@ use Spiral\Core\Attribute\Finalize;
 use Spiral\Core\Attribute\Scope as ScopeAttribute;
 use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
+use Spiral\Core\Config\Injectable;
+use Spiral\Core\Config\DeferredFactory;
 use Spiral\Core\Container\Autowire;
 use Spiral\Core\Container\InjectorInterface;
 use Spiral\Core\Container\SingletonInterface;
@@ -64,12 +66,16 @@ final class Factory implements FactoryInterface
      */
     public function make(string $alias, array $parameters = [], string $context = null): mixed
     {
-        if (!isset($this->state->bindings[$alias])) {
+        if ($parameters === [] && \array_key_exists($alias, $this->state->singletons)) {
+            return $this->state->singletons[$alias];
+        }
+
+        $binding = $this->state->bindings[$alias] ?? null;
+
+        if ($binding === null) {
             return $this->resolveWithoutBinding($alias, $parameters, $context);
         }
 
-        $avoidCache = $parameters !== [];
-        $binding = $this->state->bindings[$alias];
         try {
             $this->tracer->push(
                 false,
@@ -81,66 +87,171 @@ final class Factory implements FactoryInterface
             );
             $this->tracer->push(true);
 
-            if (\is_object($binding)) {
-                if ($binding::class === WeakReference::class) {
-                    return $this->resolveWeakReference($binding, $alias, $context, $parameters);
-                }
-
-                // When binding is instance, assuming singleton
-                return $avoidCache
-                    ? $this->createInstance(
-                        new Ctx(alias: $alias, class: $binding::class, parameter: $context),
-                        $parameters,
-                    )
-                    : $binding;
-            }
-
-            $ctx = new Ctx(alias: $alias, class: $alias, parameter: $context);
-            if (\is_string($binding)) {
-                $ctx->class = $binding;
-                return $binding === $alias
-                    ? $this->autowire($ctx, $parameters)
-                    //Binding is pointing to something else
-                    : $this->make($binding, $parameters, $context);
-            }
-
-            if ($binding[1] === true) {
-                $ctx->singleton = true;
-            }
             unset($this->state->bindings[$alias]);
-            try {
-                return $binding[0] === $alias
-                    ? $this->autowire($ctx, $parameters)
-                    : $this->evaluateBinding($ctx, $binding[0], $parameters);
-            } finally {
-                $this->state->bindings[$alias] ??= $binding;
-            }
+            return match ($binding::class) {
+                \Spiral\Core\Config\Alias::class => $this->resolveAlias($binding, $alias, $context, $parameters),
+                \Spiral\Core\Config\Autowire::class => $this->resolveAutowire($binding, $alias, $context, $parameters),
+                DeferredFactory::class,
+                \Spiral\Core\Config\Factory::class => $this->resolveFactory($binding, $alias, $context, $parameters),
+                \Spiral\Core\Config\Shared::class => $this->resolveShared($binding, $alias, $context, $parameters),
+                Injectable::class => $this->resolveInjector($binding, $alias, $context, $parameters),
+                \Spiral\Core\Config\Scalar::class => $binding->value,
+                \Spiral\Core\Config\WeakReference::class => $this
+                    ->resolveWeakReference($binding, $alias, $context, $parameters),
+                default => $binding,
+            };
         } finally {
+            $this->state->bindings[$alias] ??= $binding;
             $this->tracer->pop(true);
             $this->tracer->pop(false);
         }
     }
 
-    private function resolveWeakReference(
-        WeakReference $binding,
+    private function resolveInjector(
+        Injectable $binding,
         string $alias,
         ?string $context,
-        array $parameters
-    ): ?object {
-        $avoidCache = $parameters !== [];
+        array $arguments
+    ) {
+        $ctx = new Ctx(alias: $alias, class: $alias, parameter: $context);
 
-        if (($avoidCache || $binding->get() === null) && \class_exists($alias)) {
+        // We have to construct class using external injector when we know exact context
+        if ($arguments !== []) {
+            // todo factory?
+        }
+
+        $class = $ctx->class;
+        try {
+            $ctx->reflection = $reflection = new \ReflectionClass($class);
+        } catch (\ReflectionException $e) {
+            throw new ContainerException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        $injector = $binding->injector;
+
+        try {
+            $injectorInstance = \is_object($injector) ? $injector : $this->container->get($injector);
+
+            if (!$injectorInstance instanceof InjectorInterface) {
+                throw new InjectionException(
+                    \sprintf(
+                        "Class '%s' must be an instance of InjectorInterface for '%s'.",
+                        $injectorInstance::class,
+                        $reflection->getName()
+                    )
+                );
+            }
+
+            /**
+             * @var InjectorInterface<TObject> $injectorInstance
+             * @psalm-suppress RedundantCondition
+             */
+            $instance = $injectorInstance->createInjection($reflection, $ctx->parameter);
+            if (!$reflection->isInstance($instance)) {
+                throw new InjectionException(
+                    \sprintf(
+                        "Invalid injection response for '%s'.",
+                        $reflection->getName()
+                    )
+                );
+            }
+
+            return $instance;
+        } finally {
+            $this->state->bindings[$reflection->getName()] ??= $binding; //new Injector($injector);
+        }
+    }
+
+    private function resolveAlias(
+        \Spiral\Core\Config\Alias $binding,
+        string $alias,
+        ?string $context,
+        array $arguments,
+    ): mixed {
+        $result = $binding->alias === $alias
+            ? $this->autowire(
+                new Ctx(alias: $alias, class: $binding->alias, parameter: $context, singleton: $binding->singleton),
+                $arguments,
+            )
+            //Binding is pointing to something else
+            : $this->make($binding->alias, $arguments, $context);
+
+        if ($binding->singleton && $arguments === []) {
+            $this->state->singletons[$alias] = $result;
+        }
+
+        return $result;
+    }
+
+    private function resolveShared(
+        \Spiral\Core\Config\Shared $binding,
+        string $alias,
+        ?string $context,
+        array $arguments,
+    ): object {
+        $avoidCache = $arguments !== [];
+        return $avoidCache
+            ? $this->createInstance(
+                new Ctx(alias: $alias, class: $binding->value::class, parameter: $context),
+                $arguments,
+            )
+            : $binding->value;
+    }
+
+    private function resolveAutowire(
+        \Spiral\Core\Config\Autowire $binding,
+        string $alias,
+        ?string $context,
+        array $arguments,
+    ): mixed {
+        $instance = $binding->autowire->resolve($this, $arguments);
+
+        $ctx = new Ctx(alias: $alias, class: $alias, parameter: $context, singleton: $binding->singleton);
+        return $this->validateNewInstance($instance, $ctx, $arguments);
+    }
+
+    private function resolveFactory(
+        \Spiral\Core\Config\Factory|DeferredFactory $binding,
+        string $alias,
+        ?string $context,
+        array $arguments,
+    ): mixed {
+        $ctx = new Ctx(alias: $alias, class: $alias, parameter: $context, singleton: $binding->singleton);
+        try {
+            $instance = $binding::class === \Spiral\Core\Config\Factory::class && !$binding->hasParameters()
+                ? ($binding->factory)()
+                : $this->invoker->invoke($binding->factory, $arguments);
+        } catch (NotCallableException $e) {
+            throw new ContainerException(
+                $this->tracer->combineTraceMessage(\sprintf('Invalid binding for `%s`.', $ctx->alias)),
+                $e->getCode(),
+                $e,
+            );
+        }
+
+        return \is_object($instance) ? $this->validateNewInstance($instance, $ctx, $arguments) : $instance;
+    }
+
+    private function resolveWeakReference(
+        \Spiral\Core\Config\WeakReference $binding,
+        string $alias,
+        ?string $context,
+        array $arguments,
+    ): ?object {
+        $avoidCache = $arguments !== [];
+
+        if (($avoidCache || $binding->reference->get() === null) && \class_exists($alias)) {
             try {
                 $this->tracer->push(false, alias: $alias, source: WeakReference::class, context: $context);
 
                 $object = $this->createInstance(
                     new Ctx(alias: $alias, class: $alias, parameter: $context),
-                    $parameters,
+                    $arguments,
                 );
                 if ($avoidCache) {
                     return $object;
                 }
-                $binding = $this->state->bindings[$alias] = WeakReference::create($object);
+                $binding->reference = WeakReference::create($object);
             } catch (\Throwable) {
                 throw new ContainerException(
                     $this->tracer->combineTraceMessage(
@@ -156,7 +267,7 @@ final class Factory implements FactoryInterface
             }
         }
 
-        return $binding->get();
+        return $binding->reference->get();
     }
 
     private function resolveWithoutBinding(string $alias, array $parameters = [], string $context = null): mixed
@@ -235,45 +346,22 @@ final class Factory implements FactoryInterface
     }
 
     /**
-     * @param mixed $target Value that was bound by user.
-     *
-     * @throws ContainerException
+     * @throws BadScopeException
      * @throws \Throwable
      */
-    private function evaluateBinding(
+    private function validateNewInstance(
+        object $instance,
         Ctx $ctx,
-        mixed $target,
         array $arguments,
-    ): mixed {
-        if (\is_string($target)) {
-            // Reference
-            $instance = $this->make($target, $arguments, $ctx->parameter);
-        } else {
-            if ($target instanceof Autowire) {
-                $instance = $target->resolve($this, $arguments);
-            } else {
-                try {
-                    $instance = $this->invoker->invoke($target, $arguments);
-                } catch (NotCallableException $e) {
-                    throw new ContainerException(
-                        $this->tracer->combineTraceMessage(\sprintf('Invalid binding for `%s`.', $ctx->alias)),
-                        $e->getCode(),
-                        $e,
-                    );
-                }
-            }
-
-            // Check scope name
-            if (\is_object($instance)) {
-                $ctx->reflection = new \ReflectionClass($instance);
-                $scopeName = ($ctx->reflection->getAttributes(ScopeAttribute::class)[0] ?? null)?->newInstance()->name;
-                if ($scopeName !== null && $scopeName !== $this->scope->getScopeName()) {
-                    throw new BadScopeException($scopeName, $instance::class);
-                }
-            }
+    ): object {
+        // Check scope name
+        $ctx->reflection = new \ReflectionClass($instance);
+        $scopeName = ($ctx->reflection->getAttributes(ScopeAttribute::class)[0] ?? null)?->newInstance()->name;
+        if ($scopeName !== null && $scopeName !== $this->scope->getScopeName()) {
+            throw new BadScopeException($scopeName, $instance::class);
         }
 
-        return \is_object($instance) && $arguments === []
+        return $arguments === []
             ? $this->registerInstance($ctx, $instance)
             : $instance;
     }
@@ -310,39 +398,7 @@ final class Factory implements FactoryInterface
 
         //We have to construct class using external injector when we know exact context
         if ($parameters === [] && $this->binder->hasInjector($class)) {
-            $injector = $this->state->injectors[$reflection->getName()];
-
-            try {
-                $injectorInstance = $this->container->get($injector);
-
-                if (!$injectorInstance instanceof InjectorInterface) {
-                    throw new InjectionException(
-                        \sprintf(
-                            "Class '%s' must be an instance of InjectorInterface for '%s'.",
-                            $injectorInstance::class,
-                            $reflection->getName()
-                        )
-                    );
-                }
-
-                /**
-                 * @var InjectorInterface<TObject> $injectorInstance
-                 * @psalm-suppress RedundantCondition
-                 */
-                $instance = $injectorInstance->createInjection($reflection, $ctx->parameter);
-                if (!$reflection->isInstance($instance)) {
-                    throw new InjectionException(
-                        \sprintf(
-                            "Invalid injection response for '%s'.",
-                            $reflection->getName()
-                        )
-                    );
-                }
-
-                return $instance;
-            } finally {
-                $this->state->injectors[$reflection->getName()] = $injector;
-            }
+            return $this->resolveInjector($this->state->bindings[$ctx->class], $ctx->class, $ctx->parameter, $parameters);
         }
 
         if (!$reflection->isInstantiable()) {
@@ -413,7 +469,7 @@ final class Factory implements FactoryInterface
 
         //Declarative singletons
         if ($this->isSingleton($ctx)) {
-            $this->state->bindings[$ctx->alias] = $instance;
+            $this->state->singletons[$ctx->alias] = $instance;
         }
 
         // Register finalizer

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -218,7 +218,7 @@ final class Factory implements FactoryInterface
     ): mixed {
         $ctx = new Ctx(alias: $alias, class: $alias, parameter: $context, singleton: $binding->singleton);
         try {
-            $instance = $binding::class === \Spiral\Core\Config\Factory::class && !$binding->hasParameters()
+            $instance = $binding::class === \Spiral\Core\Config\Factory::class && $binding->getParametersCount() === 0
                 ? ($binding->factory)()
                 : $this->invoker->invoke($binding->factory, $arguments);
         } catch (NotCallableException $e) {
@@ -511,7 +511,9 @@ final class Factory implements FactoryInterface
             foreach ($this->state->inflectors as $class => $inflectors) {
                 if ($instance instanceof $class) {
                     foreach ($inflectors as $inflector) {
-                        $instance = $this->invoker->invoke($inflector->inflector, [$instance]);
+                        $instance = $inflector->getParametersCount() > 1
+                            ? $this->invoker->invoke($inflector->inflector, [$instance])
+                            : ($inflector->inflector)($instance);
                     }
                 }
             }

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -500,6 +500,20 @@ final class Factory implements FactoryInterface
         return $ctx->reflection->getAttributes(Singleton::class) !== [];
     }
 
+    private function getFinalizer(Ctx $ctx, object $instance): ?callable
+    {
+        /**
+         * @psalm-suppress UnnecessaryVarAnnotation
+         * @var Finalize|null $attribute
+         */
+        $attribute = ($ctx->reflection->getAttributes(Finalize::class)[0] ?? null)?->newInstance();
+        if ($attribute === null) {
+            return null;
+        }
+
+        return [$instance, $attribute->method];
+    }
+
     /**
      * Find and run inflector
      */

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -111,7 +111,7 @@ final class Factory implements FactoryInterface
         Injectable $binding,
         string $alias,
         ?string $context,
-        array $arguments
+        array $arguments,
     ) {
         $ctx = new Ctx(alias: $alias, class: $alias, parameter: $context);
 
@@ -143,7 +143,6 @@ final class Factory implements FactoryInterface
             }
 
             /**
-             * @var InjectorInterface<TObject> $injectorInstance
              * @psalm-suppress RedundantCondition
              */
             $instance = $injectorInstance->createInjection($reflection, $ctx->parameter);
@@ -453,15 +452,7 @@ final class Factory implements FactoryInterface
     }
 
     /**
-     * Register instance in container, might perform methods like auto-singletons, log populations
-     * and etc.
-     *
-     * @template TObject of object
-     *
-     * @param TObject $instance Created object.
-     * @param \ReflectionClass<TObject> $reflection
-     *
-     * @return TObject
+     * Register instance in container, might perform methods like auto-singletons, log populations, etc.
      */
     private function registerInstance(Ctx $ctx, object $instance): object
     {

--- a/src/Core/src/Internal/Resolver.php
+++ b/src/Core/src/Internal/Resolver.php
@@ -249,7 +249,7 @@ final class Resolver implements ResolverInterface
         ResolvingState $state,
         ReflectionParameter $parameter,
         ReflectionNamedType $typeRef,
-        bool $validate
+        bool $validate,
     ) {
         return !$typeRef->isBuiltin() && $this->resolveObjectParameter(
             $state,

--- a/src/Core/src/Internal/State.php
+++ b/src/Core/src/Internal/State.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Core\Internal;
 
 use Spiral\Core\Config\Binding;
+use Spiral\Core\Config\Inflector;
 use Spiral\Core\Container\Autowire;
 
 /**
@@ -24,7 +25,15 @@ final class State
      */
     public array $singletons = [];
 
+    /**
+     * @var array<class-string, string>
+     */
     public array $injectors = [];
+
+    /**
+     * @var array<class-string, Inflector[]>
+     */
+    public array $inflectors = [];
 
     /**
      * List of finalizers to be called on container scope destruction.

--- a/src/Core/src/Internal/State.php
+++ b/src/Core/src/Internal/State.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spiral\Core\Internal;
 
+use Spiral\Core\Config\Binding;
 use Spiral\Core\Container\Autowire;
 
 /**
@@ -12,14 +15,15 @@ use Spiral\Core\Container\Autowire;
 final class State
 {
     /**
-     * @var array<string, string|object|array{TResolver, bool}>
+     * @var array<string, Binding>
      */
     public array $bindings = [];
 
     /**
-     * List of classes responsible for handling specific instance or interface. Provides ability to
-     * delegate container functionality.
+     * @var array<string, mixed> Cache for singletons
      */
+    public array $singletons = [];
+
     public array $injectors = [];
 
     /**
@@ -30,6 +34,7 @@ final class State
 
     public function destruct(): void
     {
+        $this->singletons = [];
         $this->injectors = [];
         $this->bindings = [];
         $this->finalizers = [];

--- a/src/Core/src/Internal/Tracer/Trace.php
+++ b/src/Core/src/Internal/Tracer/Trace.php
@@ -40,7 +40,7 @@ final class Trace implements \Stringable
             $item instanceof \Closure => $this->renderClosureSignature(new \ReflectionFunction($item)),
             $item instanceof \ReflectionFunctionAbstract => $this->renderClosureSignature($item),
             $item instanceof \UnitEnum => $item::class . "::$item->name",
-            \is_object($item) => 'instance of ' . $item::class,
+            \is_object($item) => $item instanceof \Stringable ? (string) $item : 'instance of ' . $item::class,
             \is_array($item) => $this->renderArray($item),
             default => \get_debug_type($item),
         };

--- a/src/Core/src/InvokerInterface.php
+++ b/src/Core/src/InvokerInterface.php
@@ -19,7 +19,7 @@ interface InvokerInterface
      * @param callable|non-empty-string|array{class-string, non-empty-string} $target
      *        string - class name or container definition
      *        array - lazy callable where first element can be class name or container definition
-     * @param array<non-empty-string, mixed> $parameters Predefined named arguments
+     * @param array $parameters Predefined named arguments
      *
      * @throws NotCallableException
      */

--- a/src/Core/tests/BindingsTest.php
+++ b/src/Core/tests/BindingsTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Core;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Spiral\Core\ConfigsInterface;
 use Spiral\Core\Container;
 use Spiral\Tests\Core\Fixtures\Factory;
 use Spiral\Tests\Core\Fixtures\SampleClass;
@@ -72,5 +73,13 @@ class BindingsTest extends TestCase
 
         $this->assertInstanceOf(SampleClass::class, $instance);
         $this->assertSame($instance, $container->get('sampleClass'));
+    }
+
+    public function testAutoScalarBinding(): void
+    {
+        $container = new Container();
+        $container->bind(ConfigsInterface::class, 42.69);
+
+        self::assertSame(42.69, $container->get(ConfigsInterface::class));
     }
 }

--- a/src/Core/tests/ExceptionsTest.php
+++ b/src/Core/tests/ExceptionsTest.php
@@ -213,7 +213,7 @@ class ExceptionsTest extends TestCase
         yield 'binding' => [
             $binding,
             <<<'MARKDOWN'
-            Invalid binding for `Spiral\Tests\Core\Fixtures\InvalidClass`.
+            Can't resolve `Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency`: undefined class or binding `invalid`.
             Container trace list:
             - action: 'autowire'
               alias: 'Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency'
@@ -224,12 +224,10 @@ class ExceptionsTest extends TestCase
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
                 scope: 'root'
                 context: 'class'
-                binding: [
-                  0: [
-                    0: 'invalid'
-                  ],
-                  1: false
-                ]
+                binding: Deferred factory 'invalid'->invalid()
+                - action: 'autowire'
+                  alias: 'invalid'
+                  context: null
             MARKDOWN
         ];
         yield 'notConstructed' => [
@@ -246,7 +244,7 @@ class ExceptionsTest extends TestCase
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
                 scope: 'root'
                 context: 'class'
-                binding: 'Spiral\Tests\Core\Fixtures\WithPrivateConstructor'
+                binding: Alias to `Spiral\Tests\Core\Fixtures\WithPrivateConstructor`
                 - action: 'autowire'
                   alias: 'Spiral\Tests\Core\Fixtures\WithPrivateConstructor'
                   context: 'class'
@@ -278,10 +276,7 @@ class ExceptionsTest extends TestCase
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
                 scope: 'root'
                 context: 'class'
-                binding: [
-                  0: static function (Psr\Container\ContainerInterface $container),
-                  1: false
-                ]
+                binding: Factory from static function (Psr\Container\ContainerInterface $container)
                 - action: 'autowire'
                   alias: 'invalid'
                   context: null

--- a/src/Core/tests/InjectableTest.php
+++ b/src/Core/tests/InjectableTest.php
@@ -75,18 +75,6 @@ class InjectableTest extends TestCase
         $container->get(TestConfig::class);
     }
 
-    public function testInjectorOuterBinding(): void
-    {
-        $this->expectException(AutowireException::class);
-        $this->expectExceptionMessage(
-            "Can't resolve `Spiral\Tests\Core\Fixtures\TestConfig`: undefined class or binding `invalid-configurator`."
-        );
-        $container = new Container();
-        $container->bind(ConfigsInterface::class, 'invalid-configurator');
-
-        $container->get(TestConfig::class);
-    }
-
     public function testInvalidInjection(): void
     {
         $this->expectException(InjectionException::class);
@@ -114,8 +102,7 @@ class InjectableTest extends TestCase
             ->with(m::on(static function (ReflectionClass $r) {
                 return $r->getName() === TestConfig::class;
             }), null)
-            ->andReturn($expected)
-        ;
+            ->andReturn($expected);
 
         $this->assertSame($expected, $container->get(TestConfig::class));
     }
@@ -132,8 +119,7 @@ class InjectableTest extends TestCase
             ->with(m::on(static function (ReflectionClass $r) {
                 return $r->getName() === TestConfig::class;
             }), 'context')
-            ->andReturn($expected)
-        ;
+            ->andReturn($expected);
 
         $this->assertSame($expected, $container->get(TestConfig::class, 'context'));
     }

--- a/src/Core/tests/Internal/Factory/InflectorTest.php
+++ b/src/Core/tests/Internal/Factory/InflectorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Internal\Factory;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use Spiral\Core\Config\Inflector;
 use Spiral\Tests\Core\Stub\EngineMarkTwo;
 use Spiral\Tests\Core\Stub\EngineVAZ2101;
@@ -32,6 +34,27 @@ final class InflectorTest extends BaseTestCase
         $this->assertInstanceOf(stdClass::class, $object);
         $this->assertObjectHasProperty('foo', $object);
         $this->assertSame($object->foo, 'bar');
+    }
+
+    public function testInflectAutowiring(): void
+    {
+        $this->bind(DateTimeInterface::class, $time = new DateTimeImmutable());
+        $this->bind(
+            stdClass::class,
+            new Inflector(
+                static function (stdClass $object, DateTimeInterface $time): stdClass {
+                    $object->time = $time;
+
+                    return $object;
+                }
+            ),
+        );
+
+        $object = $this->make(stdClass::class);
+
+        $this->assertInstanceOf(stdClass::class, $object);
+        $this->assertObjectHasProperty('time', $object);
+        $this->assertSame($time, $object->time);
     }
 
     public function testFewObjectsUsingAbstractParent(): void

--- a/src/Core/tests/Internal/Factory/InflectorTest.php
+++ b/src/Core/tests/Internal/Factory/InflectorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Internal\Factory;
+
+use Spiral\Core\Config\Inflector;
+use Spiral\Tests\Core\Stub\EngineMarkTwo;
+use Spiral\Tests\Core\Stub\EngineVAZ2101;
+use Spiral\Tests\Core\Stub\EngineZIL130;
+use Spiral\Tests\Core\Stub\LightEngine;
+use Spiral\Tests\Core\Stub\MadeInUssrInterface;
+use stdClass;
+
+final class InflectorTest extends BaseTestCase
+{
+    public function testInflectStdClass(): void
+    {
+        $this->bind(
+            stdClass::class,
+            new Inflector(
+                static function (stdClass $object): stdClass {
+                    $object->foo = 'bar';
+
+                    return $object;
+                }
+            ),
+        );
+
+        $object = $this->make(stdClass::class);
+
+        $this->assertInstanceOf(stdClass::class, $object);
+        $this->assertObjectHasProperty('foo', $object);
+        $this->assertSame($object->foo, 'bar');
+    }
+
+    public function testFewObjectsUsingAbstractParent(): void
+    {
+        $this->bind(
+            LightEngine::class,
+            new Inflector(
+                static function (LightEngine $object): LightEngine {
+                    return $object->withPower(999999);
+                }
+            ),
+        );
+
+        $object1 = $this->make(EngineVAZ2101::class);
+        $object2 = $this->make(EngineMarkTwo::class);
+        $this->make(EngineZIL130::class);
+
+        $this->assertSame(999999, $object1->getPower());
+        $this->assertSame(999999, $object2->getPower());
+    }
+
+    public function testFewObjectsUsingInterface(): void
+    {
+        $result = [];
+        $this->bind(
+            MadeInUssrInterface::class,
+            new Inflector(
+                static function (MadeInUssrInterface $object) use (&$result): MadeInUssrInterface {
+                    $result[] = $object;
+
+                    return $object;
+                }
+            ),
+        );
+
+        $object1 = $this->make(EngineVAZ2101::class);
+        $this->make(EngineMarkTwo::class);
+        $object3 = $this->make(EngineZIL130::class);
+
+        $this->assertSame([$object1, $object3], $result);
+    }
+
+    public function testMultipleInflector(): void
+    {
+        $result1 = $result2 = [];
+        $this->bind(
+            MadeInUssrInterface::class,
+            new Inflector(
+                static function (MadeInUssrInterface $object) use (&$result1): MadeInUssrInterface {
+                    $result1[] = $object;
+
+                    return $object;
+                }
+            ),
+        );
+        $this->bind(
+            MadeInUssrInterface::class,
+            new Inflector(
+                static function (MadeInUssrInterface $object) use (&$result2): MadeInUssrInterface {
+                    $result2[] = $object;
+
+                    return $object;
+                }
+            ),
+        );
+
+        $object1 = $this->make(EngineVAZ2101::class);
+        $this->make(EngineMarkTwo::class);
+        $object3 = $this->make(EngineZIL130::class);
+
+        $this->assertSame([$object1, $object3], $result1);
+        $this->assertSame([$object1, $object3], $result2);
+    }
+}

--- a/src/Core/tests/Scope/Stub/LoggerInjector.php
+++ b/src/Core/tests/Scope/Stub/LoggerInjector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Scope\Stub;
+
+use Spiral\Core\Container\InjectorInterface;
+
+/**
+ * @implements InjectorInterface<LoggerInterface>
+ */
+final class LoggerInjector implements InjectorInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function createInjection(\ReflectionClass $class, ?string $context = null): LoggerInterface
+    {
+        return $this->logger;
+    }
+}

--- a/src/Core/tests/ScopesTest.php
+++ b/src/Core/tests/ScopesTest.php
@@ -113,4 +113,22 @@ class ScopesTest extends TestCase
 
         $this->assertSame($container, $result);
     }
+
+    public function testSingletonRebindingInScope(): void
+    {
+        $c = new Container();
+        $c->bindSingleton('bucket', new Container\Autowire(Bucket::class, ['a']));
+
+        $this->assertSame('a', $c->get('bucket')->getName());
+
+        $this->assertTrue($c->runScope([
+            'bucket' => new Bucket('b'),
+        ], function ($c): bool {
+            $this->assertSame('b', $c->get('bucket')->getName());
+
+            return $c->get('bucket')->getName() === 'b';
+        }));
+
+        $this->assertSame('a', $c->get('bucket')->getName());
+    }
 }

--- a/src/Core/tests/Stub/LightEngine.php
+++ b/src/Core/tests/Stub/LightEngine.php
@@ -13,6 +13,14 @@ abstract class LightEngine implements EngineInterface
         return $this->power;
     }
 
+    public function withPower(int $value): static
+    {
+        $clone = clone $this;
+        $clone->power = $value;
+
+        return $clone;
+    }
+
     public static function isWroomWroom(): bool
     {
         return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->

With this update, we have focused on enhancing the overall performance of the component while introducing new features without any degradation in performance.

One of the key improvements in this update is the significant boost in container efficiency. By moving most of the internal operations from runtime into configuration time, we have achieved up to 2x faster container functionality. This optimization ensures that the container works swiftly and efficiently, resulting in improved application performance.

Additionally, we have replaced the previous array-based structure for storing information about bindings within the container. The new approach employs Data Transfer Objects (DTO), providing a more structured and organized way to store binding information. With this change, developers now can easily configure container bindings using these objects.

To demonstrate the enhanced container functionality, here's an example showcasing the new binding configuration:

```php
use Spiral\Core\Config\Factory;

$container->bind(LoggerInterface::class, new Factory(
    callable: static function() {
        return new Logger(....);
    }, 
    singleton: true
))
```

### Available bindings

### Alias 

This simplified DTO allows you to create a link to another binding within the container.

```php
use Spiral\Core\Config\Alias;

$container->bind(
    \DatetimeImmutable::class, 
    static fn() => new \DatetimeImmutable()
);

$container->bind(
    'now', 
    new Alias(alias: \DatetimeImmutable::class)
);
```

In this example, we first bind the` \DatetimeImmutable` class to a factory function that creates a new instance of `\DatetimeImmutable` every time it's requested. Then, we create an Alias binding named `now` and associate it with the `\DatetimeImmutable` class binding.

Now you can request ` \DatetimeImmutable` class from the container by alias `$container->get('now')`

The Alias also provides a second argument called `singleton`. By setting `singleton` to `true`, the aliased class becomes a singleton. This means that whenever you request `$container->get('now')` from the container, it will return the same instance every time. On the other hand, calling `$container->get(\DatetimeImmutable::class)` will return a new instance of `\DatetimeImmutable` with the current time on each request.

### Autowire

The `Spiral\Core\Config\Autowire` binding serves as a wrapper for the `Spiral\Core\Container\Autowire` class, providing an automated way to resolve and instantiate classes by injecting their dependencies.

```php
use Spiral\Core\Config\Autowire;
use Spiral\Core\Container\Autowire as AutowireAlias;

$container->bind(MyClass::class, new Autowire(
    autowire: new AutowireAlias(MyClass::class, ['foo' => 'bar']),
    singleton: true
));
```

The `singleton` argument, set to `true` in this example, indicates that the container should treat `MyClass` as a singleton. When you request an instance of `MyClass` from the container (`$container->get(MyClass::class)`), it will return the same instance every time.

### Factory

The `Spiral\Core\Config\Factory` binding serves as a simple factory for creating mixed types using a closure.

```php
use Spiral\Core\Config\Factory;

$container->bind('time', new Factory(
    callable: static fn() => time(),
));
```

Every time when you request current time from the container `$container->get('time')` it will return current timestamp.

Additionally, the Factory binding can be configured as a singleton:

```php
$container->bind('time', new Factory(
    callable: static fn() => time(),
    singleton: true
));
```

By setting the `singleton` argument to `true`. This means that whenever you request the `time` value from the container (`$container->get('time')`), it will return the same value across multiple invocations.

### DeferredFactory

The ``Spiral\Core\Config\DeferredFactory binding enables you to bind deferred factories to the container using array callables. 


```php
use Spiral\Core\Config\DeferredFactory;

$container->bind('some-binding', new DeferredFactory(
    factory: [MyClass::class, 'handle'],
));
```

In the example above, we bind the key `some-binding` to a DeferredFactory instance. The factory property is set to `[MyClass::class, 'handle']`. When the `some-binding` key is requested from the container (`$container->get('some-binding')`), the DeferredFactory will create an instance of `MyClass` and then invoke the `handle` method on that instance.

Additionally, the DeferredFactory binding can be configured as a singleton:

```php
$container->bind('some-binding', new DeferredFactory(
    factory: ...],
    singleton: true
));
```

### Scalar

The Scalar binding is a new functionality introduced for the container. It provides a convenient way to store and retrieve static scalar values within the container. It can be useful for configuring paths, constants, or any other scalar values needed by your application.

```php
use Spiral\Core\Config\Scalar;

$container->bind('app-path', new Scalar(value: '/var/www/my-app'));
```

### Shared

The Shared binding allows you to bind a persistent object to a key in the container. Once the object is created, it will be reused every time the key is requested, and custom arguments cannot be provided during subsequent requests.

```php
use Spiral\Core\Config\Shared;

$container->bind(MyClass::class, new Shared(value: new MyClass(...)));
```

It's important to note that with the Shared binding, custom arguments cannot be provided during subsequent requests. The object will be created with the initial arguments and reused as is.

It is particularly useful when you want to ensure that the same instance of an object is used throughout the application. It provides persistence and prevents the creation of multiple instances with different arguments.


### Inflector

An inflector allows you to manipulate an object before returning it from the container. This is particularly useful for applying common modifications or injections to objects of a specific type.

```php
use Spiral\Core\Config\Inflector;

$container->bind(LoggerAwareInterface::class, new Inflector(
    inflector: static function (LoggerAwareInterface $obj, LoggerInterface $logger): LoggerAwareInterface {
        $obj->setLogger($logger);

        return $obj;
    }
));
```

By configuring the Inflector binding, you can apply modifications or injections to objects of a specific type automatically whenever they are requested from the container. In this case, any object implementing `LoggerAwareInterface` will have its logger set based on the specified configuration.

The Inflector binding is a powerful tool for applying common modifications or injections consistently across objects in your application. It simplifies the process of configuring and customizing objects retrieved from the container.

### WeakReference

The WeakReference feature allows you to work with weak reference objects within the container. Weak references are references to an object that do not prevent the object from being garbage-collected when there are no strong references to it.

```php
use Spiral\Core\Config\WeakReference;

$obj = new MyClass();

$container->bind(MyClass::class, new WeakReference(
    reference: new \WeakReference($obj)
));

$obj === $container->get(MyClass::class); // true

unset($obj);

$obj1 = $container->get(MyClass::class); // A new object will be created
$obj1 === $container->get(MyClass::class); // true
```

When you retrieve `MyClass` from the container (`$container->get(MyClass::class)`), the container returns the original object because it still exists. However, when you unset the `$obj` variable, removing the strong reference to the object, it becomes eligible for garbage collection. Subsequent calls to `$container->get(MyClass::class)` will create a new instance of `MyClass` because the original object has been garbage-collected.

Using weak references can be beneficial in certain scenarios where you want to have control over the object's lifecycle and allow it to be garbage-collected when there are no more strong references to it.

## Exceptions

With the updated refactoring, developers can expect more descriptive and informative exception messages when working with bindings. These enhanced exception messages can greatly simplify the process of identifying and resolving issues related to bindings, ultimately improving the development experience.


-----


We believe that this refactoring and optimization effort will greatly benefit the Spiral framework community. It not only enhances the performance of the spiral/core component but also introduces new container features that facilitate streamlined development and configuration processes.

Description in Russian
https://dynalist.io/d/HoV_w91uHBOr1U0f1-udc8Ir
