### PR TITLE
Assigning `null` instead of using `unset` in the reset method

### DIFF
--- a/src/Framework/Debug/StateCollector/HttpCollector.php
+++ b/src/Framework/Debug/StateCollector/HttpCollector.php
@@ -46,6 +46,6 @@ final class HttpCollector implements MiddlewareInterface, StateCollectorInterfac
      */
     public function reset(): void
     {
-        unset($this->request);
+        $this->request = null;
     }
 }

--- a/tests/Framework/Debug/HttpCollectorTest.php
+++ b/tests/Framework/Debug/HttpCollectorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Debug\StateCollector\HttpCollector;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class HttpCollectorTest extends TestCase
+{
+    public function testReset(): void
+    {
+        $collector = new HttpCollector();
+        $collector->process(
+            $this->createMock(ServerRequestInterface::class),
+            $this->createMock(RequestHandlerInterface::class)
+        );
+        $collector->reset();
+
+        $this->assertNull((new \ReflectionProperty($collector, 'request'))->getValue($collector));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | #983 