### PR TITLE
[spiral/queue] Adding `RetryPolicyInterceptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+- **Other Features**
+  - [spiral/queue] Added `Spiral\Queue\Interceptor\Consume\RetryPolicyInterceptor` to enable automatic job retries 
+    with a configurable retry policy.
+
 ## 3.8.0 - 2023-08-14
 - **Medium Impact Changes**
   - [spiral/scaffolder] Method `baseDirectory` of `Spiral\Scaffolder\Config\ScaffolderConfig` class is deprecated.

--- a/src/Queue/src/Attribute/RetryPolicy.php
+++ b/src/Queue/src/Attribute/RetryPolicy.php
@@ -22,16 +22,16 @@ use Spiral\Queue\RetryPolicy as Policy;
  * })
  */
 #[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
-final class RetryPolicy
+class RetryPolicy
 {
     /**
      * @param 0|positive-int $maxAttempts
      * @param positive-int $delay in seconds.
      */
     public function __construct(
-        private readonly int $maxAttempts = 3,
-        private readonly int $delay = 1,
-        private readonly float $multiplier = 1
+        protected readonly int $maxAttempts = 3,
+        protected readonly int $delay = 1,
+        protected readonly float $multiplier = 1
     ) {
     }
 

--- a/src/Queue/src/Attribute/RetryPolicy.php
+++ b/src/Queue/src/Attribute/RetryPolicy.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Attribute;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+use Spiral\Attributes\NamedArgumentConstructor;
+use Spiral\Queue\RetryPolicyInterface;
+use Spiral\Queue\RetryPolicy as Policy;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS"})
+ * @Attributes({
+ *     @Attribute("maxAttempts", type="int"),
+ *     @Attribute("delay", type="int"),
+ *     @Attribute("multiplier", type="float"),
+ * })
+ */
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+final class RetryPolicy
+{
+    /**
+     * @param 0|positive-int $maxAttempts
+     * @param positive-int $delay in seconds.
+     */
+    public function __construct(
+        private readonly int $maxAttempts = 3,
+        private readonly int $delay = 1,
+        private readonly float $multiplier = 1
+    ) {
+    }
+
+    public function getRetryPolicy(): RetryPolicyInterface
+    {
+        return new Policy(
+            maxAttempts: $this->maxAttempts,
+            delay: $this->delay,
+            multiplier: $this->multiplier
+        );
+    }
+}

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -25,7 +25,7 @@ use Spiral\Queue\Core\QueueInjector;
 use Spiral\Queue\Driver\{NullDriver, SyncDriver};
 use Spiral\Queue\Failed\{FailedJobHandlerInterface, LogFailedJobHandler};
 use Spiral\Queue\HandlerRegistryInterface;
-use Spiral\Queue\Interceptor\Consume\{Core as ConsumeCore, ErrorHandlerInterceptor, Handler};
+use Spiral\Queue\Interceptor\Consume\{Core as ConsumeCore, ErrorHandlerInterceptor, Handler, RetryPolicyInterceptor};
 use Spiral\Telemetry\Bootloader\TelemetryBootloader;
 use Spiral\Telemetry\TracerFactoryInterface;
 
@@ -164,6 +164,7 @@ final class QueueBootloader extends Bootloader
                 'interceptors' => [
                     'consume' => [
                         ErrorHandlerInterceptor::class,
+                        RetryPolicyInterceptor::class,
                     ],
                     'push' => [],
                 ],

--- a/src/Queue/src/Exception/RetryableExceptionInterface.php
+++ b/src/Queue/src/Exception/RetryableExceptionInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Exception;
+
+use Spiral\Queue\RetryPolicyInterface;
+
+interface RetryableExceptionInterface
+{
+    public function isRetryable(): bool;
+
+    public function getRetryPolicy(): ?RetryPolicyInterface;
+}

--- a/src/Queue/src/Interceptor/Consume/RetryPolicyInterceptor.php
+++ b/src/Queue/src/Interceptor/Consume/RetryPolicyInterceptor.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Interceptor\Consume;
+
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Core\CoreInterceptorInterface;
+use Spiral\Core\CoreInterface;
+use Spiral\Queue\Attribute\RetryPolicy as Attribute;
+use Spiral\Queue\Exception\JobException;
+use Spiral\Queue\Exception\RetryableExceptionInterface;
+use Spiral\Queue\Exception\RetryException;
+use Spiral\Queue\Options;
+use Spiral\Queue\RetryPolicy;
+
+final class RetryPolicyInterceptor implements CoreInterceptorInterface
+{
+    public function __construct(
+        private readonly ReaderInterface $reader
+    ) {
+    }
+
+    public function process(string $controller, string $action, array $parameters, CoreInterface $core): mixed
+    {
+        try {
+            return $core->callAction($controller, $action, $parameters);
+        } catch (\Throwable $e) {
+            $attribute = $this->reader->firstClassMetadata(new \ReflectionClass($controller), Attribute::class);
+            if ($attribute === null) {
+                throw $e;
+            }
+
+            $policy = $this->getRetryPolicy($e, $attribute);
+
+            $headers = $parameters['headers'] ?? [];
+            $attempts = (int)($headers['attempts'][0] ?? 0);
+
+            if ($policy->isRetryable($e, $attempts) === false) {
+                throw $e;
+            }
+
+            throw new RetryException(
+                reason: $e->getMessage(),
+                options: (new Options())
+                    ->withDelay($policy->getDelay($attempts))
+                    ->withHeader('attempts', (string)($attempts + 1))
+            );
+        }
+    }
+
+    private function getRetryPolicy(\Throwable $exception, Attribute $attribute): RetryPolicy
+    {
+        if ($exception instanceof JobException && $exception->getPrevious() !== null) {
+            $exception = $exception->getPrevious();
+        }
+
+        $policy = $exception instanceof RetryableExceptionInterface ? $exception->getRetryPolicy() : null;
+
+        return $policy ?? $attribute->getRetryPolicy();
+    }
+}

--- a/src/Queue/src/RetryPolicy.php
+++ b/src/Queue/src/RetryPolicy.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+use Spiral\Queue\Exception\InvalidArgumentException;
+use Spiral\Queue\Exception\JobException;
+use Spiral\Queue\Exception\RetryableExceptionInterface;
+
+final class RetryPolicy implements RetryPolicyInterface
+{
+    /**
+     * @var positive-int|0
+     */
+    private int $maxAttempts;
+
+    /**
+     * @var positive-int|0
+     */
+    private int $delay;
+
+    private float $multiplier;
+
+    /**
+     * @param positive-int|0 $maxAttempts
+     * @param positive-int|0 $delay
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(int $maxAttempts, int $delay, float $multiplier = 1)
+    {
+        if ($maxAttempts < 0) {
+            throw new InvalidArgumentException(
+                \sprintf('Maximum attempts must be greater than or equal to zero: `%s` given.', $maxAttempts)
+            );
+        }
+        $this->maxAttempts = $maxAttempts;
+
+        if ($delay < 0) {
+            throw new InvalidArgumentException(
+                \sprintf('Delay must be greater than or equal to zero: `%s` given.', $delay)
+            );
+        }
+        $this->delay = $delay;
+
+        if ($multiplier < 1) {
+            throw new InvalidArgumentException(
+                \sprintf('Multiplier must be greater than zero: `%s` given.', $multiplier)
+            );
+        }
+        $this->multiplier = $multiplier;
+    }
+
+    /**
+     * @param positive-int|0 $attempts
+     *
+     * @return positive-int
+     */
+    public function getDelay(int $attempts = 0): int
+    {
+        return (int) \ceil($this->delay * $this->multiplier ** $attempts);
+    }
+
+    /**
+     * @param positive-int|0 $attempts
+     */
+    public function isRetryable(\Throwable $exception, int $attempts = 0): bool
+    {
+        if ($exception instanceof JobException && $exception->getPrevious() !== null) {
+            $exception = $exception->getPrevious();
+        }
+
+        if (!$exception instanceof RetryableExceptionInterface || $this->maxAttempts === 0) {
+            return false;
+        }
+
+        return $exception->isRetryable() && $attempts < $this->maxAttempts;
+    }
+}

--- a/src/Queue/src/RetryPolicy.php
+++ b/src/Queue/src/RetryPolicy.php
@@ -23,9 +23,6 @@ final class RetryPolicy implements RetryPolicyInterface
     private float $multiplier;
 
     /**
-     * @param positive-int|0 $maxAttempts
-     * @param positive-int|0 $delay
-     *
      * @throws InvalidArgumentException
      */
     public function __construct(int $maxAttempts, int $delay, float $multiplier = 1)

--- a/src/Queue/src/RetryPolicyInterface.php
+++ b/src/Queue/src/RetryPolicyInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+interface RetryPolicyInterface
+{
+    /**
+     * @param positive-int|0 $attempts
+     */
+    public function isRetryable(\Throwable $exception, int $attempts = 0): bool;
+
+    /**
+     * @param positive-int|0 $attempts
+     *
+     * @return positive-int
+     */
+    public function getDelay(int $attempts = 0): int;
+}

--- a/src/Queue/tests/Attribute/RetryPolicyTest.php
+++ b/src/Queue/tests/Attribute/RetryPolicyTest.php
@@ -8,8 +8,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Spiral\Attributes\Factory;
 use Spiral\Queue\Attribute\RetryPolicy;
+use Spiral\Tests\Queue\Attribute\Stub\ExtendedRetryPolicy;
 use Spiral\Tests\Queue\Attribute\Stub\WithDefaultRetryPolicyAnnotation;
 use Spiral\Tests\Queue\Attribute\Stub\WithDefaultRetryPolicyAttribute;
+use Spiral\Tests\Queue\Attribute\Stub\WithExtendedRetryPolicyAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\WithExtendedRetryPolicyAttribute;
 use Spiral\Tests\Queue\Attribute\Stub\WithoutRetryPolicy;
 use Spiral\Tests\Queue\Attribute\Stub\WithRetryPolicyAnnotation;
 use Spiral\Tests\Queue\Attribute\Stub\WithRetryPolicyAttribute;
@@ -31,5 +34,7 @@ final class RetryPolicyTest extends TestCase
         yield [WithDefaultRetryPolicyAttribute::class, new RetryPolicy()];
         yield [WithRetryPolicyAnnotation::class, new RetryPolicy(5, 3_000, 2.5)];
         yield [WithRetryPolicyAttribute::class, new RetryPolicy(5, 3_000, 2.5)];
+        yield [WithExtendedRetryPolicyAttribute::class, new ExtendedRetryPolicy()];
+        yield [WithExtendedRetryPolicyAnnotation::class, new ExtendedRetryPolicy()];
     }
 }

--- a/src/Queue/tests/Attribute/RetryPolicyTest.php
+++ b/src/Queue/tests/Attribute/RetryPolicyTest.php
@@ -20,7 +20,7 @@ use Spiral\Tests\Queue\Attribute\Stub\WithRetryPolicyAttribute;
 final class RetryPolicyTest extends TestCase
 {
     #[DataProvider('classesProvider')]
-    public function testQueueable(string $class, ?RetryPolicy $expected): void
+    public function testRetryPolicy(string $class, ?RetryPolicy $expected): void
     {
         $reader = (new Factory())->create();
 

--- a/src/Queue/tests/Attribute/RetryPolicyTest.php
+++ b/src/Queue/tests/Attribute/RetryPolicyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\Attributes\Factory;
+use Spiral\Queue\Attribute\RetryPolicy;
+use Spiral\Tests\Queue\Attribute\Stub\WithDefaultRetryPolicyAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\WithDefaultRetryPolicyAttribute;
+use Spiral\Tests\Queue\Attribute\Stub\WithoutRetryPolicy;
+use Spiral\Tests\Queue\Attribute\Stub\WithRetryPolicyAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\WithRetryPolicyAttribute;
+
+final class RetryPolicyTest extends TestCase
+{
+    #[DataProvider('classesProvider')]
+    public function testQueueable(string $class, ?RetryPolicy $expected): void
+    {
+        $reader = (new Factory())->create();
+
+        $this->assertEquals($expected, $reader->firstClassMetadata(new \ReflectionClass($class), RetryPolicy::class));
+    }
+
+    public static function classesProvider(): \Traversable
+    {
+        yield [WithoutRetryPolicy::class, null];
+        yield [WithDefaultRetryPolicyAnnotation::class, new RetryPolicy()];
+        yield [WithDefaultRetryPolicyAttribute::class, new RetryPolicy()];
+        yield [WithRetryPolicyAnnotation::class, new RetryPolicy(5, 3_000, 2.5)];
+        yield [WithRetryPolicyAttribute::class, new RetryPolicy(5, 3_000, 2.5)];
+    }
+}

--- a/src/Queue/tests/Attribute/Stub/ExtendedRetryPolicy.php
+++ b/src/Queue/tests/Attribute/Stub/ExtendedRetryPolicy.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+use Spiral\Attributes\NamedArgumentConstructor;
+use Spiral\Queue\Attribute\RetryPolicy;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS"})
+ */
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+final class ExtendedRetryPolicy extends RetryPolicy
+{
+    public function __construct()
+    {
+        parent::__construct(maxAttempts: 10, delay: 12, multiplier: 5);
+    }
+}

--- a/src/Queue/tests/Attribute/Stub/WithDefaultRetryPolicyAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/WithDefaultRetryPolicyAnnotation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\RetryPolicy;
+
+/**
+ * @RetryPolicy
+ */
+final class WithDefaultRetryPolicyAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithDefaultRetryPolicyAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/WithDefaultRetryPolicyAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\RetryPolicy;
+
+#[RetryPolicy]
+final class WithDefaultRetryPolicyAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithExtendedRetryPolicyAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/WithExtendedRetryPolicyAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+/**
+ * @ExtendedRetryPolicy
+ */
+final class WithExtendedRetryPolicyAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithExtendedRetryPolicyAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/WithExtendedRetryPolicyAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+#[ExtendedRetryPolicy]
+final class WithExtendedRetryPolicyAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithRetryPolicyAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/WithRetryPolicyAnnotation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\RetryPolicy;
+
+/**
+ * @RetryPolicy(maxAttempts=5, delay=3000, multiplier=2.5)
+ */
+final class WithRetryPolicyAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithRetryPolicyAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/WithRetryPolicyAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\RetryPolicy;
+
+#[RetryPolicy(maxAttempts: 5, delay: 3_000, multiplier: 2.5)]
+final class WithRetryPolicyAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithoutRetryPolicy.php
+++ b/src/Queue/tests/Attribute/Stub/WithoutRetryPolicy.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+final class WithoutRetryPolicy
+{
+}

--- a/src/Queue/tests/Exception/TestRetryException.php
+++ b/src/Queue/tests/Exception/TestRetryException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Exception;
+
+use Spiral\Queue\Exception\RetryableExceptionInterface;
+use Spiral\Queue\RetryPolicyInterface;
+
+final class TestRetryException extends \Exception implements RetryableExceptionInterface
+{
+    public function __construct(
+        private readonly bool $retryable = true,
+        private readonly ?RetryPolicyInterface $retryPolicy = null
+    ) {
+    }
+
+    public function isRetryable(): bool
+    {
+        return $this->retryable;
+    }
+
+    public function getRetryPolicy(): ?RetryPolicyInterface
+    {
+        return $this->retryPolicy;
+    }
+}

--- a/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Interceptor\Consume;
+
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Core\CoreInterface;
+use Spiral\Queue\Attribute\RetryPolicy;
+use Spiral\Queue\Exception\JobException;
+use Spiral\Queue\Exception\RetryException;
+use Spiral\Queue\Interceptor\Consume\RetryPolicyInterceptor;
+use Spiral\Tests\Queue\Exception\TestRetryException;
+use Spiral\Tests\Queue\TestCase;
+
+final class RetryPolicyInterceptorTest extends TestCase
+{
+    private ReaderInterface $reader;
+    private CoreInterface $core;
+    private RetryPolicyInterceptor $interceptor;
+
+    protected function setUp(): void
+    {
+        $this->reader = $this->createMock(ReaderInterface::class);
+        $this->core = $this->createMock(CoreInterface::class);
+        $this->interceptor = new RetryPolicyInterceptor($this->reader);
+    }
+
+    public function testWithoutException(): void
+    {
+        $this->reader->expects($this->never())->method('firstClassMetadata');
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with('foo', 'bar', [])
+            ->willReturn('result');
+
+        $this->assertSame('result', $this->interceptor->process('foo', 'bar', [], $this->core));
+    }
+
+    public function testWithoutRetryPolicy(): void
+    {
+        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(null);
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with(self::class, 'bar', [])
+            ->willThrowException(new \Exception('Something went wrong'));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Something went wrong');
+        $this->interceptor->process(self::class, 'bar', [], $this->core);
+    }
+
+    public function testNotRetryableException(): void
+    {
+        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(new RetryPolicy());
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with(self::class, 'bar', [])
+            ->willThrowException(new \Exception('Something went wrong'));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Something went wrong');
+        $this->interceptor->process(self::class, 'bar', [], $this->core);
+    }
+
+    public function testWithDefaultRetryPolicy(): void
+    {
+        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(new RetryPolicy());
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with(self::class, 'bar', [])
+            ->willThrowException(new TestRetryException());
+
+        try {
+            $this->interceptor->process(self::class, 'bar', [], $this->core);
+        } catch (RetryException $e) {
+            $this->assertSame(1, $e->getOptions()->getDelay());
+            $this->assertSame(['attempts' => ['1']], $e->getOptions()->getHeaders());
+        }
+    }
+
+    public function testWithRetryPolicyInAttribute(): void
+    {
+        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+            new RetryPolicy(maxAttempts: 3, delay: 4, multiplier: 2)
+        );
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with(self::class, 'bar', ['headers' => ['attempts' => ['1']]])
+            ->willThrowException(new TestRetryException());
+
+        try {
+            $this->interceptor->process(
+                self::class,
+                'bar',
+                ['headers' => ['attempts' => ['1']]],
+                $this->core
+            );
+        } catch (RetryException $e) {
+            $this->assertSame(8, $e->getOptions()->getDelay());
+            $this->assertSame(['attempts' => ['2']], $e->getOptions()->getHeaders());
+        }
+    }
+
+    public function testWithRetryPolicyInException(): void
+    {
+        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+            new RetryPolicy(maxAttempts: 30, delay: 400, multiplier: 25)
+        );
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with(self::class, 'bar', ['headers' => ['attempts' => ['1']]])
+            ->willThrowException(new TestRetryException(
+                retryPolicy: new \Spiral\Queue\RetryPolicy(maxAttempts: 3, delay: 4, multiplier: 2)
+            ));
+
+        try {
+            $this->interceptor->process(
+                self::class,
+                'bar',
+                ['headers' => ['attempts' => ['1']]],
+                $this->core
+            );
+        } catch (RetryException $e) {
+            $this->assertSame(8, $e->getOptions()->getDelay());
+            $this->assertSame(['attempts' => ['2']], $e->getOptions()->getHeaders());
+        }
+    }
+
+    public function testWithRetryPolicyInExceptionInsideJobException(): void
+    {
+        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+            new RetryPolicy(maxAttempts: 30, delay: 400, multiplier: 25)
+        );
+
+        $this->core
+            ->expects($this->once())
+            ->method('callAction')
+            ->with(self::class, 'bar', ['headers' => ['attempts' => ['1']]])
+            ->willThrowException(new JobException(
+                previous: new TestRetryException(
+                    retryPolicy: new \Spiral\Queue\RetryPolicy(maxAttempts: 3, delay: 4, multiplier: 2)
+                )
+            ));
+
+        try {
+            $this->interceptor->process(
+                self::class,
+                'bar',
+                ['headers' => ['attempts' => ['1']]],
+                $this->core
+            );
+        } catch (RetryException $e) {
+            $this->assertSame(8, $e->getOptions()->getDelay());
+            $this->assertSame(['attempts' => ['2']], $e->getOptions()->getHeaders());
+        }
+    }
+}

--- a/src/Queue/tests/RetryPolicyTest.php
+++ b/src/Queue/tests/RetryPolicyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Spiral\Queue\Exception\InvalidArgumentException;
+use Spiral\Queue\RetryPolicy;
+use Spiral\Tests\Queue\Exception\TestRetryException;
+
+final class RetryPolicyTest extends TestCase
+{
+    public function testInvalidMaxAttempts(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Maximum attempts must be greater than or equal to zero: `-1` given.');
+        new RetryPolicy(-1, 0);
+    }
+
+    public function testInvalidDelay(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Delay must be greater than or equal to zero: `-1` given.');
+        new RetryPolicy(1, -1);
+    }
+
+    public function testInvalidMultiplier(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multiplier must be greater than zero: `-1` given.');
+        new RetryPolicy(1, 1, -1);
+    }
+
+    #[DataProvider('retryableDataProvider')]
+    public function testIsRetryable(\Throwable $exception, int $attempts, bool $expected): void
+    {
+        $policy = new RetryPolicy(1, 0);
+
+        $this->assertSame($expected, $policy->isRetryable($exception, $attempts));
+    }
+
+    public function testGetDelayWithoutMultiplier(): void
+    {
+        $policy = new RetryPolicy(4, 1_000);
+
+        $this->assertSame(1_000, $policy->getDelay());
+        $this->assertSame(1_000, $policy->getDelay(1));
+        $this->assertSame(1_000, $policy->getDelay(2));
+        $this->assertSame(1_000, $policy->getDelay(3));
+        $this->assertSame(1_000, $policy->getDelay(4));
+    }
+
+    public function testGetDelayWithMultiplier(): void
+    {
+        $policy = new RetryPolicy(4, 1_000, 2);
+
+        $this->assertSame(1_000, $policy->getDelay());
+        $this->assertSame(2_000, $policy->getDelay(1));
+        $this->assertSame(4_000, $policy->getDelay(2));
+        $this->assertSame(8_000, $policy->getDelay(3));
+        $this->assertSame(16_000, $policy->getDelay(4));
+    }
+
+    public static function retryableDataProvider(): \Traversable
+    {
+        yield [new \DomainException(), 0, false];
+        yield [new \DomainException(), 1, false];
+        yield [new TestRetryException(), 0, true];
+        yield [new TestRetryException(), 1, false];
+        yield [new TestRetryException(false), 0, false];
+        yield [new TestRetryException(false), 1, false];
+    }
+}

--- a/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
+++ b/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
@@ -83,6 +83,7 @@ final class QueueBootloaderTest extends BaseTestCase
             'interceptors' => [
                 'consume' => [
                     \Spiral\Queue\Interceptor\Consume\ErrorHandlerInterceptor::class,
+                    \Spiral\Queue\Interceptor\Consume\RetryPolicyInterceptor::class,
                 ],
                 'push' => []
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #911

### What was changed

Added `Spiral\Queue\Interceptor\Consume\RetryPolicyInterceptor` to enable automatic job retries with a configurable retry policy. To use it, need to add the `Spiral\Queue\Attribute\RetryPolicy` attribute to the job class:

```php
use Spiral\Queue\Attribute\RetryPolicy;
use Spiral\Queue\JobHandler;

#[RetryPolicy(maxAttempts: 3, delay: 5, multiplier: 2)]
final class Ping extends JobHandler
{
    public function invoke(array $payload): void
    {
        // ...
    }
}
```

Create an exception that implements interface `Spiral\Queue\Exception\RetryableExceptionInterface`:

```php
use Spiral\Queue\Exception\RetryableExceptionInterface;
use Spiral\Queue\RetryPolicyInterface;

class RetryException extends \DomainException implements RetryableExceptionInterface
{
    public function isRetryable(): bool
    {
        return true;
    }

    public function getRetryPolicy(): ?RetryPolicyInterface
    {
        return null;
    }
}
```

The exception must implement the two methods **isRetryable** and **getRetryPolicy**. These methods can override the retry behavior and cancel the re-queue- or change the retry policy.

**If a `RetryException` is thrown while a job runs, the job will be re-queued according to the retry policy.**





