### PR TITLE
[spiral/tokenizer] Fixed adding directory via bootloader

### DIFF
--- a/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
@@ -56,20 +56,11 @@ final class TokenizerListenerBootloader extends Bootloader implements
         $this->listeners[] = $listener;
     }
 
-    public function boot(AbstractKernel $kernel, TokenizerConfig $config): void
+    public function boot(AbstractKernel $kernel): void
     {
-        if ($config->isLoadClassesEnabled()) {
-            $kernel->booted($this->loadClasses(...));
-        }
-
-        if ($config->isLoadEnumsEnabled()) {
-            $kernel->booted($this->loadEnums(...));
-        }
-
-        if ($config->isLoadInterfacesEnabled()) {
-            $kernel->booted($this->loadInterfaces(...));
-        }
-
+        $kernel->booted($this->loadClasses(...));
+        $kernel->booted($this->loadEnums(...));
+        $kernel->booted($this->loadInterfaces(...));
         $kernel->booted($this->finalizeListeners(...));
     }
 
@@ -130,27 +121,36 @@ final class TokenizerListenerBootloader extends Bootloader implements
     }
 
     private function loadClasses(
+        TokenizerConfig $config,
         ClassesInterface $classes,
         ClassesLoaderInterface $loader,
         ListenerInvoker $invoker,
     ): void {
-        $this->loadReflections($invoker, $classes->getClasses(...), $loader->loadClasses(...));
+        if ($config->isLoadClassesEnabled()) {
+            $this->loadReflections($invoker, $classes->getClasses(...), $loader->loadClasses(...));
+        }
     }
 
     private function loadEnums(
+        TokenizerConfig $config,
         EnumsInterface $enums,
         EnumsLoaderInterface $loader,
         ListenerInvoker $invoker,
     ): void {
-        $this->loadReflections($invoker, $enums->getEnums(...), $loader->loadEnums(...));
+        if ($config->isLoadEnumsEnabled()) {
+            $this->loadReflections($invoker, $enums->getEnums(...), $loader->loadEnums(...));
+        }
     }
 
     private function loadInterfaces(
+        TokenizerConfig $config,
         InterfacesInterface $interfaces,
         InterfacesLoaderInterface $loader,
         ListenerInvoker $invoker,
     ): void {
-        $this->loadReflections($invoker, $interfaces->getInterfaces(...), $loader->loadInterfaces(...));
+        if ($config->isLoadInterfacesEnabled()) {
+            $this->loadReflections($invoker, $interfaces->getInterfaces(...), $loader->loadInterfaces(...));
+        }
     }
 
     /**

--- a/src/Tokenizer/tests/Bootloader/TokenizerListenerBootloaderTest.php
+++ b/src/Tokenizer/tests/Bootloader/TokenizerListenerBootloaderTest.php
@@ -14,6 +14,7 @@ use Spiral\Boot\Memory;
 use Spiral\Boot\MemoryInterface;
 use Spiral\Core\Container;
 use Spiral\Core\FactoryInterface;
+use Spiral\Tests\Tokenizer\Fixtures\TestCoreWithTokenizer;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
 use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
@@ -265,6 +266,16 @@ final class TokenizerListenerBootloaderTest extends TestCase
         $this->assertSame($expected, (new \ReflectionProperty($loader, 'readCache'))->getValue($loader));
         $this->assertSame($expected, (new \ReflectionProperty($enumLoader, 'readCache'))->getValue($enumLoader));
         $this->assertSame($expected, (new \ReflectionProperty($interfaceLoader, 'readCache'))->getValue($interfaceLoader));
+    }
+
+    public function testAddDirectoryInBootloaderInit(): void
+    {
+        $container = new Container();
+
+        $kernel = TestCoreWithTokenizer::create(directories: ['root' => __DIR__], container: $container);
+        $kernel->run();
+
+        $this->assertTrue(in_array('/foo', $container->get(TokenizerConfig::class)->getDirectories()));
     }
 
     public static function readCacheDataProvider(): \Traversable

--- a/src/Tokenizer/tests/Bootloader/TokenizerListenerBootloaderTest.php
+++ b/src/Tokenizer/tests/Bootloader/TokenizerListenerBootloaderTest.php
@@ -275,7 +275,10 @@ final class TokenizerListenerBootloaderTest extends TestCase
         $kernel = TestCoreWithTokenizer::create(directories: ['root' => __DIR__], container: $container);
         $kernel->run();
 
-        $this->assertTrue(in_array('/foo', $container->get(TokenizerConfig::class)->getDirectories()));
+        $this->assertTrue(\in_array(
+            \dirname(__DIR__) . '/Fixtures/Bootloader',
+            $container->get(TokenizerConfig::class)->getDirectories()
+        ));
     }
 
     public static function readCacheDataProvider(): \Traversable

--- a/src/Tokenizer/tests/Fixtures/Bootloader/DirectoryBootloader.php
+++ b/src/Tokenizer/tests/Fixtures/Bootloader/DirectoryBootloader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Tokenizer\Fixtures\Bootloader;
+
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
+
+final class DirectoryBootloader extends Bootloader
+{
+    public function init(TokenizerBootloader $tokenizer): void
+    {
+        $tokenizer->addDirectory('/foo');
+    }
+}

--- a/src/Tokenizer/tests/Fixtures/Bootloader/DirectoryBootloader.php
+++ b/src/Tokenizer/tests/Fixtures/Bootloader/DirectoryBootloader.php
@@ -11,6 +11,6 @@ final class DirectoryBootloader extends Bootloader
 {
     public function init(TokenizerBootloader $tokenizer): void
     {
-        $tokenizer->addDirectory('/foo');
+        $tokenizer->addDirectory(\dirname(__DIR__, 2) . '/Fixtures/Bootloader');
     }
 }

--- a/src/Tokenizer/tests/Fixtures/TestCore.php
+++ b/src/Tokenizer/tests/Fixtures/TestCore.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Tokenizer\Fixtures;
+
+use Spiral\Boot\AbstractKernel;
+use Spiral\Boot\Bootloader\CoreBootloader;
+
+class TestCore extends AbstractKernel
+{
+    protected const SYSTEM = [
+        CoreBootloader::class,
+    ];
+
+    protected function bootstrap(): void
+    {
+    }
+
+    protected function mapDirectories(array $directories): array
+    {
+        $dir = \dirname(__DIR__) . '/Fixtures';
+
+        return $directories + ['config' => $dir, 'app' => $dir, 'resources' => $dir, 'runtime' => $dir];
+    }
+}

--- a/src/Tokenizer/tests/Fixtures/TestCoreWithTokenizer.php
+++ b/src/Tokenizer/tests/Fixtures/TestCoreWithTokenizer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Tokenizer\Fixtures;
+
+use Spiral\Boot\AbstractKernel;
+use Spiral\Boot\Bootloader\CoreBootloader;
+use Spiral\Tests\Tokenizer\Fixtures\Bootloader\DirectoryBootloader;
+use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
+
+class TestCoreWithTokenizer extends AbstractKernel
+{
+    protected const SYSTEM = [
+        CoreBootloader::class,
+        TokenizerListenerBootloader::class,
+    ];
+
+    protected const LOAD = [
+        DirectoryBootloader::class,
+    ];
+
+    protected function bootstrap(): void
+    {
+    }
+
+    protected function mapDirectories(array $directories): array
+    {
+        $dir = \dirname(__DIR__) . '/Fixtures';
+
+        return $directories + ['config' => $dir, 'app' => $dir, 'resources' => $dir, 'runtime' => $dir];
+    }
+}

--- a/src/Tokenizer/tests/Listener/ListenerInvokerTest.php
+++ b/src/Tokenizer/tests/Listener/ListenerInvokerTest.php
@@ -6,18 +6,14 @@ namespace Spiral\Tests\Tokenizer\Listener;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
-use Spiral\Boot\BootloadManager\BootloadManager;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Core\Container;
-use Spiral\Tests\Boot\Fixtures\TestCore;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
 use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Listener\ClassesLoaderInterface;
 use Spiral\Tokenizer\Listener\ListenerInvoker;
 use Spiral\Tests\Tokenizer\Classes\Targets;
+use Spiral\Tests\Tokenizer\Fixtures\TestCore;
 use Spiral\Tokenizer\TokenizationListenerInterface;
 
 final class ListenerInvokerTest extends TestCase
@@ -70,9 +66,9 @@ final class ListenerInvokerTest extends TestCase
         $container->bind(ClassesInterface::class, $classes);
         $container->bind(ClassesLoaderInterface::class, $loader);
 
-        $kernel = TestCore::create(['root' => __DIR__], true, null, $container);
+        $kernel = TestCore::create(directories: ['root' => __DIR__], container: $container);
 
-        $bootloader = new TokenizerListenerBootloader();
+        $bootloader = $container->get(TokenizerListenerBootloader::class);
         $bootloader->addListener($listener);
 
         $config = new TokenizerConfig([

--- a/src/Tokenizer/tests/Listener/ListenerInvokerTest.php
+++ b/src/Tokenizer/tests/Listener/ListenerInvokerTest.php
@@ -10,7 +10,11 @@ use Spiral\Core\Container;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
 use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
+use Spiral\Tokenizer\EnumsInterface;
+use Spiral\Tokenizer\InterfacesInterface;
 use Spiral\Tokenizer\Listener\ClassesLoaderInterface;
+use Spiral\Tokenizer\Listener\EnumsLoaderInterface;
+use Spiral\Tokenizer\Listener\InterfacesLoaderInterface;
 use Spiral\Tokenizer\Listener\ListenerInvoker;
 use Spiral\Tests\Tokenizer\Classes\Targets;
 use Spiral\Tests\Tokenizer\Fixtures\TestCore;
@@ -55,8 +59,20 @@ final class ListenerInvokerTest extends TestCase
             ->once()
             ->andReturn([self::class => new \ReflectionClass($this)]);
 
-        $loader = \Mockery::mock(ClassesLoaderInterface::class);
-        $loader->shouldReceive('loadClasses')->once()->andReturnFalse();
+        $classesLoader = \Mockery::mock(ClassesLoaderInterface::class);
+        $classesLoader->shouldReceive('loadClasses')->once()->andReturnFalse();
+
+        $enums = \Mockery::mock(EnumsInterface::class);
+        $enums->shouldReceive('getEnums')->never();
+
+        $enumsLoader = \Mockery::mock(EnumsLoaderInterface::class);
+        $enumsLoader->shouldReceive('loadEnums')->never();
+
+        $interfaces = \Mockery::mock(InterfacesInterface::class);
+        $interfaces->shouldReceive('getInterfaces')->never();
+
+        $interfacesLoader = \Mockery::mock(InterfacesLoaderInterface::class);
+        $interfacesLoader->shouldReceive('loadInterfaces')->never();
 
         $listener = \Mockery::mock(TokenizationListenerInterface::class);
         $listener->shouldReceive('listen')->once();
@@ -64,22 +80,28 @@ final class ListenerInvokerTest extends TestCase
 
         $container = new Container();
         $container->bind(ClassesInterface::class, $classes);
-        $container->bind(ClassesLoaderInterface::class, $loader);
+        $container->bind(ClassesLoaderInterface::class, $classesLoader);
+        $container->bind(EnumsInterface::class, $enums);
+        $container->bind(EnumsLoaderInterface::class, $enumsLoader);
+        $container->bind(InterfacesInterface::class, $interfaces);
+        $container->bind(InterfacesLoaderInterface::class, $interfacesLoader);
+        $container->bind(TokenizerConfig::class, new TokenizerConfig([
+            'load' => [
+                'classes' => true,
+                'enums' => false,
+                'interfaces' => false,
+            ],
+        ]));
 
         $kernel = TestCore::create(directories: ['root' => __DIR__], container: $container);
 
         $bootloader = $container->get(TokenizerListenerBootloader::class);
         $bootloader->addListener($listener);
 
-        $config = new TokenizerConfig([
-            'load' => [
-                'classes' => true,
-                'enums' => false,
-                'interfaces' => false,
-            ],
-        ]);
-
-        $container->invoke([$bootloader, 'boot'], compact('kernel', 'config'));
+        $container->invoke(
+            [$bootloader, 'boot'],
+            ['kernel' => $kernel, 'config' => $container->get(TokenizerConfig::class)]
+        );
 
         $kernel->run();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌

### What was changed
1) Added fix and test for adding a `directory` to the **Tokinizer** in the **init** method of the bootloader. This way of adding directories is used, for example, here:
https://github.com/spiral/validator/blob/master/src/Bootloader/ValidatorBootloader.php#L136
After the latest Tokenizer changes, an exception throws: **Unable to patch config `tokenizer`, config object has already been delivered.**
2) The Tokinizer tests use the fixture from the tests of the **spiral/boot** component. Created a similar fixture in Tokinizer tests.
