### PR TITLE
[spiral/queue] Adding the ability to configure serializer and job type via attributes

### DIFF
--- a/src/Queue/composer.json
+++ b/src/Queue/composer.json
@@ -34,6 +34,7 @@
         "spiral/serializer": "^3.9",
         "spiral/snapshots": "^3.9",
         "spiral/telemetry": "^3.9",
+        "spiral/tokenizer": "^3.9",
         "spiral/attributes": "^2.8|^3.0",
         "doctrine/inflector": "^1.4|^2.0",
         "ramsey/uuid": "^4.2.3",

--- a/src/Queue/src/Attribute/JobHandler.php
+++ b/src/Queue/src/Attribute/JobHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Attribute;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+use Spiral\Attributes\NamedArgumentConstructor;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS"})
+ * @Attributes({
+ *     @Attribute("type", type="string")
+ * })
+ */
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+class JobHandler
+{
+    public function __construct(
+        public readonly string $type
+    ) {
+    }
+}

--- a/src/Queue/src/Attribute/Serializer.php
+++ b/src/Queue/src/Attribute/Serializer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue\Attribute;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+use Spiral\Attributes\NamedArgumentConstructor;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS"})
+ * @Attributes({
+ *     @Attribute("serializer", type="string")
+ * })
+ */
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+class Serializer
+{
+    public function __construct(
+        public readonly string $serializer
+    ) {
+    }
+}

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -13,12 +13,13 @@ use Spiral\Config\Patch\Append;
 use Spiral\Core\{BinderInterface, FactoryInterface, InterceptableCore};
 use Spiral\Core\Container\Autowire;
 use Spiral\Core\CoreInterceptorInterface;
-use Spiral\Queue\{QueueConnectionProviderInterface,
+use Spiral\Queue\{JobHandlerLocatorListener,
+    QueueConnectionProviderInterface,
     QueueInterface,
     QueueManager,
     QueueRegistry,
-    SerializerRegistryInterface
-};
+    SerializerLocatorListener,
+    SerializerRegistryInterface};
 use Spiral\Queue\Config\QueueConfig;
 use Spiral\Queue\ContainerRegistry;
 use Spiral\Queue\Core\QueueInjector;
@@ -28,10 +29,13 @@ use Spiral\Queue\HandlerRegistryInterface;
 use Spiral\Queue\Interceptor\Consume\{Core as ConsumeCore, ErrorHandlerInterceptor, Handler};
 use Spiral\Telemetry\Bootloader\TelemetryBootloader;
 use Spiral\Telemetry\TracerFactoryInterface;
+use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
+use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
 
 final class QueueBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
+        TokenizerListenerBootloader::class,
         TelemetryBootloader::class,
     ];
 
@@ -73,6 +77,15 @@ final class QueueBootloader extends Bootloader
                 $registry->setSerializer($jobType, $serializer);
             }
         });
