### PR TITLE
[spiral/monolog-bridge] Adding the ability to configure the Monolog messages format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Other Features**
     - [spiral/queue] Added `Spiral\Queue\Interceptor\Consume\RetryPolicyInterceptor` to enable automatic job retries 
       with a configurable retry policy.
+    - [spiral/monolog-bridge] Added the ability to configure the **Monolog** messages format via environment variable 
+      `MONOLOG_FORMAT`.
 
 ## 3.8.4 - 2023-09-08
 

--- a/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
+++ b/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
@@ -22,8 +22,6 @@ use Spiral\Monolog\LogFactory;
 
 final class MonologBootloader extends Bootloader implements Container\SingletonInterface
 {
-    private const DEFAULT_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
-
     protected const SINGLETONS = [
         LogsInterface::class => LogFactory::class,
         LoggerInterface::class => Logger::class,
@@ -32,6 +30,8 @@ final class MonologBootloader extends Bootloader implements Container\SingletonI
     protected const BINDINGS = [
         'log.rotate' => [self::class, 'logRotate'],
     ];
+
+    private const DEFAULT_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
 
     public function __construct(
         private readonly ConfiguratorInterface $config,

--- a/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
+++ b/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
@@ -9,6 +9,7 @@ use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
 use Monolog\ResettableInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\EnvironmentInterface;
@@ -32,7 +33,8 @@ final class MonologBootloader extends Bootloader implements Container\SingletonI
     ];
 
     public function __construct(
-        private readonly ConfiguratorInterface $config
+        private readonly ConfiguratorInterface $config,
+        private readonly ContainerInterface $container
     ) {
     }
 
@@ -64,6 +66,7 @@ final class MonologBootloader extends Bootloader implements Container\SingletonI
             'default' => $env->get('MONOLOG_DEFAULT_CHANNEL', MonologConfig::DEFAULT_CHANNEL),
             'globalLevel' => Logger::DEBUG,
             'handlers' => [],
+            'format' => $env->get('MONOLOG_FORMAT', MonologConfig::DEFAULT_FORMAT),
         ]);
 
         $container->bindInjector(Logger::class, LogFactory::class);
@@ -101,7 +104,7 @@ final class MonologBootloader extends Bootloader implements Container\SingletonI
         );
 
         return $handler->setFormatter(
-            new LineFormatter("[%datetime%] %level_name%: %message% %context%\n")
+            new LineFormatter($this->container->get(MonologConfig::class)->getFormat())
         );
     }
 }

--- a/src/Bridge/Monolog/src/Config/MonologConfig.php
+++ b/src/Bridge/Monolog/src/Config/MonologConfig.php
@@ -13,11 +13,13 @@ final class MonologConfig extends InjectableConfig
 {
     public const CONFIG = 'monolog';
     public const DEFAULT_CHANNEL = 'default';
+    public const DEFAULT_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
 
     protected array $config = [
-        'default'     => self::DEFAULT_CHANNEL,
+        'default' => self::DEFAULT_CHANNEL,
         'globalLevel' => Logger::DEBUG,
-        'handlers'    => [],
+        'handlers' => [],
+        'format' => self::DEFAULT_FORMAT,
     ];
 
     public function getDefault(): string
@@ -73,6 +75,11 @@ final class MonologConfig extends InjectableConfig
 
             yield $wire;
         }
+    }
+
+    public function getFormat(): string
+    {
+        return $this->config['format'] ?? self::DEFAULT_FORMAT;
     }
 
     private function wire(Autowire|string|array $definition): ?Autowire

--- a/src/Bridge/Monolog/src/Config/MonologConfig.php
+++ b/src/Bridge/Monolog/src/Config/MonologConfig.php
@@ -13,13 +13,11 @@ final class MonologConfig extends InjectableConfig
 {
     public const CONFIG = 'monolog';
     public const DEFAULT_CHANNEL = 'default';
-    public const DEFAULT_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
 
     protected array $config = [
-        'default' => self::DEFAULT_CHANNEL,
+        'default'     => self::DEFAULT_CHANNEL,
         'globalLevel' => Logger::DEBUG,
-        'handlers' => [],
-        'format' => self::DEFAULT_FORMAT,
+        'handlers'    => [],
     ];
 
     public function getDefault(): string
@@ -75,11 +73,6 @@ final class MonologConfig extends InjectableConfig
 
             yield $wire;
         }
-    }
-
-    public function getFormat(): string
-    {
-        return $this->config['format'] ?? self::DEFAULT_FORMAT;
     }
 
     private function wire(Autowire|string|array $definition): ?Autowire

--- a/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
+++ b/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
@@ -26,8 +26,8 @@ final class MonologConfigTest extends TestCase
         $config = new MonologConfig();
         $this->assertSame(Logger::DEBUG, $config->getEventLevel());
 
-        $config = new MonologConfig(['globalLevel' => 'foo']);
-        $this->assertSame('foo', $config->getEventLevel());
+        $config = new MonologConfig(['globalLevel' => Logger::INFO]);
+        $this->assertSame(Logger::INFO, $config->getEventLevel());
     }
 
     public function testGetHandlers(): void
