### PR TITLE
Adding running bridges tests to phpunit.xml config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,9 @@
         <testsuite name="Components Test Suite">
             <directory suffix="Test.php">src/*/tests</directory>
         </testsuite>
+        <testsuite name="Bridges Test Suite">
+            <directory suffix="Test.php">src/Bridge/*/tests</directory>
+        </testsuite>
         <testsuite name="Framework Test Suite">
             <directory>tests</directory>
         </testsuite>

--- a/src/Bridge/Dotenv/tests/LoadTest.php
+++ b/src/Bridge/Dotenv/tests/LoadTest.php
@@ -7,7 +7,6 @@ namespace Spiral\Tests\DotEnv;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
-use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Directories;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\DotEnv\Bootloader\DotenvBootloader;
@@ -16,33 +15,38 @@ final class LoadTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function testUseKernelCallback(): void
+    public function testSetValue(): void
     {
-        $d = new Directories(['root' => __DIR__.'/']);
+        $dirs = new Directories(['root' => __DIR__.'/']);
 
-        $e = m::mock(EnvironmentInterface::class);
-        $e->shouldReceive('get')->once()->withSomeOfArgs('DOTENV_PATH')->andReturn($d->get('root').'.env.custom');
-        $e->shouldReceive('set')->once()->with('KEY', 'custom_value');
-
-        $k = m::mock(AbstractKernel::class);
-        $k->shouldReceive('running')->once()->andReturnUsing(fn(\Closure $callback) => $callback($e));
+        $env = m::mock(EnvironmentInterface::class);
+        $env
+            ->shouldReceive('get')
+            ->once()
+            ->withSomeOfArgs('DOTENV_PATH')
+            ->andReturn($dirs->get('root') . '.env.custom');
+        $env->shouldReceive('set')
+            ->once()->with('KEY', 'custom_value');
 
         $b = new DotenvBootloader();
-        $b->init($k, $d);
+        $b->init($dirs, $env);
     }
 
     public function testNotFound(): void
     {
-        $d = new Directories(['root' => __DIR__.'/']);
+        $dirs = new Directories(['root' => __DIR__.'/']);
 
-        $e = m::mock(EnvironmentInterface::class);
-        $e->shouldReceive('get')->once()->withSomeOfArgs('DOTENV_PATH')->andReturn($d->get('root').'.env');
-        $e->shouldNotReceive('set')->with('KEY', 'custom_value');
-
-        $k = m::mock(AbstractKernel::class);
-        $k->shouldReceive('running')->once()->andReturnUsing(fn(\Closure $callback) => $callback($e));
+        $env = m::mock(EnvironmentInterface::class);
+        $env
+            ->shouldReceive('get')
+            ->once()
+            ->withSomeOfArgs('DOTENV_PATH')
+            ->andReturn($dirs->get('root').'.env');
+        $env
+            ->shouldNotReceive('set')
+            ->with('KEY', 'custom_value');
 
         $b = new DotenvBootloader();
-        $b->init($k, $d);
+        $b->init($dirs, $env);
     }
 }

--- a/src/Bridge/Monolog/tests/BaseTestCase.php
+++ b/src/Bridge/Monolog/tests/BaseTestCase.php
@@ -9,7 +9,7 @@ use Spiral\Boot\Environment;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Core\Container;
 
-abstract class BaseTest extends TestCase
+abstract class BaseTestCase extends TestCase
 {
     protected Container $container;
 

--- a/src/Bridge/Monolog/tests/BaseTestCase.php
+++ b/src/Bridge/Monolog/tests/BaseTestCase.php
@@ -7,6 +7,10 @@ namespace Spiral\Tests\Monolog;
 use PHPUnit\Framework\TestCase;
 use Spiral\Boot\Environment;
 use Spiral\Boot\EnvironmentInterface;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Core\Container;
 
 abstract class BaseTestCase extends TestCase
@@ -17,5 +21,7 @@ abstract class BaseTestCase extends TestCase
     {
         $this->container = new Container();
         $this->container->bind(EnvironmentInterface::class, new Environment());
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
     }
 }

