### PR TITLE
[spiral/auth-http] Setting default transport in AuthTransportMiddleware

### DIFF
--- a/src/AuthHttp/src/Middleware/AuthTransportMiddleware.php
+++ b/src/AuthHttp/src/Middleware/AuthTransportMiddleware.php
@@ -49,6 +49,7 @@ final class AuthTransportMiddleware implements MiddlewareInterface
     private function getTransportRegistry(TransportRegistry $registry, string $transportName): TransportRegistry
     {
         $transports = new TransportRegistry();
+        $transports->setDefaultTransport($transportName);
         $transports->setTransport($transportName, $registry->getTransport($transportName));
 
         return $transports;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       |  ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | #949 

### What was changed

Added default token transport in the `AuthTransportMiddleware`.

Before to these changes, calling the `start` method of the `AuthContextInterface` without passing a transport name resulted in an exception "Undefined auth transport ...":

```php
public function login(AuthContextInterface $auth): string
{
    // ...
    $auth->start(new Token('1', ['some' => 'data']));
    // ...
}
```

See: #949 

