### PR TITLE
Checking `singletons` in the hasInstance method

### DIFF
--- a/src/Core/src/Internal/Config/StateBinder.php
+++ b/src/Core/src/Internal/Config/StateBinder.php
@@ -79,11 +79,15 @@ class StateBinder implements BinderInterface
                 return $binding->alias === $alias ?: throw new Exception('Circular alias detected');
             }
 
+            if (\array_key_exists($alias, $this->state->singletons)) {
+                return true;
+            }
+
             $flags[$binding->alias] = true;
             $alias = $binding->alias;
         }
 
-        return isset($bindings[$alias]) && \is_object($bindings[$alias]);
+        return \array_key_exists($alias, $this->state->singletons) or isset($bindings[$alias]);
     }
 
     public function removeBinding(string $alias): void

--- a/src/Core/tests/Internal/Config/StateBinderTest.php
+++ b/src/Core/tests/Internal/Config/StateBinderTest.php
@@ -7,6 +7,7 @@ namespace Spiral\Tests\Core\Internal\Config;
 use Spiral\Core\BinderInterface;
 use Spiral\Core\Exception\Binder\SingletonOverloadException;
 use Spiral\Core\FactoryInterface;
+use Spiral\Tests\Core\Fixtures\SampleClass;
 use Spiral\Tests\Core\Internal\BaseTestCase;
 
 final class StateBinderTest extends BaseTestCase
@@ -37,5 +38,16 @@ final class StateBinderTest extends BaseTestCase
 
         $this->expectException(SingletonOverloadException::class);
         $binder->bind('test', new \stdClass());
+    }
+
+    public function testHasInstanceAfterMake(): void
+    {
+        $binder = $this->constructor->get('binder', BinderInterface::class);
+        $factory = $this->constructor->get('factory', FactoryInterface::class);
+
+        $this->bindSingleton('test', SampleClass::class);
+        $factory->make('test');
+
+        $this->assertTrue($binder->hasInstance('test'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

### What was changed

The **make** method on the `Spiral\Core\Internal\Factory` class removes the requested alias from the **bindings** array if it is a singleton. In the **hasInstance** method of the `Spiral\Core\Internal\Config\StateBinder` class, need to check the singletons array.