--- a/src/Bridge/Monolog/tests/FactoryTest.php
+++ b/src/Bridge/Monolog/tests/FactoryTest.php
@@ -10,6 +10,10 @@ use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
 use Psr\Log\LoggerInterface;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
@@ -23,9 +27,17 @@ use Spiral\Monolog\Bootloader\MonologBootloader;
 use Spiral\Monolog\Config\MonologConfig;
 use Spiral\Monolog\LogFactory;
 
-class FactoryTest extends BaseTest
+class FactoryTest extends BaseTestCase
 {
     use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
+    }
 
     public function testDefaultLogger(): void
     {
@@ -108,8 +120,8 @@ class FactoryTest extends BaseTest
             ]
         ]), new ListenerRegistry(), $this->container);
 
-        $handler->shouldReceive('reset')->once();
-        $processor->shouldReceive('reset')->once();
+        $handler->shouldReceive('reset')->twice();
+        $processor->shouldReceive('reset')->twice();
 
         $this->container->bind(LogFactory::class, $factory);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);

--- a/src/Bridge/Monolog/tests/FactoryTest.php
+++ b/src/Bridge/Monolog/tests/FactoryTest.php
@@ -10,10 +10,6 @@ use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
 use Psr\Log\LoggerInterface;
-use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
@@ -30,14 +26,6 @@ use Spiral\Monolog\LogFactory;
 class FactoryTest extends BaseTestCase
 {
     use MockeryPHPUnitIntegration;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
-        $this->container->bind(InitializerInterface::class, Initializer::class);
-    }
 
     public function testDefaultLogger(): void
     {

--- a/src/Bridge/Monolog/tests/HandlersTest.php
+++ b/src/Bridge/Monolog/tests/HandlersTest.php
@@ -6,6 +6,10 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -19,7 +23,7 @@ use Spiral\Monolog\Bootloader\MonologBootloader;
 use Spiral\Monolog\Config\MonologConfig;
 use Spiral\Monolog\Exception\ConfigException;
 
-class HandlersTest extends BaseTest
+class HandlersTest extends BaseTestCase
 {
     public function setUp(): void
     {
@@ -42,6 +46,8 @@ class HandlersTest extends BaseTest
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 

--- a/src/Bridge/Monolog/tests/HandlersTest.php
+++ b/src/Bridge/Monolog/tests/HandlersTest.php
@@ -6,10 +6,6 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -46,8 +42,6 @@ class HandlersTest extends BaseTestCase
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
-        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
-        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 

--- a/src/Bridge/Monolog/tests/LoggerTest.php
+++ b/src/Bridge/Monolog/tests/LoggerTest.php
@@ -8,10 +8,6 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
-use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
@@ -50,8 +46,6 @@ class LoggerTest extends BaseTestCase
 
         $injector->shouldReceive('createInjection')->once()->andReturn($logger);
 
-        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
-        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LoggerInterface::class);
 

--- a/src/Bridge/Monolog/tests/LoggerTest.php
+++ b/src/Bridge/Monolog/tests/LoggerTest.php
@@ -8,6 +8,10 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\Finalizer;
 use Spiral\Boot\FinalizerInterface;
@@ -18,7 +22,7 @@ use Spiral\Core\Container;
 use Spiral\Monolog\Bootloader\MonologBootloader;
 use Spiral\Monolog\LogFactory;
 
-class LoggerTest extends BaseTest
+class LoggerTest extends BaseTestCase
 {
     use MockeryPHPUnitIntegration;
 
@@ -46,6 +50,8 @@ class LoggerTest extends BaseTest
 
         $injector->shouldReceive('createInjection')->once()->andReturn($logger);
 
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->get(LoggerInterface::class);
 

--- a/src/Bridge/Monolog/tests/ProcessorsTest.php
+++ b/src/Bridge/Monolog/tests/ProcessorsTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Tests\Monolog;
 
 use Monolog\Processor\PsrLogMessageProcessor;
-use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -44,8 +40,6 @@ class ProcessorsTest extends BaseTestCase
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
-        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
-        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 

--- a/src/Bridge/Monolog/tests/ProcessorsTest.php
+++ b/src/Bridge/Monolog/tests/ProcessorsTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Spiral\Tests\Monolog;
 
 use Monolog\Processor\PsrLogMessageProcessor;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -17,7 +21,7 @@ use Spiral\Monolog\Bootloader\MonologBootloader;
 use Spiral\Monolog\Config\MonologConfig;
 use Spiral\Monolog\Exception\ConfigException;
 
-class ProcessorsTest extends BaseTest
+class ProcessorsTest extends BaseTestCase
 {
     public function setUp(): void
     {
@@ -40,6 +44,8 @@ class ProcessorsTest extends BaseTest
             }
         ));
         $this->container->bindSingleton(ListenerRegistryInterface::class, new ListenerRegistry());
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
     }
 

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -6,10 +6,6 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
-use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -38,8 +34,6 @@ class RotateHandlerTest extends BaseTestCase
                 }
             }
         ));
