### PR TITLE
[spiral/reactor] Fix Psalm issues and tests in Reactor

### DIFF
--- a/src/Reactor/src/AbstractDeclaration.php
+++ b/src/Reactor/src/AbstractDeclaration.php
@@ -10,6 +10,8 @@ use Spiral\Reactor\Traits;
 
 /**
  * Generic element declaration.
+ *
+ * @template T of ClassLike
  */
 abstract class AbstractDeclaration implements DeclarationInterface, NamedInterface, \Stringable
 {
@@ -17,6 +19,9 @@ abstract class AbstractDeclaration implements DeclarationInterface, NamedInterfa
     use Traits\NameAware;
     use Traits\AttributeAware;
 
+    /**
+     * @var T
+     */
     protected ClassLike $element;
 
     public function __toString(): string

--- a/src/Reactor/src/ClassDeclaration.php
+++ b/src/Reactor/src/ClassDeclaration.php
@@ -11,6 +11,9 @@ use Spiral\Reactor\Partial\Property;
 use Spiral\Reactor\Partial\TraitUse;
 use Spiral\Reactor\Traits;
 
+/**
+ * @extends AbstractDeclaration<ClassType>
+ */
 class ClassDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;

--- a/src/Reactor/src/EnumDeclaration.php
+++ b/src/Reactor/src/EnumDeclaration.php
@@ -13,6 +13,9 @@ use Spiral\Reactor\Partial\Method;
 use Spiral\Reactor\Partial\TraitUse;
 use Spiral\Reactor\Traits;
 
+/**
+ * @extends AbstractDeclaration<EnumType>
+ */
 class EnumDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;

--- a/src/Reactor/src/InterfaceDeclaration.php
+++ b/src/Reactor/src/InterfaceDeclaration.php
@@ -9,6 +9,9 @@ use Spiral\Reactor\Partial\Constant;
 use Spiral\Reactor\Partial\Method;
 use Spiral\Reactor\Traits;
 
+/**
+ * @extends AbstractDeclaration<InterfaceType>
+ */
 class InterfaceDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;

--- a/src/Reactor/src/Partial/Parameter.php
+++ b/src/Reactor/src/Partial/Parameter.php
@@ -11,6 +11,9 @@ use Spiral\Reactor\AggregableInterface;
 use Spiral\Reactor\NamedInterface;
 use Spiral\Reactor\Traits;
 
+/**
+ * @property NetteParameter $element
+ */
 class Parameter implements NamedInterface, AggregableInterface
 {
     use Traits\AttributeAware;

--- a/src/Reactor/src/Partial/PromotedParameter.php
+++ b/src/Reactor/src/Partial/PromotedParameter.php
@@ -8,6 +8,9 @@ use Doctrine\Inflector\Rules\English\InflectorFactory;
 use Nette\PhpGenerator\PromotedParameter as NettePromotedParameter;
 use Spiral\Reactor\Traits;
 
+/**
+ * @property NettePromotedParameter $element
+ */
 final class PromotedParameter extends Parameter
 {
     use Traits\CommentAware;

--- a/src/Reactor/src/TraitDeclaration.php
+++ b/src/Reactor/src/TraitDeclaration.php
@@ -11,6 +11,9 @@ use Spiral\Reactor\Partial\Property;
 use Spiral\Reactor\Partial\TraitUse;
 use Spiral\Reactor\Traits;
 
+/**
+ * @extends AbstractDeclaration<TraitType>
+ */
 class TraitDeclaration extends AbstractDeclaration implements AggregableInterface
 {
     use Traits\ConstantsAware;

--- a/src/Reactor/src/Traits/TraitsAware.php
+++ b/src/Reactor/src/Traits/TraitsAware.php
@@ -36,9 +36,9 @@ trait TraitsAware
         return $this->getTraits()->get($name);
     }
 
-    public function addTrait(string $name, array|bool|null $deprecatedParam = null): TraitUse
+    public function addTrait(string $name): TraitUse
     {
-        return TraitUse::fromElement($this->element->addTrait($name, $deprecatedParam));
+        return TraitUse::fromElement($this->element->addTrait($name));
     }
 
     public function removeTrait(string $name): static

--- a/src/Reactor/tests/FileDeclarationTest.php
+++ b/src/Reactor/tests/FileDeclarationTest.php
@@ -130,6 +130,7 @@ final class FileDeclarationTest extends BaseWithElementsTestCase
     {
         $file = new FileDeclaration();
         $file->addUse('Foo\\Bar');
+        $file->addClass('Test')->addImplement('Foo\\Bar');
 
         $this->assertStringContainsString('use Foo\\Bar;', (string) $file);
     }

--- a/src/Reactor/tests/Partial/PhpNamespaceTest.php
+++ b/src/Reactor/tests/Partial/PhpNamespaceTest.php
@@ -44,14 +44,17 @@ final class PhpNamespaceTest extends BaseWithElementsTestCase
 
         $this->assertEmpty($namespace->getUses());
 
-        $namespace->addUse('foo');
-        $namespace->addUse('bar', 'baz');
-        $this->assertSame(['baz' => 'bar', 'foo' => 'foo'], $namespace->getUses());
-        $this->assertStringContainsString('use bar as baz;', $namespace->__toString());
-        $this->assertStringContainsString('use foo;', $namespace->__toString());
+        $namespace->addUse('Some\\Other');
+        $namespace->addUse('Other\\Some', 'Baz');
+        $namespace->addClass('Test')->setExtends('Some\\Other')->addImplement('Baz');
 
-        $namespace->removeUse('bar');
-        $this->assertSame(['foo' => 'foo'], $namespace->getUses());
+        $this->assertSame(['Baz' => 'Other\\Some', 'Other' => 'Some\\Other'], $namespace->getUses());
+
+        $this->assertStringContainsString('use Other\\Some as Baz;', $namespace->__toString());
+        $this->assertStringContainsString('use Some\\Other;', $namespace->__toString());
+
+        $namespace->removeUse('Other\\Some');
+        $this->assertSame(['Other' => 'Some\\Other'], $namespace->getUses());
     }
 
     public function testUseFunction(): void
@@ -62,6 +65,8 @@ final class PhpNamespaceTest extends BaseWithElementsTestCase
 
         $namespace->addUseFunction('foo');
         $namespace->addUseFunction('bar', 'baz');
+        $namespace->addClass('Test')->addMethod('test')->addBody('foo();baz();');
+
         $this->assertSame(['baz' => 'bar', 'foo' => 'foo'], $namespace->getUses(NettePhpNamespace::NameFunction));
         $this->assertStringContainsString('use function bar as baz;', $namespace->__toString());
         $this->assertStringContainsString('use function foo;', $namespace->__toString());
@@ -78,6 +83,8 @@ final class PhpNamespaceTest extends BaseWithElementsTestCase
 
         $namespace->addUseConstant('foo');
         $namespace->addUseConstant('bar', 'baz');
+        $namespace->addClass('Test')->addMethod('test')->addBody('foo::some;baz::some;');
+
         $this->assertSame(['baz' => 'bar', 'foo' => 'foo'], $namespace->getUses(NettePhpNamespace::NameConstant));
         $this->assertStringContainsString('use const bar as baz;', $namespace->__toString());
         $this->assertStringContainsString('use const foo;', $namespace->__toString());
@@ -175,6 +182,7 @@ final class PhpNamespaceTest extends BaseWithElementsTestCase
     public function testRender(): void
     {
         $namespace = new PhpNamespace('Foo\\Bar');
+        $namespace->addClass('Test');
 
         $this->assertStringContainsString('namespace Foo\\Bar;', $namespace->__toString());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

1) In the release of **nette/php-generator v4.1.1**, the `omitEmptyNamespaces` parameter was added with the default value `true`:
https://github.com/nette/php-generator/releases/tag/v4.1.1
Now if the namespace is empty or use is not used anywhere, the printer does not print it. The use of these elements has been added in tests. 
2) Psalm issues fixed.