### PR TITLE
Support psr/http-message v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
         "symfony/translation": "^5.1|^6.0",
         "vlucas/phpdotenv": "^5.4"
     },
+    "conflict": {
+        "aws/aws-sdk-php": "<3.270"
+    },
     "autoload": {
         "files": [
             "src/Boot/src/helpers.php",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "psr/event-dispatcher": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "1 - 3",
         "psr/simple-cache": "2 - 3",
@@ -123,8 +123,8 @@
         }
     },
     "require-dev": {
-        "aws/aws-sdk-php": "^3.0",
-        "guzzlehttp/psr7": "^1.7",
+        "aws/aws-sdk-php": "^3.270",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "jetbrains/phpstorm-attributes": "^1.0",
         "league/flysystem-async-aws-s3": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -24,6 +24,7 @@
     <issueHandlers>
         <UnusedClosureParam errorLevel="suppress" />
         <UnusedPsalmSuppress errorLevel="suppress" />
+        <UnsupportedPropertyReferenceUsage errorLevel="suppress" />
         <InvalidThrow>
             <errorLevel type="suppress">
                 <referencedClass name="Psr\Container\NotFoundExceptionInterface"/>

--- a/src/AuthHttp/composer.json
+++ b/src/AuthHttp/composer.json
@@ -29,7 +29,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "spiral/auth": "^3.8",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "psr/http-server-middleware": "^1.0",
         "psr/event-dispatcher": "^1.0"
     },

--- a/src/Broadcasting/composer.json
+++ b/src/Broadcasting/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "1 - 3",

--- a/src/Core/psalm.xml
+++ b/src/Core/psalm.xml
@@ -16,4 +16,7 @@
     <projectFiles>
         <directory name="src" />
     </projectFiles>
+    <issueHandlers>
+        <UnsupportedPropertyReferenceUsage errorLevel="suppress" />
+    </issueHandlers>
 </psalm>

--- a/src/Distribution/composer.json
+++ b/src/Distribution/composer.json
@@ -25,8 +25,8 @@
     },
     "require-dev": {
         "spiral/boot": "^3.8",
-        "aws/aws-sdk-php": "^3.0",
-        "guzzlehttp/psr7": "^1.7",
+        "aws/aws-sdk-php": "^3.270",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "jetbrains/phpstorm-attributes": "^1.0",
         "phpunit/phpunit": "^10.1",
         "vimeo/psalm": "^5.9"
@@ -37,7 +37,7 @@
         }
     },
     "suggest": {
-        "aws/aws-sdk-php": "(^3.0) For use S3 and CloudFront URI Resolvers"
+        "aws/aws-sdk-php": "(^3.270) For use S3 and CloudFront URI Resolvers"
     },
     "extra": {
         "branch-alias": {

--- a/src/Distribution/composer.json
+++ b/src/Distribution/composer.json
@@ -18,6 +18,9 @@
         "php": ">=8.1",
         "psr/http-factory": "^1.0"
     },
+    "conflict": {
+        "aws/aws-sdk-php": "<3.270"
+    },
     "autoload": {
         "psr-4": {
             "Spiral\\Distribution\\": "src"

--- a/src/Filters/composer.json
+++ b/src/Filters/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "spiral/attributes": "^2.8|^3.0",
         "spiral/auth": "^3.8",
         "spiral/core": "^3.8",

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -34,7 +34,7 @@
         "spiral/files": "^3.8",
         "spiral/streams": "^3.8",
         "spiral/telemetry": "^3.8",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/event-dispatcher": "^1.0"

--- a/src/Router/tests/PipelineFactoryTest.php
+++ b/src/Router/tests/PipelineFactoryTest.php
@@ -95,7 +95,7 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
             ->andReturn($response = m::mock(ResponseInterface::class));
 
         $response
-            ->shouldReceive('getHeaderLine')->with('Content-Length')->andReturn(['test'])
+            ->shouldReceive('getHeaderLine')->with('Content-Length')->andReturn('test')
             ->shouldReceive('getStatusCode')->andReturn(200);
 
         $p

--- a/src/Streams/composer.json
+++ b/src/Streams/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ⁉
| New feature?  | ❌
| Issues        | #929

Expand `psr/http-message` version.

> **Warning**:
> Merging this PR might generate a lot of issues related with the `distribution` module because it
recommends to use the `aws/aws-sdk-php` package.
> The `aws/aws-sdk-php` isn't compatible with the `psr/http-message` 2.x yet.
> They've pinned `psar/http-message` `^1` from `aws/aws-sdk-php` `3.269.1`

https://github.com/aws/aws-sdk-php/issues/2681
https://github.com/aws/aws-sdk-php/pull/2684

> Unfortunately, we can't fix this for now since this repository supports PHP versions down to 5.5 and this would be a breaking change. We have started a https://github.com/aws/aws-sdk-php/discussions/2638 announcing that we will no longer support versions below 7.2.5 after the minor version bump that will happen on August 15th, 2023.


As a solution I propose to add the `aws/aws-sdk-php` `<3.270` into the `conflict` section of the `composer.json`