+    }
+
+    public function boot(
+        TokenizerListenerRegistryInterface $listenerRegistry,
+        JobHandlerLocatorListener $jobHandlerLocator,
+        SerializerLocatorListener $serializerLocator
+    ): void {
+        $listenerRegistry->addListener($jobHandlerLocator);
+        $listenerRegistry->addListener($serializerLocator);
     }
 
     /**

--- a/src/Queue/src/JobHandlerLocatorListener.php
+++ b/src/Queue/src/JobHandlerLocatorListener.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Queue\Attribute\JobHandler as Attribute;
+use Spiral\Tokenizer\Attribute\TargetAttribute;
+use Spiral\Tokenizer\TokenizationListenerInterface;
+
+#[TargetAttribute(Attribute::class)]
+final class JobHandlerLocatorListener implements TokenizationListenerInterface
+{
+    public function __construct(
+        private readonly ReaderInterface $reader,
+        private readonly QueueRegistry $registry
+    ) {
+    }
+
+    public function listen(\ReflectionClass $class): void
+    {
+        $attribute = $this->reader->firstClassMetadata($class, Attribute::class);
+        if ($attribute === null) {
+            return;
+        }
+
+        $this->registry->setHandler($attribute->type, $class->getName());
+    }
+
+    public function finalize(): void
+    {
+    }
+}

--- a/src/Queue/tests/Attribute/JobHandlerTest.php
+++ b/src/Queue/tests/Attribute/JobHandlerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\Attributes\Factory;
+use Spiral\Queue\Attribute\JobHandler;
+use Spiral\Tests\Queue\Attribute\Stub\ExtendedJobHandler;
+use Spiral\Tests\Queue\Attribute\Stub\JobHandlerAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\JobHandlerAttribute;
+use Spiral\Tests\Queue\Attribute\Stub\WithExtendedJobHandlerAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\WithExtendedJobHandlerAttribute;
+use Spiral\Tests\Queue\Attribute\Stub\WithoutJobHandler;
+
+final class JobHandlerTest extends TestCase
+{
+    #[DataProvider('classesProvider')]
+    public function testJobHandler(string $class, ?JobHandler $expected): void
+    {
+        $reader = (new Factory())->create();
+
+        $this->assertEquals($expected, $reader->firstClassMetadata(new \ReflectionClass($class), JobHandler::class));
+    }
+
+    public static function classesProvider(): \Traversable
+    {
+        yield [WithoutJobHandler::class, null];
+        yield [JobHandlerAnnotation::class, new JobHandler('test')];
+        yield [JobHandlerAttribute::class, new JobHandler('test')];
+        yield [WithExtendedJobHandlerAnnotation::class, new ExtendedJobHandler()];
+        yield [WithExtendedJobHandlerAttribute::class, new ExtendedJobHandler()];
+    }
+}

--- a/src/Queue/tests/Attribute/SerializerTest.php
+++ b/src/Queue/tests/Attribute/SerializerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\Attributes\Factory;
+use Spiral\Queue\Attribute\Serializer;
+use Spiral\Tests\Queue\Attribute\Stub\ExtendedSerializer;
+use Spiral\Tests\Queue\Attribute\Stub\SerializerAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\SerializerAttribute;
+use Spiral\Tests\Queue\Attribute\Stub\WithExtendedSerializerAnnotation;
+use Spiral\Tests\Queue\Attribute\Stub\WithExtendedSerializerAttribute;
+use Spiral\Tests\Queue\Attribute\Stub\WithoutSerializer;
+
+final class SerializerTest extends TestCase
+{
+    #[DataProvider('classesProvider')]
+    public function testSerializer(string $class, ?Serializer $expected): void
+    {
+        $reader = (new Factory())->create();
+
+        $this->assertEquals($expected, $reader->firstClassMetadata(new \ReflectionClass($class), Serializer::class));
+    }
+
+    public static function classesProvider(): \Traversable
+    {
+        yield [WithoutSerializer::class, null];
+        yield [SerializerAnnotation::class, new Serializer('test')];
+        yield [SerializerAttribute::class, new Serializer('test')];
+        yield [WithExtendedSerializerAnnotation::class, new ExtendedSerializer()];
+        yield [WithExtendedSerializerAttribute::class, new ExtendedSerializer()];
+    }
+}

--- a/src/Queue/tests/Attribute/Stub/ExtendedJobHandler.php
+++ b/src/Queue/tests/Attribute/Stub/ExtendedJobHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\JobHandler;
+use Doctrine\Common\Annotations\Annotation\Target;
+use Spiral\Attributes\NamedArgumentConstructor;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS"})
+ */
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+final class ExtendedJobHandler extends JobHandler
+{
+    public function __construct()
+    {
+        parent::__construct('bar');
+    }
+}

--- a/src/Queue/tests/Attribute/Stub/ExtendedSerializer.php
+++ b/src/Queue/tests/Attribute/Stub/ExtendedSerializer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+use Spiral\Attributes\NamedArgumentConstructor;
+use Spiral\Queue\Attribute\Serializer;
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS"})
+ */
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+final class ExtendedSerializer extends Serializer
+{
+    public function __construct()
+    {
+        parent::__construct('foo');
+    }
+}

--- a/src/Queue/tests/Attribute/Stub/JobHandlerAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/JobHandlerAnnotation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\JobHandler;
+
+/**
+ * @JobHandler(type="test")
+ */
+final class JobHandlerAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/JobHandlerAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/JobHandlerAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\JobHandler;
+
+#[JobHandler(type: 'test')]
+final class JobHandlerAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/SerializerAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/SerializerAnnotation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\Serializer;
+
+/**
+ * @Serializer(serializer="test")
+ */
+final class SerializerAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/SerializerAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/SerializerAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+use Spiral\Queue\Attribute\Serializer;
+
+#[Serializer(serializer: 'test')]
+final class SerializerAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithExtendedJobHandlerAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/WithExtendedJobHandlerAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+/**
+ * @ExtendedJobHandler
+ */
+final class WithExtendedJobHandlerAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithExtendedJobHandlerAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/WithExtendedJobHandlerAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+#[ExtendedJobHandler]
+final class WithExtendedJobHandlerAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithExtendedSerializerAnnotation.php
+++ b/src/Queue/tests/Attribute/Stub/WithExtendedSerializerAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+/**
+ * @ExtendedSerializer
+ */
+final class WithExtendedSerializerAnnotation
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithExtendedSerializerAttribute.php
+++ b/src/Queue/tests/Attribute/Stub/WithExtendedSerializerAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+#[ExtendedSerializer]
+final class WithExtendedSerializerAttribute
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithoutJobHandler.php
+++ b/src/Queue/tests/Attribute/Stub/WithoutJobHandler.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+final class WithoutJobHandler
+{
+}

--- a/src/Queue/tests/Attribute/Stub/WithoutSerializer.php
+++ b/src/Queue/tests/Attribute/Stub/WithoutSerializer.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue\Attribute\Stub;
+
+final class WithoutSerializer
+{
+}

