### PR TITLE
[spiral/scaffolder] Changing job payload type from `array` to `mixed` 

### DIFF
--- a/src/Scaffolder/src/Declaration/JobHandlerDeclaration.php
+++ b/src/Scaffolder/src/Declaration/JobHandlerDeclaration.php
@@ -25,7 +25,7 @@ class JobHandlerDeclaration extends AbstractDeclaration implements HasInstructio
             ->setType('string');
 
         $method->addParameter('payload')
-            ->setType('array');
+            ->setType('mixed');
 
         $method->addParameter('headers')
             ->setType('array');

--- a/src/Scaffolder/tests/Command/JobHandlerTest.php
+++ b/src/Scaffolder/tests/Command/JobHandlerTest.php
@@ -32,6 +32,7 @@ class JobHandlerTest extends AbstractCommandTestCase
         $this->assertStringContainsString('strict_types=1', $content);
         $this->assertStringContainsString('{project-name}', $content);
         $this->assertStringContainsString('@author {author-name}', $content);
+        $this->assertStringContainsString('function invoke(string $id, mixed $payload, array $headers)', $content);
         $this->assertStringContainsString('Sample Job Handler', $reflection->getDocComment());
         $this->assertTrue($reflection->hasMethod('invoke'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | #943 

### What was changed

Changed the type of payload in the generated JobHandler from array to mixed.

```php

use Spiral\Queue\JobHandler;

/**
 * Sample Job Handler
 */
final class SampleJob extends JobHandler
{
    public function invoke(string $id, mixed $payload, array $headers): void
    {
    }
}
```