-        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
-        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
 
         $autowire = new Container\Autowire('log.rotate', [

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -6,6 +6,10 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -14,7 +18,7 @@ use Spiral\Config\LoaderInterface;
 use Spiral\Core\Container;
 use Spiral\Monolog\Bootloader\MonologBootloader;
 
-class RotateHandlerTest extends BaseTest
+class RotateHandlerTest extends BaseTestCase
 {
     public function testRotateHandler(): void
     {
@@ -34,6 +38,8 @@ class RotateHandlerTest extends BaseTest
                 }
             }
         ));
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
 
         $autowire = new Container\Autowire('log.rotate', [

--- a/src/Bridge/Monolog/tests/TraitTest.php
+++ b/src/Bridge/Monolog/tests/TraitTest.php
@@ -6,6 +6,10 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Logger;
 use Psr\Log\NullLogger;
+use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
+use Spiral\Boot\BootloadManager\Initializer;
+use Spiral\Boot\BootloadManager\InitializerInterface;
+use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -18,7 +22,7 @@ use Spiral\Logger\Traits\LoggerTrait;
 use Spiral\Monolog\Bootloader\MonologBootloader;
 use Spiral\Monolog\Config\MonologConfig;
 
-class TraitTest extends BaseTest
+class TraitTest extends BaseTestCase
 {
     use LoggerTrait;
 
@@ -61,6 +65,8 @@ class TraitTest extends BaseTest
                 }
             }
         ));
+        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
+        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->bind(MonologConfig::class, new MonologConfig());
         $this->container->bind(ListenerRegistryInterface::class, new ListenerRegistry());

--- a/src/Bridge/Monolog/tests/TraitTest.php
+++ b/src/Bridge/Monolog/tests/TraitTest.php
@@ -6,10 +6,6 @@ namespace Spiral\Tests\Monolog;
 
 use Monolog\Logger;
 use Psr\Log\NullLogger;
-use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
-use Spiral\Boot\BootloadManager\Initializer;
-use Spiral\Boot\BootloadManager\InitializerInterface;
-use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
@@ -65,8 +61,6 @@ class TraitTest extends BaseTestCase
                 }
             }
         ));
-        $this->container->bind(InvokerStrategyInterface::class, DefaultInvokerStrategy::class);
-        $this->container->bind(InitializerInterface::class, Initializer::class);
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
         $this->container->bind(MonologConfig::class, new MonologConfig());
         $this->container->bind(ListenerRegistryInterface::class, new ListenerRegistry());

