### PR TITLE
[spiral/translator] Adding the ability to register additional translation directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
       with a configurable retry policy.
     - [spiral/monolog-bridge] Added the ability to configure the **Monolog** messages format via environment variable 
       `MONOLOG_FORMAT`.
+    - [spiral/translator] Added the ability to register additional locales directories.
 
 ## 3.8.4 - 2023-09-08
 

--- a/src/Framework/Bootloader/I18nBootloader.php
+++ b/src/Framework/Bootloader/I18nBootloader.php
@@ -9,6 +9,7 @@ use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\Environment\DebugMode;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Append;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Translator\Catalogue\CacheInterface;
 use Spiral\Translator\Catalogue\CatalogueLoader;
@@ -55,6 +56,7 @@ final class I18nBootloader extends Bootloader implements SingletonInterface
                 'locale' => $env->get('LOCALE', 'en'),
                 'fallbackLocale' => $env->get('LOCALE', 'en'),
                 'directory' => $dirs->get('locale'),
+                'directories' => [],
                 'autoRegister' => $debugMode->isEnabled(),
                 'loaders' => [
                     'php' => Loader\PhpFileLoader::class,
@@ -77,8 +79,13 @@ final class I18nBootloader extends Bootloader implements SingletonInterface
     }
 
     /**
-     * @noRector RemoveUnusedPrivateMethodRector
+     * @param non-empty-string $directory
      */