--- a/src/Queue/tests/JobHandlerLocatorListenerTest.php
+++ b/src/Queue/tests/JobHandlerLocatorListenerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Core\Container;
+use Spiral\Core\InvokerInterface;
+use Spiral\Queue\Attribute\JobHandler as Attribute;
+use Spiral\Queue\HandlerInterface;
+use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\JobHandler;
+use Spiral\Queue\JobHandlerLocatorListener;
+use Spiral\Queue\QueueRegistry;
+
+final class JobHandlerLocatorListenerTest extends TestCase
+{
+    public function testListen(): void
+    {
+        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+
+        $registry = new QueueRegistry(
+            new Container(),
+            new Container(),
+            $this->createMock(HandlerRegistryInterface::class)
+        );
+
+        $reader = $this->createMock(ReaderInterface::class);
+        $reader
+            ->expects($this->once())
+            ->method('firstClassMetadata')
+            ->willReturn(new Attribute('test'));
+
+        $listener = new JobHandlerLocatorListener($reader, $registry);
+        $listener->listen(new \ReflectionClass($handler::class));
+
+        $this->assertInstanceOf(HandlerInterface::class, $registry->getHandler('test'));
+    }
+}

--- a/src/Queue/tests/SerializerLocatorListenerTest.php
+++ b/src/Queue/tests/SerializerLocatorListenerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use Mockery as m;
+use Spiral\Attributes\ReaderInterface;
+use Spiral\Core\Container;
+use Spiral\Core\InvokerInterface;
+use Spiral\Queue\Attribute\Serializer;
+use Spiral\Queue\Config\QueueConfig;
+use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\JobHandler;
+use Spiral\Queue\QueueRegistry;
+use Spiral\Queue\SerializerLocatorListener;
+use Spiral\Serializer\Serializer\PhpSerializer;
+use Spiral\Serializer\SerializerRegistry;
+use Spiral\Serializer\SerializerRegistryInterface;
+
+final class SerializerLocatorListenerTest extends TestCase
+{
+    public function testListenWithJobTypeFromConfig(): void
+    {
+        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+
+        $container = new Container();
+        $container->bind('test', new PhpSerializer());
+        $container->bind(SerializerRegistryInterface::class, SerializerRegistry::class);
+
+        $registry = new QueueRegistry(
+            $container,
+            $container,
+            $this->createMock(HandlerRegistryInterface::class)
+        );
+
+        $reader = m::mock(ReaderInterface::class);
+        $reader
+            ->shouldReceive('firstClassMetadata')
+            ->with(m::type(\ReflectionClass::class), Serializer::class)
+            ->andReturn(new Serializer('test'));
+        $reader
+            ->shouldReceive('firstClassMetadata')
+            ->with(m::type(\ReflectionClass::class), \Spiral\Queue\Attribute\JobHandler::class)
+            ->andReturnNull();
+
+        $listener = new SerializerLocatorListener($reader, $registry, new QueueConfig([
+            'registry' => [
+                'handlers' => [
+                    $handler::class => $handler::class,
+                ]
+            ]
+        ]));
+        $listener->listen(new \ReflectionClass($handler::class));
+
+        $this->assertEquals(new PhpSerializer(), $registry->getSerializer($handler::class));
+    }
+
+    public function testListenWithJobTypeFromAttribute(): void
+    {
+        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+
+        $container = new Container();
+        $container->bind('test', new PhpSerializer());
+        $container->bind(SerializerRegistryInterface::class, SerializerRegistry::class);
+
+        $registry = new QueueRegistry(
+            $container,
+            $container,
+            $this->createMock(HandlerRegistryInterface::class)
+        );
+
+        $reader = m::mock(ReaderInterface::class);
+        $reader
+            ->shouldReceive('firstClassMetadata')
+            ->with(m::type(\ReflectionClass::class), Serializer::class)
+            ->andReturn(new Serializer('test'));
+        $reader
+            ->shouldReceive('firstClassMetadata')
+            ->with(m::type(\ReflectionClass::class), \Spiral\Queue\Attribute\JobHandler::class)
+            ->andReturn(new \Spiral\Queue\Attribute\JobHandler('test'));
+
+        $listener = new SerializerLocatorListener($reader, $registry, new QueueConfig([
+            'registry' => [
+                'handlers' => [
+                    'test' => $handler::class,
+                ]
+            ]
+        ]));
+        $listener->listen(new \ReflectionClass($handler::class));
+
+        $this->assertEquals(new PhpSerializer(), $registry->getSerializer('test'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #909 

### What was changed

Added ability to configure serializer and job type using attributes.

```php
use App\Domain\User\Entity\User;
use Spiral\Queue\Attribute\Serializer;
use Spiral\Queue\Attribute\JobHandler as Handler;
use Spiral\Queue\JobHandler;

#[Handler('ping')]
#[Serializer('marshaller-json')]
final class Ping extends JobHandler
{
    public function invoke(User $payload): void
    {
        // ...
    }
}

```