--- a/src/Bridge/Stempler/tests/BaseTestCase.php
+++ b/src/Bridge/Stempler/tests/BaseTestCase.php
@@ -25,7 +25,7 @@ use Spiral\Stempler\StemplerEngine;
 use Spiral\Views\ViewManager;
 use Spiral\Views\ViewsInterface;
 
-abstract class BaseTest extends TestCase
+abstract class BaseTestCase extends TestCase
 {
     public const BOOTLOADERS = [
         StemplerBootloader::class,

--- a/src/Bridge/Stempler/tests/CacheTest.php
+++ b/src/Bridge/Stempler/tests/CacheTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Spiral\Tests\Stempler;
 
 use Spiral\Config\ConfiguratorInterface;
-use Spiral\Config\PatchInterface;
 use Spiral\Files\Files;
 use Spiral\Files\FilesInterface;
 use Spiral\Views\ViewContext;
 
-class CacheTest extends BaseTest
+class CacheTest extends BaseTestCase
 {
     /** @var FilesInterface */
     protected $files;

--- a/src/Bridge/Stempler/tests/ConfigTest.php
+++ b/src/Bridge/Stempler/tests/ConfigTest.php
@@ -16,7 +16,7 @@ use Spiral\Stempler\Directive\PHPDirective;
 use Spiral\Stempler\Directive\RouteDirective;
 use Spiral\Views\Processor\ContextProcessor;
 
-class ConfigTest extends BaseTest
+class ConfigTest extends BaseTestCase
 {
     public function testWireConfigString(): void
     {

--- a/src/Bridge/Stempler/tests/DirectiveTest.php
+++ b/src/Bridge/Stempler/tests/DirectiveTest.php
@@ -8,7 +8,7 @@ use Spiral\Views\Exception\CompileException;
 use Spiral\Views\Exception\RenderException;
 use Spiral\Views\ViewContext;
 
-class DirectiveTest extends BaseTest
+class DirectiveTest extends BaseTestCase
 {
     public function testRenderDirectiveEx(): void
     {

--- a/src/Bridge/Stempler/tests/EngineTest.php
+++ b/src/Bridge/Stempler/tests/EngineTest.php
@@ -9,7 +9,7 @@ use Spiral\Views\Exception\CompileException;
 use Spiral\Views\Exception\RenderException;
 use Spiral\Views\ViewContext;
 
-class EngineTest extends BaseTest
+class EngineTest extends BaseTestCase
 {
     public function testList(): void
     {

--- a/src/Bridge/Stempler/tests/FormatTest.php
+++ b/src/Bridge/Stempler/tests/FormatTest.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Stempler;
 
 use Spiral\Views\ViewContext;
 
-class FormatTest extends BaseTest
+class FormatTest extends BaseTestCase
 {
     public function testFormatDiv(): void
     {

--- a/src/Bridge/Stempler/tests/Processor/NullLocaleProcessorTest.php
+++ b/src/Bridge/Stempler/tests/Processor/NullLocaleProcessorTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Stempler\Processor;
 
-use Spiral\Tests\Stempler\BaseTest;
+use Spiral\Tests\Stempler\BaseTestCase;
 use Spiral\Views\ViewContext;
 
-final class NullLocaleProcessorTest extends BaseTest
+final class NullLocaleProcessorTest extends BaseTestCase
 {
     public function testProcess(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

### What was changed

1. The **phpunit.xml** configuration file was missing configuration for bridge tests. Fixed.
2. The **spiral/dotenv-bridge** tests have been fixed; the bootloader no longer uses a callback.
3. Added `InvokerStrategyInterface` and `InitializerInterface` binding.
4. Abstract classes have been renamed from *Test to *TestCase.

Before these changes:

<img width="451" alt="11" src="https://github.com/spiral/framework/assets/67324318/2bfc67e7-1e72-4f4b-96d0-77834ff9ac1a">

After these changes:

<img width="450" alt="222" src="https://github.com/spiral/framework/assets/67324318/b6e2ed21-588f-49bc-9ed9-2bceda0d88b7">

