### PR TITLE
[spiral/monolog-bridge] Set `bubble` as `true` by default in logRotate method

### DIFF
--- a/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
+++ b/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
@@ -92,7 +92,7 @@ final class MonologBootloader extends Bootloader implements Container\SingletonI
         string $filename,
         int $level = Logger::DEBUG,
         int $maxFiles = 0,
-        bool $bubble = false
+        bool $bubble = true
     ): HandlerInterface {
         $handler = new RotatingFileHandler(
             $filename,

--- a/src/Bridge/Monolog/src/EventHandler.php
+++ b/src/Bridge/Monolog/src/EventHandler.php
@@ -33,6 +33,6 @@ final class EventHandler extends AbstractHandler
             $listener($e);
         }
 
-        return true;
+        return false === $this->bubble;
     }
 }

--- a/src/Bridge/Monolog/tests/EventHandlerTest.php
+++ b/src/Bridge/Monolog/tests/EventHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Monolog;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Logger\Event\LogEvent;
+use Spiral\Logger\ListenerRegistry;
+use Spiral\Monolog\EventHandler;
+
+final class EventHandlerTest extends TestCase
+{
+    private ListenerRegistry $registry;
+    private object $listener;
+
+    protected function setUp(): void
+    {
+        $this->listener = new class() {
+            public LogEvent $event;
+
+            public function __invoke(LogEvent $event): void
+            {
+                $this->event = $event;
+            }
+        };
+
+        $this->registry = new ListenerRegistry();
+        $this->registry->addListener($this->listener);
+    }
+
+    public function testHandle(): void
+    {
+        $handler = new EventHandler($this->registry);
+
+        $result = $handler->handle([
+            'datetime' => new \DateTimeImmutable(),
+            'channel' => 'foo',
+            'level' => 100,
+            'message' => 'bar',
+            'context' => ['foo' => 'bar'],
+        ]);
+
+        $this->assertSame('foo', $this->listener->event->getChannel());
+        $this->assertSame('bar', $this->listener->event->getMessage());
+        $this->assertSame(['foo' => 'bar'], $this->listener->event->getContext());
+        $this->assertSame('debug', $this->listener->event->getLevel());
+        $this->assertFalse($result);
+    }
+
+    public function testHandleWithBubbleFalse(): void
+    {
+        $handler = new EventHandler(listenerRegistry: $this->registry, bubble: false);
+
+        $result = $handler->handle([
+            'datetime' => new \DateTimeImmutable(),
+            'channel' => 'foo',
+            'level' => 100,
+            'message' => 'bar',
+            'context' => ['foo' => 'bar'],
+        ]);
+
+        $this->assertSame('foo', $this->listener->event->getChannel());
+        $this->assertSame('bar', $this->listener->event->getMessage());
+        $this->assertSame(['foo' => 'bar'], $this->listener->event->getContext());
+        $this->assertSame('debug', $this->listener->event->getLevel());
+        $this->assertTrue($result);
+    }
+}

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -59,6 +59,7 @@ class RotateHandlerTest extends BaseTestCase
         $this->assertInstanceOf(RotatingFileHandler::class, $handler);
 
         $this->assertSame(Logger::DEBUG, $handler->getLevel());
+        $this->assertTrue($handler->getBubble());
     }
 
     public function testChangeFormat(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 