+    public function addDirectory(string $directory): void
+    {
+        $this->config->modify(TranslatorConfig::CONFIG, new Append('directories', null, $directory));
+    }
+
     private function identityTranslator(): IdentityTranslator
     {
         return new IdentityTranslator();

--- a/src/Translator/src/Config/TranslatorConfig.php
+++ b/src/Translator/src/Config/TranslatorConfig.php
@@ -20,8 +20,9 @@ final class TranslatorConfig extends InjectableConfig
      * @var array{
      *     locale: string,
      *     fallbackLocale?: string,
-     *     directory: string,
-     *     localesDirectory?: string,
+     *     directory: non-empty-string,
+     *     directories: array<array-key, non-empty-string>,
+     *     localesDirectory?: non-empty-string,
      *     registerMessages?: bool,
      *     cacheLocales: bool,
      *     autoRegister: bool,
@@ -33,6 +34,7 @@ final class TranslatorConfig extends InjectableConfig
     protected array $config = [
         'locale'         => '',
         'directory'      => '',
+        'directories'    => [],
         'cacheLocales'   => true,
         'autoRegister'   => true,
         'domains'        => [],
@@ -71,14 +73,39 @@ final class TranslatorConfig extends InjectableConfig
         return !empty($this->config['autoRegister']) || !empty($this->config['registerMessages']);
     }
 
+    /**
+     * Returns application locales directory.
+     *
+     * @return non-empty-string
+     */
     public function getLocalesDirectory(): string
     {
         return $this->config['localesDirectory'] ?? $this->config['directory'] ?? '';
     }
 
-    public function getLocaleDirectory(string $locale): string
+    /**
+     * Returns additional locales directories.
+     *
+     * @return array<array-key, non-empty-string>
+     */
+    public function getDirectories(): array
     {
-        return $this->getLocalesDirectory() . $locale . '/';
+        return $this->config['directories'] ?? [];
+    }
+
+    /**
+     * @param non-empty-string $locale
+     * @param non-empty-string|null $directory
+     *
+     * @return non-empty-string
+     */
+    public function getLocaleDirectory(string $locale, ?string $directory = null): string
+    {
+        if ($directory !== null) {
+            return \rtrim($directory, '/') . '/' . $locale . '/';
+        }
+
+        return \trim($this->getLocalesDirectory(), '/') . '/' . $locale . '/';
     }
 
     /**

--- a/src/Translator/tests/ConfigTest.php
+++ b/src/Translator/tests/ConfigTest.php
@@ -80,6 +80,27 @@ class ConfigTest extends TestCase
         $this->assertSame('directory/ru/', $config->getLocaleDirectory('ru'));
     }
 
+    public function testLocaleDirectoryWithoutSlash(): void
+    {
+        $config = new TranslatorConfig([
+            'localesDirectory' => 'directory'
+        ]);
+        $this->assertSame('directory/en/', $config->getLocaleDirectory('en'));
+
+        $config = new TranslatorConfig([
+            'directory' => 'directory'
+        ]);
+        $this->assertSame('directory/en/', $config->getLocaleDirectory('en'));
+    }
+
+    public function testLocaleDirectoryWithDirectoryParam(): void
+    {
+        $config = new TranslatorConfig();
+
+        $this->assertSame('directory/en/', $config->getLocaleDirectory('en', 'directory'));
+        $this->assertSame('directory/en/', $config->getLocaleDirectory('en', 'directory/'));
+    }
+
     public function testDomains(): void
     {
         $config = new TranslatorConfig([
@@ -144,5 +165,19 @@ class ConfigTest extends TestCase
         ]);
 
         $this->assertInstanceOf(DumperInterface::class, $config->getDumper('po'));
+    }
+
+    public function testGetDirectories(): void
+    {
+        $config = new TranslatorConfig();
+        $this->assertSame([], $config->getDirectories());
+
+        $config = new TranslatorConfig([
+            'directories' => [
+                'foo',
+                'bar/'
+            ]
+        ]);
+        $this->assertSame(['foo', 'bar/'], $config->getDirectories());
     }
 }

--- a/src/Translator/tests/LoaderTest.php
+++ b/src/Translator/tests/LoaderTest.php
@@ -23,6 +23,18 @@ class LoaderTest extends TestCase
 
         $this->assertTrue($loader->hasLocale('ru'));
         $this->assertTrue($loader->hasLocale('RU'));
+        $this->assertFalse($loader->hasLocale('fr'));
+        $this->assertFalse($loader->hasLocale('FR'));
+
+        $loader = new CatalogueLoader(new TranslatorConfig([
+            'directory' => __DIR__ . '/fixtures/locales/',
+            'directories' => [__DIR__ . '/fixtures/additional'],
+        ]));
+
+        $this->assertTrue($loader->hasLocale('ru'));
+        $this->assertTrue($loader->hasLocale('RU'));
+        $this->assertTrue($loader->hasLocale('fr'));
+        $this->assertTrue($loader->hasLocale('FR'));
     }
 
     public function testGetLocales(): void
@@ -39,10 +51,26 @@ class LoaderTest extends TestCase
         $this->assertSame($shouldBe, $compared);
     }
 
+    public function testGetLocalesWithAdditionalDirectories(): void
+    {
+        $loader = new CatalogueLoader(new TranslatorConfig([
+            'directory' => __DIR__ . '/fixtures/locales/',
+            'directories' => [__DIR__ . '/fixtures/additional'],
+        ]));
+
+        $compared = $loader->getLocales();
+        $shouldBe = ['en', 'ru', 'fr'];
+        sort($shouldBe);
+        sort($compared);
+
+        $this->assertSame($shouldBe, $compared);
+    }
+
     public function testLoadCatalogue(): void
     {
         $loader = new CatalogueLoader(new TranslatorConfig([
             'directory' => __DIR__ . '/fixtures/locales/',
+            'directories' => [__DIR__ . '/fixtures/additional'],
             'loaders'   => [
                 'php' => PhpFileLoader::class,
                 'po'  => PoFileLoader::class,
@@ -77,6 +105,51 @@ class LoaderTest extends TestCase
             'Twig версия',
             $mc->get('Twig Version', 'views')
         );
+
+        $this->assertFalse($loader->hasLocale('fr'));
+    }
+
+    public function testLoadCatalogueWithAdditionalDirectories(): void
+    {
+        $loader = new CatalogueLoader(new TranslatorConfig([
+            'directory' => __DIR__ . '/fixtures/locales/',
+            'directories' => [__DIR__ . '/fixtures/additional'],
+            'loaders'   => [
+                'php' => PhpFileLoader::class,
+                'po'  => PoFileLoader::class,
+            ],
+        ]));
+
+        $catalogue = $loader->loadCatalogue('fr');
+        $mc = $catalogue->toMessageCatalogue();
+        $this->assertTrue($mc->has('Welcome To Spiral', 'views'));
+        $this->assertSame(
+            'Bienvenue à Spirale',
+            $mc->get('Welcome To Spiral', 'views')
+        );
+
+        $this->assertTrue($loader->hasLocale('fr'));
+        $this->assertTrue($loader->hasLocale('FR'));
+        $this->assertTrue($loader->hasLocale('ru'));
+        $this->assertTrue($loader->hasLocale('RU'));
+    }
+
+    public function testApplicationTranslationShouldOverrideAdditionalTranslations(): void
+    {
+        $loader = new CatalogueLoader(new TranslatorConfig([
+            'directory' => __DIR__ . '/fixtures/locales/',
+            'directories' => [__DIR__ . '/fixtures/additional'],
+            'loaders'   => [
+                'php' => PhpFileLoader::class,
+                'po'  => PoFileLoader::class,
+            ],
+        ]));
+
+        $catalogue = $loader->loadCatalogue('ru');
+        $mc = $catalogue->toMessageCatalogue();
+
+        $this->assertTrue($mc->has('should_be_override'));
+        $this->assertSame('changed by application translation', $mc->get('should_be_override'));
     }
 
     public function testLoadCatalogueNoLoader(): void

--- a/src/Translator/tests/LoaderTest.php
+++ b/src/Translator/tests/LoaderTest.php
@@ -70,7 +70,6 @@ class LoaderTest extends TestCase
     {
         $loader = new CatalogueLoader(new TranslatorConfig([
             'directory' => __DIR__ . '/fixtures/locales/',
-            'directories' => [__DIR__ . '/fixtures/additional'],
             'loaders'   => [
                 'php' => PhpFileLoader::class,
                 'po'  => PoFileLoader::class,

--- a/src/Translator/tests/ManagerTest.php
+++ b/src/Translator/tests/ManagerTest.php
@@ -78,7 +78,8 @@ class ManagerTest extends TestCase
             'ru',
             [
                 'messages' => [
-                    'message' => 'translation'
+                    'message' => 'translation',
+                    'should_be_override' => 'changed by application translation'
                 ],
                 'views'    => [
                     'Welcome To Spiral' => 'Добро пожаловать в Spiral Framework',
@@ -91,7 +92,8 @@ class ManagerTest extends TestCase
             'ru',
             [
                 'messages' => [
-                    'message' => 'new message'
+                    'message' => 'new message',
+                    'should_be_override' => 'changed by application translation'
                 ],
                 'views'    => [
                     'Welcome To Spiral' => 'Добро пожаловать в Spiral Framework',

--- a/src/Translator/tests/fixtures/additional/fr/messages.fr.php
+++ b/src/Translator/tests/fixtures/additional/fr/messages.fr.php
@@ -4,5 +4,4 @@ declare(strict_types=1);
 
 return [
     'message' => 'translation',
-    'should_be_override' => 'changed by application translation'
 ];

--- a/src/Translator/tests/fixtures/additional/fr/views.fr.po
+++ b/src/Translator/tests/fixtures/additional/fr/views.fr.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"X-Generator: Poedit 1.8.6\n"
+
+msgid "Welcome To Spiral"
+msgstr "Bienvenue à Spirale"
+
+msgid "Twig Version"
+msgstr "Twig Version"

--- a/src/Translator/tests/fixtures/additional/ru/messages.ru.php
+++ b/src/Translator/tests/fixtures/additional/ru/messages.ru.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'should_be_override' => 'original'
+];

--- a/tests/Framework/Bootloader/Translation/I18nBootloaderTest.php
+++ b/tests/Framework/Bootloader/Translation/I18nBootloaderTest.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace Framework\Bootloader\Translation;
 
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Boot\Environment\DebugMode;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Bootloader\I18nBootloader;
 use Spiral\Tests\Framework\BaseTestCase;
 use Spiral\Translator\Catalogue\CacheInterface;
 use Spiral\Translator\Catalogue\CatalogueLoader;
 use Spiral\Translator\Catalogue\CatalogueManager;
 use Spiral\Translator\Catalogue\LoaderInterface;
 use Spiral\Translator\CatalogueManagerInterface;
+use Spiral\Translator\Config\TranslatorConfig;
 use Spiral\Translator\MemoryCache;
 use Spiral\Translator\Translator;
 use Spiral\Translator\TranslatorInterface;
 use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Translation\Dumper;
+use Symfony\Component\Translation\Loader;
 
 class I18nBootloaderTest extends BaseTestCase
 {
@@ -56,6 +63,51 @@ class I18nBootloaderTest extends BaseTestCase
         $this->assertContainerBoundAsSingleton(
             IdentityTranslator::class,
             IdentityTranslator::class
+        );
+    }
+
+    public function testAddDirectory(): void
+    {
+        $this->getContainer()->get(I18nBootloader::class)->addDirectory('directory');
+
+        $this->assertSame(
+            [
+                'directory',
+            ],
+            $this->getConfig(TranslatorConfig::CONFIG)['directories']
+        );
+    }
+
+    public function testDefaultConfig(): void
+    {
+        $env = $this->getContainer()->get(EnvironmentInterface::class);
+        $dirs = $this->getContainer()->get(DirectoriesInterface::class);
+        $debugMode = $this->getContainer()->get(DebugMode::class);
+
+        $this->assertSame(
+            [
+                'locale' => $env->get('LOCALE', 'en'),
+                'fallbackLocale' => $env->get('LOCALE', 'en'),
+                'directory' => $dirs->get('locale'),
+                'directories' => [],
+                'autoRegister' => $debugMode->isEnabled(),
+                'loaders' => [
+                    'php' => Loader\PhpFileLoader::class,
+                    'po' => Loader\PoFileLoader::class,
+                    'csv' => Loader\CsvFileLoader::class,
+                    'json' => Loader\JsonFileLoader::class,
+                ],
+                'dumpers' => [
+                    'php' => Dumper\PhpFileDumper::class,
+                    'po' => Dumper\PoFileDumper::class,
+                    'csv' => Dumper\CsvFileDumper::class,
+                    'json' => Dumper\JsonFileDumper::class,
+                ],
+                'domains' => [
+                    'messages' => ['*'],
+                ],
+            ],
+            $this->getConfig(TranslatorConfig::CONFIG)
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #951 

### What was changed

Added the ability to register additional directories with translation files for the **Translator** component.
This can be useful when developing additional packages for the Spiral Framework, where the package may provide translation files (for example, validators). **Translation files in an application can override translations from additional directories.**

A directory with translations can be registered via the `Spiral\Bootloader\I18nBootloader` bootloader or `translator.php` configuration file.

#### Via I18nBootloader bootloader

```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Bootloader\I18nBootloader;

final class AppBootloader extends Bootloader
{
    public function init(I18nBootloader $i18n): void
    {
        $i18n->addDirectory('some/directory');
    }
}
```

#### Via configuration file

```php
return [
    // ...
    'directories' => [
        'some/directory'
    ],
    // ...
];

```
