### PR TITLE
[spiral/router] Adding host check when importing routes via RoutingConfigurator

### DIFF
--- a/src/Router/src/Router.php
+++ b/src/Router/src/Router.php
@@ -147,7 +147,10 @@ final class Router implements RouterInterface
                 $target = $target->withCore($configurator->core);
             }
 
-            $route = new Route(\ltrim($configurator->pattern, '/'), $target, $configurator->defaults);
+            $pattern = \str_starts_with($configurator->pattern, '//')
+                ? $configurator->pattern
+                : \ltrim($configurator->pattern, '/');
+            $route = new Route($pattern, $target, $configurator->defaults);
 
             if ($configurator->middleware !== null) {
                 $route = $route->withMiddleware(...$configurator->middleware);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | #988 

### What's was changed

Fixed an error when importing routes with a pattern starting with **host**. For example:
```php
protected function defineRoutes(RoutingConfigurator $routes): void
{
    $routes->add('test', '//<host>/register-configurator')->callable(fn () => 'foo');
}
```

Before changes:

<img width="870" alt="222" src="https://github.com/spiral/framework/assets/67324318/80dcf618-66a2-4aee-882b-a67d592c6589">

After changes:

<img width="874" alt="333" src="https://github.com/spiral/framework/assets/67324318/1bb67a6b-5950-40fb-9ca9-11b757b7081f">