@@ -44,7 +44,7 @@ final class MonologConfigTest extends TestCase
         ]);
         $this->assertInstanceOf(
             HandlerInterface::class,
-            \iterator_to_array($config->getHandlers('foo')[0])
+            \iterator_to_array($config->getHandlers('foo'))[0]
         );
     }
 
@@ -62,7 +62,7 @@ final class MonologConfigTest extends TestCase
         ]);
         $this->assertInstanceOf(
             ProcessorInterface::class,
-            \iterator_to_array($config->getProcessors('foo')[0])
+            \iterator_to_array($config->getProcessors('foo'))[0]
         );
     }
 

--- a/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
+++ b/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Monolog\Config;
+
+use Monolog\Handler\HandlerInterface;
+use Monolog\Logger;
+use Monolog\Processor\ProcessorInterface;
+use PHPUnit\Framework\TestCase;
+use Spiral\Monolog\Config\MonologConfig;
+
+final class MonologConfigTest extends TestCase
+{
+    public function testGetDefault(): void
+    {
+        $config = new MonologConfig();
+        $this->assertSame(MonologConfig::DEFAULT_CHANNEL, $config->getDefault());
+
+        $config = new MonologConfig(['default' => 'foo']);
+        $this->assertSame('foo', $config->getDefault());
+    }
+
+    public function testGetEventLevel(): void
+    {
+        $config = new MonologConfig();
+        $this->assertSame(Logger::DEBUG, $config->getEventLevel());
+
+        $config = new MonologConfig(['globalLevel' => 'foo']);
+        $this->assertSame('foo', $config->getEventLevel());
+    }
+
+    public function testGetHandlers(): void
+    {
+        $config = new MonologConfig();
+        $this->assertEmpty(\iterator_to_array($config->getHandlers('foo')));
+
+        $config = new MonologConfig([
+            'handlers' => [
+                'foo' => [
+                    $this->createMock(HandlerInterface::class)
+                ]
+            ]
+        ]);
+        $this->assertInstanceOf(
+            HandlerInterface::class,
+            \iterator_to_array($config->getHandlers('foo')[0])
+        );
+    }
+
+    public function testGetProcessors(): void
+    {
+        $config = new MonologConfig();
+        $this->assertEmpty(\iterator_to_array($config->getProcessors('foo')));
+
+        $config = new MonologConfig([
+            'processors' => [
+                'foo' => [
+                    $this->createMock(ProcessorInterface::class)
+                ]
+            ]
+        ]);
+        $this->assertInstanceOf(
+            ProcessorInterface::class,
+            \iterator_to_array($config->getProcessors('foo')[0])
+        );
+    }
+
+    public function testGetFormat(): void
+    {
+        $config = new MonologConfig();
+        $this->assertSame(MonologConfig::DEFAULT_FORMAT, $config->getFormat());
+
+        $config = new MonologConfig(['format' => 'foo']);
+        $this->assertSame('foo', $config->getFormat());
+    }
+}

--- a/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
+++ b/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
@@ -65,13 +65,4 @@ final class MonologConfigTest extends TestCase
             \iterator_to_array($config->getProcessors('foo'))[0]
         );
     }
-
-    public function testGetFormat(): void
-    {
-        $config = new MonologConfig();
-        $this->assertSame(MonologConfig::DEFAULT_FORMAT, $config->getFormat());
-
-        $config = new MonologConfig(['format' => 'foo']);
-        $this->assertSame('foo', $config->getFormat());
-    }
 }

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -11,13 +11,14 @@ use Spiral\Boot\BootloadManager\Initializer;
 use Spiral\Boot\BootloadManager\InitializerInterface;
 use Spiral\Boot\BootloadManager\InvokerStrategyInterface;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
+use Spiral\Boot\Environment;
+use Spiral\Boot\EnvironmentInterface;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\LoaderInterface;
 use Spiral\Core\Container;
 use Spiral\Monolog\Bootloader\MonologBootloader;
-use Spiral\Monolog\Config\MonologConfig;
 
 class RotateHandlerTest extends BaseTest
 {
@@ -65,9 +66,7 @@ class RotateHandlerTest extends BaseTest
         $this->container->bind(FinalizerInterface::class, $finalizer = \Mockery::mock(FinalizerInterface::class));
         $finalizer->shouldReceive('addFinalizer')->once();
 
-        $this->container->bind(MonologConfig::class, new MonologConfig([
-            'format' => 'foo'
-        ]));
+        $this->container->bind(EnvironmentInterface::class, new Environment(['MONOLOG_FORMAT' => 'foo']));
         $this->container->bind(ConfiguratorInterface::class, $this->createMock(ConfiguratorInterface::class));
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #989 

### What was changed

Added the ability to configure the **Monolog** messages format via environment variable `MONOLOG_FORMAT`.
We can't add the **format** parameter to the configuration file because it is needed in the `logRotate` method, which is used to add handlers to the configuration file:
https://github.com/spiral/app/blob/master/app/src/Application/Bootloader/LoggingBootloader.php#L20

