### PR TITLE
[spiral/tokenizer] Improving `Tokenizer Info` console command

### DIFF
--- a/src/Framework/Bootloader/CommandBootloader.php
+++ b/src/Framework/Bootloader/CommandBootloader.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Command\Encrypter;
 use Spiral\Command\Router;
+use Spiral\Command\Tokenizer;
 use Spiral\Command\Translator;
 use Spiral\Command\Views;
 use Spiral\Command\CleanCommand;
@@ -18,6 +19,7 @@ use Spiral\Console\Sequence\RuntimeDirectory;
 use Spiral\Encrypter\EncryptionInterface;
 use Spiral\Files\FilesInterface;
 use Spiral\Router\RouterInterface;
+use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Translator\Config\TranslatorConfig;
 use Spiral\Translator\TranslatorInterface;
 use Spiral\Views\ViewsInterface;
@@ -60,6 +62,10 @@ final class CommandBootloader extends Bootloader
 
         if ($container->has(RouterInterface::class)) {
             $console->addCommand(Router\ListCommand::class);
+        }
+
+        if ($container->has(ClassesInterface::class)) {
+            $console->addCommand(Tokenizer\InfoCommand::class);
         }
     }
 

--- a/src/Framework/Command/Tokenizer/InfoCommand.php
+++ b/src/Framework/Command/Tokenizer/InfoCommand.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace Spiral\Command\Tokenizer;
 
 use Spiral\Boot\DirectoriesInterface;
-use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Command;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 
-#[AsCommand(
-    name: 'tokenizer:info',
-    description: 'Get information about tokenizer directories to scan'
-)]
 final class InfoCommand extends Command
 {
+    protected const NAME = 'tokenizer:info';
+    protected const DESCRIPTION = 'Get information about tokenizer directories to scan';
+
     public function perform(TokenizerConfig $config, DirectoriesInterface $dirs): int
     {
         $this->info('Included directories:');
@@ -46,8 +44,27 @@ final class InfoCommand extends Command
         $grid->render();
 
         $this->newLine();
+
+        $this->info('Loaders:');
+        $grid = $this->table(['Loader', 'Status']);
+
+        $grid->addRow(['Classes', $config->isLoadClassesEnabled()
+            ? '<info>enabled</>'
+            : '<error>disabled</>. <comment>To enable, add "TOKENIZER_LOAD_CLASSES=true" to your .env file.</>']);
+        $grid->addRow(['Enums', $config->isLoadEnumsEnabled()
+            ? '<info>enabled</>'
+            : '<error>disabled</>. <comment>To enable, add "TOKENIZER_LOAD_ENUMS=true" to your .env file.</>']);
+        $grid->addRow(
+            ['Interfaces', $config->isLoadInterfacesEnabled()
+                ? '<info>enabled</>'
+                : '<error>disabled</>. <comment>To enable, add "TOKENIZER_LOAD_INTERFACES=true" to your .env file.</>']
+        );
+
+        $grid->render();
+
+        $this->newLine();
         $this->info(
-            \sprintf('Tokenizer cache: %s', $config->isCacheEnabled() ? '<success>enabled</>' : '<error>disabled</>'),
+            \sprintf('Tokenizer cache: %s', $config->isCacheEnabled() ? '<info>enabled</>' : '<error>disabled</>'),
         );
         if (!$config->isCacheEnabled()) {
             $this->comment('To enable cache, add "TOKENIZER_CACHE_TARGETS=true" to your .env file.');

--- a/src/Tokenizer/src/Bootloader/TokenizerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerBootloader.php
@@ -70,6 +70,11 @@ final class TokenizerBootloader extends Bootloader implements SingletonInterface
                     'directory' => $dirs->get('runtime') . 'cache/listeners',
                     'enabled' => \filter_var($env->get('TOKENIZER_CACHE_TARGETS', false), \FILTER_VALIDATE_BOOL),
                 ],
+                'load' => [
+                    'classes' => \filter_var($env->get('TOKENIZER_LOAD_CLASSES', true), \FILTER_VALIDATE_BOOL),
+                    'enums' => \filter_var($env->get('TOKENIZER_LOAD_ENUMS', false), \FILTER_VALIDATE_BOOL),
+                    'interfaces' => \filter_var($env->get('TOKENIZER_LOAD_INTERFACES', false), \FILTER_VALIDATE_BOOL),
+                ],
             ],
         );
     }

--- a/src/Tokenizer/tests/Bootloader/TokenizerBootloaderTest.php
+++ b/src/Tokenizer/tests/Bootloader/TokenizerBootloaderTest.php
@@ -17,7 +17,7 @@ use Spiral\Tokenizer\Config\TokenizerConfig;
 
 final class TokenizerBootloaderTest extends TestCase
 {
-    #[DataProvider('readCacheDataProvider')]
+    #[DataProvider('boolValuesDataProvider')]
     public function testCastingReadCacheEnvVariable(mixed $readCache, bool $expected): void
     {
         $binder = m::spy(BinderInterface::class);
@@ -25,6 +25,9 @@ final class TokenizerBootloaderTest extends TestCase
         $env = m::mock(EnvironmentInterface::class);
 
         $env->shouldReceive('get')->once()->with('TOKENIZER_CACHE_TARGETS', false)->andReturn($readCache);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_CLASSES', true)->andReturn(true);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_ENUMS', false)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_INTERFACES', false)->andReturn(false);
 
         $dirs->shouldReceive('get')->once()->with('app')->andReturn('app/');
         $dirs->shouldReceive('get')->once()->with('resources')->andReturn('resources/');
@@ -40,7 +43,73 @@ final class TokenizerBootloaderTest extends TestCase
         $this->assertSame($expected, $initConfig['cache']['enabled']);
     }
 
