### PR TITLE
[spiral/prototype] Introducing new `prototype:list` console command for listing prototype dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - [spiral/monolog-bridge] Added the ability to configure the **Monolog** messages format via environment variable 
       `MONOLOG_FORMAT`.
     - [spiral/translator] Added the ability to register additional locales directories.
+    - [spiral/prototype] Added console command `Spiral\Prototype\Command\ListCommand` for listing prototype dependencies.
 
 ## 3.8.4 - 2023-09-08
 

--- a/src/Prototype/src/Bootloader/PrototypeBootloader.php
+++ b/src/Prototype/src/Bootloader/PrototypeBootloader.php
@@ -79,6 +79,7 @@ final class PrototypeBootloader extends Bootloader\Bootloader implements Contain
     public function init(ConsoleBootloader $console): void
     {
         $console->addCommand(Command\DumpCommand::class);
+        $console->addCommand(Command\ListCommand::class);
         $console->addCommand(Command\UsageCommand::class);
         $console->addCommand(Command\InjectCommand::class);
 

--- a/src/Prototype/src/Bootloader/PrototypeBootloader.php
+++ b/src/Prototype/src/Bootloader/PrototypeBootloader.php
@@ -79,7 +79,7 @@ final class PrototypeBootloader extends Bootloader\Bootloader implements Contain
     public function init(ConsoleBootloader $console): void
     {
         $console->addCommand(Command\DumpCommand::class);
-        $console->addCommand(Command\ListCommand::class);
+        $console->addCommand(Command\UsageCommand::class);
         $console->addCommand(Command\InjectCommand::class);
 
         $console->addConfigureSequence(

--- a/src/Prototype/src/Command/ListCommand.php
+++ b/src/Prototype/src/Command/ListCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Prototype\Command;
+
+final class ListCommand extends AbstractCommand
+{
+    public const NAME = 'prototype:list';
+    public const DESCRIPTION = 'List all declared prototype dependencies';
+
+    public function perform(): int
+    {
+        $bindings = $this->registry->getPropertyBindings();
+        if ($bindings === []) {
+            $this->comment('No prototype dependencies found.');
+
+            return self::SUCCESS;
+        }
+
+        $grid = $this->table(['Name:', 'Target:']);
+
+        foreach ($bindings as $binding) {
+            $grid->addRow([$binding->property, $binding->type->name()]);
+        }
+
+        $grid->render();
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Prototype/src/Command/UsageCommand.php
+++ b/src/Prototype/src/Command/UsageCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Prototype\Command;
 
-final class ListCommand extends AbstractCommand
+final class UsageCommand extends AbstractCommand
 {
-    public const NAME        = 'prototype:list';
+    public const NAME = 'prototype:usage';
     public const DESCRIPTION = 'List all prototyped classes';
 
     /**

--- a/src/Prototype/tests/Commands/InjectCommandTest.php
+++ b/src/Prototype/tests/Commands/InjectCommandTest.php
@@ -16,6 +16,16 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class InjectCommandTest extends AbstractCommandsTestCase
 {
+    public function testCommandRegistered(): void
+    {
+        $out = new BufferedOutput();
+        $this->app->get(Console::class)->run('list', new ArrayInput([]), $out);
+
+        $result = $out->fetch();
+
+        $this->assertStringContainsString('prototype:inject', $result);
+    }
+
     public function testEmptyInjection(): void
     {
         $target = EmptyInjectionClass::class;

--- a/src/Prototype/tests/Commands/ListCommandTest.php
+++ b/src/Prototype/tests/Commands/ListCommandTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Prototype\Commands;
+
+use Spiral\Console\Console;
+use Spiral\Tests\Prototype\Fixtures\TestApp;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class ListCommandTest extends AbstractCommandsTestCase
+{
+    public function testCommandRegistered(): void
+    {
+        $out = new BufferedOutput();
+        $this->app->get(Console::class)->run('list', new ArrayInput([]), $out);
+
+        $result = $out->fetch();
+
+        $this->assertStringContainsString('prototype:list', $result);
+    }
+
+    public function testList(): void
+    {
+        $out = new BufferedOutput();
+        $this->app->get(Console::class)->run('prototype:list', new ArrayInput([]), $out);
+
+        $result = $out->fetch();
+
+        $this->assertStringContainsString('app', $result);
+        $this->assertStringContainsString(TestApp::class, $result);
+        $this->assertStringContainsString('classLocator', $result);
+        $this->assertStringContainsString(\Spiral\Tokenizer\ClassesInterface::class, $result);
+        $this->assertStringContainsString('console', $result);
+        $this->assertStringContainsString(\Spiral\Console\Console::class, $result);
+        $this->assertStringContainsString('broadcast', $result);
+        $this->assertStringContainsString(\Spiral\Broadcasting\BroadcastInterface::class, $result);
+        $this->assertStringContainsString('container', $result);
+        $this->assertStringContainsString(\Psr\Container\ContainerInterface::class, $result);
+        $this->assertStringContainsString('encrypter', $result);
+        $this->assertStringContainsString(\Spiral\Encrypter\EncrypterInterface::class, $result);
+        $this->assertStringContainsString('env', $result);
+        $this->assertStringContainsString(\Spiral\Boot\EnvironmentInterface::class, $result);
+        $this->assertStringContainsString('files', $result);
+        $this->assertStringContainsString(\Spiral\Files\FilesInterface::class, $result);
+        $this->assertStringContainsString('guard', $result);
+        $this->assertStringContainsString(\Spiral\Security\GuardInterface::class, $result);
+        $this->assertStringContainsString('http', $result);
+        $this->assertStringContainsString(\Spiral\Http\Http::class, $result);
+        $this->assertStringContainsString('i18n', $result);
+        $this->assertStringContainsString(\Spiral\Translator\TranslatorInterface::class, $result);
+        $this->assertStringContainsString('input', $result);
+        $this->assertStringContainsString(\Spiral\Http\Request\InputManager::class, $result);
+        $this->assertStringContainsString('session', $result);
+        $this->assertStringContainsString(\Spiral\Session\SessionScope::class, $result);
+        $this->assertStringContainsString('cookies', $result);
+        $this->assertStringContainsString(\Spiral\Cookies\CookieManager::class, $result);
+        $this->assertStringContainsString('logger', $result);
+        $this->assertStringContainsString(\Psr\Log\LoggerInterface::class, $result);
+        $this->assertStringContainsString('logs', $result);
+        $this->assertStringContainsString(\Spiral\Logger\LogsInterface::class, $result);
+        $this->assertStringContainsString('memory', $result);
+        $this->assertStringContainsString(\Spiral\Boot\MemoryInterface::class, $result);
+        $this->assertStringContainsString('paginators', $result);
+        $this->assertStringContainsString(\Spiral\Pagination\PaginationProviderInterface::class, $result);
+        $this->assertStringContainsString('queue', $result);
+        $this->assertStringContainsString(\Spiral\Queue\QueueInterface::class, $result);
+        $this->assertStringContainsString('queueManager', $result);
+        $this->assertStringContainsString(\Spiral\Queue\QueueConnectionProviderInterface::class, $result);
+        $this->assertStringContainsString('request', $result);
+        $this->assertStringContainsString(\Spiral\Http\Request\InputManager::class, $result);
+        $this->assertStringContainsString('response', $result);
+        $this->assertStringContainsString(\Spiral\Http\ResponseWrapper::class, $result);
+        $this->assertStringContainsString('router', $result);
+        $this->assertStringContainsString(\Spiral\Router\RouterInterface::class, $result);
+        $this->assertStringContainsString('snapshots', $result);
+        $this->assertStringContainsString(\Spiral\Snapshots\SnapshotterInterface::class, $result);
+        $this->assertStringContainsString('storage', $result);
+        $this->assertStringContainsString(\Spiral\Storage\BucketInterface::class, $result);
+        $this->assertStringContainsString('serializer', $result);
+        $this->assertStringContainsString(\Spiral\Serializer\SerializerManager::class, $result);
+        $this->assertStringContainsString('validator', $result);
+        $this->assertStringContainsString(\Spiral\Validation\ValidationInterface::class, $result);
+        $this->assertStringContainsString('views', $result);
+        $this->assertStringContainsString(\Spiral\Views\ViewsInterface::class, $result);
+        $this->assertStringContainsString('auth', $result);
+        $this->assertStringContainsString(\Spiral\Auth\AuthScope::class, $result);
+        $this->assertStringContainsString('authTokens', $result);
+        $this->assertStringContainsString(\Spiral\Auth\TokenStorageInterface::class, $result);
+        $this->assertStringContainsString('cache', $result);
+        $this->assertStringContainsString(\Psr\SimpleCache\CacheInterface::class, $result);
+        $this->assertStringContainsString('cacheManager', $result);
+        $this->assertStringContainsString(\Spiral\Cache\CacheStorageProviderInterface::class, $result);
+        $this->assertStringContainsString('exceptionHandler', $result);
+        $this->assertStringContainsString(\Spiral\Exceptions\ExceptionHandlerInterface::class, $result);
+    }
+}

--- a/src/Prototype/tests/Commands/UsageCommandTest.php
+++ b/src/Prototype/tests/Commands/UsageCommandTest.php
@@ -9,7 +9,7 @@ use Spiral\Tests\Prototype\Fixtures\TestApp;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class ListCommandTest extends AbstractCommandsTestCase
+class UsageCommandTest extends AbstractCommandsTestCase
 {
     public function testList(): void
     {
@@ -19,7 +19,7 @@ class ListCommandTest extends AbstractCommandsTestCase
 
         $result = $out->fetch();
 
-        $this->assertStringContainsString('prototype:list', $result);
+        $this->assertStringContainsString('prototype:usage', $result);
         $this->assertStringContainsString('prototype:inject', $result);
     }
 
@@ -27,7 +27,7 @@ class ListCommandTest extends AbstractCommandsTestCase
     {
         $inp = new ArrayInput([]);
         $out = new BufferedOutput();
-        $this->app->get(Console::class)->run('prototype:list', $inp, $out);
+        $this->app->get(Console::class)->run('prototype:usage', $inp, $out);
 
         $result = $out->fetch();
 
@@ -41,7 +41,7 @@ class ListCommandTest extends AbstractCommandsTestCase
 
         $inp = new ArrayInput([]);
         $out = new BufferedOutput();
-        $this->app->get(Console::class)->run('prototype:list', $inp, $out);
+        $this->app->get(Console::class)->run('prototype:usage', $inp, $out);
 
         $result = $out->fetch();
 
@@ -57,7 +57,7 @@ class ListCommandTest extends AbstractCommandsTestCase
 
         $inp = new ArrayInput([]);
         $out = new BufferedOutput();
-        $this->app->get(Console::class)->run('prototype:list', $inp, $out);
+        $this->app->get(Console::class)->run('prototype:usage', $inp, $out);
 
         $result = $out->fetch();
 

--- a/src/Prototype/tests/Commands/UsageCommandTest.php
+++ b/src/Prototype/tests/Commands/UsageCommandTest.php
@@ -11,16 +11,14 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class UsageCommandTest extends AbstractCommandsTestCase
 {
-    public function testList(): void
+    public function testCommandRegistered(): void
     {
-        $inp = new ArrayInput([]);
         $out = new BufferedOutput();
-        $this->app->get(Console::class)->run('list', $inp, $out);
+        $this->app->get(Console::class)->run('list', new ArrayInput([]), $out);
 
         $result = $out->fetch();
 
         $this->assertStringContainsString('prototype:usage', $result);
-        $this->assertStringContainsString('prototype:inject', $result);
     }
 
     public function testPrototypes(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #1001

## What is the `prototype:list` command?

The `prototype:list` command is a super cool addition to our Spiral Framework. It helps developers by providing an easy way to list all the classes registered in the `Spiral\Prototype\PrototypeRegistry`. These registered classes are essential for project prototyping.

### How to Use It

Using the command is simple. Just run the following line in your terminal:

```shell
php app.php prototype:list
```

Once you do that, you'll get a neat table that displays all the registered prototypes, including their names and target classes. This makes it incredibly easy to see what's available for your project prototyping needs.

```shell
+------------------+-------------------------------------------------------+
| Name:            | Target:                                               |
+------------------+-------------------------------------------------------+
| app              | App\Application\Kernel                                |
| classLocator     | Spiral\Tokenizer\ClassesInterface                     |
| console          | Spiral\Console\Console                                |
| broadcast        | Spiral\Broadcasting\BroadcastInterface                |
| container        | Psr\Container\ContainerInterface                      |
| encrypter        | Spiral\Encrypter\EncrypterInterface                   |
| env              | Spiral\Boot\EnvironmentInterface                      |
| files            | Spiral\Files\FilesInterface                           |
| guard            | Spiral\Security\GuardInterface                        |
| http             | Spiral\Http\Http                                      |
| i18n             | Spiral\Translator\TranslatorInterface                 |
| input            | Spiral\Http\Request\InputManager                      |
| session          | Spiral\Session\SessionScope                           |
| cookies          | Spiral\Cookies\CookieManager                          |
| logger           | Psr\Log\LoggerInterface                               |
| logs             | Spiral\Logger\LogsInterface                           |
| memory           | Spiral\Boot\MemoryInterface                           |
| paginators       | Spiral\Pagination\PaginationProviderInterface         |
| queue            | Spiral\Queue\QueueInterface                           |
| queueManager     | Spiral\Queue\QueueConnectionProviderInterface         |
| request          | Spiral\Http\Request\InputManager                      |
| response         | Spiral\Http\ResponseWrapper                           |
| router           | Spiral\Router\RouterInterface                         |
| snapshots        | Spiral\Snapshots\SnapshotterInterface                 |
| storage          | Spiral\Storage\BucketInterface                        |
| serializer       | Spiral\Serializer\SerializerManager                   |
| validator        | Spiral\Validation\ValidationInterface                 |
| views            | Spiral\Views\ViewsInterface                           |
| auth             | Spiral\Auth\AuthScope                                 |
| authTokens       | Spiral\Auth\TokenStorageInterface                     |
| cache            | Psr\SimpleCache\CacheInterface                        |
| cacheManager     | Spiral\Cache\CacheStorageProviderInterface            |
| exceptionHandler | Spiral\Exceptions\ExceptionHandlerInterface           |
| users            | App\Infrastructure\Persistence\CycleORMUserRepository |
+------------------+-------------------------------------------------------+
```

### Why It Matters

This new feature enhances developer productivity and ensures that we're making the most of the Spiral Framework's capabilities. It provides clarity on available prototypes, which can be crucial when building and extending our projects.

> **Note**
> You might notice that we've also renamed the old `prototype:list` command to `prototype:usage` to better align with its purpose.

---

I encourage you all to give this new command a try and see how it streamlines our development process. Your feedback is, as always, greatly appreciated.