-    public static function readCacheDataProvider(): \Traversable
+    #[DataProvider('boolValuesDataProvider')]
+    public function testCastingLoadClassesEnvVariable(mixed $classes, bool $expected): void
+    {
+        $dirs = m::mock(DirectoriesInterface::class);
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->once()->with('TOKENIZER_CACHE_TARGETS', false)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_CLASSES', true)->andReturn($classes);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_ENUMS', false)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_INTERFACES', false)->andReturn(false);
+
+        $dirs->shouldReceive('get')->once()->with('app')->andReturn('app/');
+        $dirs->shouldReceive('get')->once()->with('resources')->andReturn('resources/');
+        $dirs->shouldReceive('get')->once()->with('config')->andReturn('config/');
+        $dirs->shouldReceive('get')->once()->with('runtime')->andReturn('runtime/');
+
+        $bootloader = new TokenizerBootloader($config = new ConfigManager(new DirectoryLoader('config')));
+        $bootloader->init(m::spy(BinderInterface::class), $dirs, $env);
+
+        $this->assertSame($expected, $config->getConfig(TokenizerConfig::CONFIG)['load']['classes']);
+    }
+
+    #[DataProvider('boolValuesDataProvider')]
+    public function testCastingLoadEnumsEnvVariable(mixed $enums, bool $expected): void
+    {
+        $dirs = m::mock(DirectoriesInterface::class);
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->once()->with('TOKENIZER_CACHE_TARGETS', false)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_CLASSES', true)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_ENUMS', false)->andReturn($enums);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_INTERFACES', false)->andReturn(false);
+
+        $dirs->shouldReceive('get')->once()->with('app')->andReturn('app/');
+        $dirs->shouldReceive('get')->once()->with('resources')->andReturn('resources/');
+        $dirs->shouldReceive('get')->once()->with('config')->andReturn('config/');
+        $dirs->shouldReceive('get')->once()->with('runtime')->andReturn('runtime/');
+
+        $bootloader = new TokenizerBootloader($config = new ConfigManager(new DirectoryLoader('config')));
+        $bootloader->init(m::spy(BinderInterface::class), $dirs, $env);
+
+        $this->assertSame($expected, $config->getConfig(TokenizerConfig::CONFIG)['load']['enums']);
+    }
+
+    #[DataProvider('boolValuesDataProvider')]
+    public function testCastingLoadInterfacesEnvVariable(mixed $interfaces, bool $expected): void
+    {
+        $dirs = m::mock(DirectoriesInterface::class);
+        $env = m::mock(EnvironmentInterface::class);
+
+        $env->shouldReceive('get')->once()->with('TOKENIZER_CACHE_TARGETS', false)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_CLASSES', true)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_ENUMS', false)->andReturn(false);
+        $env->shouldReceive('get')->once()->with('TOKENIZER_LOAD_INTERFACES', false)->andReturn($interfaces);
+
+        $dirs->shouldReceive('get')->once()->with('app')->andReturn('app/');
+        $dirs->shouldReceive('get')->once()->with('resources')->andReturn('resources/');
+        $dirs->shouldReceive('get')->once()->with('config')->andReturn('config/');
+        $dirs->shouldReceive('get')->once()->with('runtime')->andReturn('runtime/');
+
+        $bootloader = new TokenizerBootloader($config = new ConfigManager(new DirectoryLoader('config')));
+        $bootloader->init(m::spy(BinderInterface::class), $dirs, $env);
+
+        $this->assertSame($expected, $config->getConfig(TokenizerConfig::CONFIG)['load']['interfaces']);
+    }
+
+    public static function boolValuesDataProvider(): \Traversable
     {
         yield [true, true];
         yield [false, false];

--- a/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
@@ -66,7 +66,12 @@ final class TokenizerBootloaderTest extends BaseTestCase
                 'cache' => [
                     'directory' => $this->getDirectoryByAlias('runtime') .'cache/listeners',
                     'enabled' => false
-                ]
+                ],
+                'load' => [
+                    'classes' => true,
+                    'enums' => false,
+                    'interfaces' => false,
+                ],
             ]
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ✔️

### Bugfixes:

1. Fixed registration of a console command in the framework.
2. Changed "success" to "info".

Before:

<img width="308" alt="11" src="https://github.com/spiral/framework/assets/67324318/467d4aa3-6926-4b8c-a9b1-4755830cbbbf">

After: 

<img width="254" alt="22" src="https://github.com/spiral/framework/assets/67324318/93bb611c-a5de-450a-bebb-edb579bd1324">

### Features:

1. Added the ability to configure classes, enums, interfaces using env variables.
2. Added information about loaders to the console command **tokenizer:info**