### PR TITLE
[spiral/boot] Adding `BootloaderRegistry` to improve the bootloader registration process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+- **Other Features**
+    - [spiral/boot] Added `Spiral\Boot\Bootloader\BootloaderRegistryInterface` and `Spiral\Boot\Bootloader\BootloaderRegistry`
+      to allow for easier management of bootloaders.
+
 ## 3.9.0 - 2023-10-19
 
 - **Other Features**

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -6,6 +6,8 @@ namespace Spiral\Boot;
 
 use Closure;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Boot\Bootloader\BootloaderRegistry;
+use Spiral\Boot\Bootloader\BootloaderRegistryInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
@@ -135,6 +137,10 @@ abstract class AbstractKernel implements KernelInterface
         \assert($bootloadManager instanceof BootloadManagerInterface);
         $container->bind(BootloadManagerInterface::class, $bootloadManager);
 
+        if (!$container->has(BootloaderRegistryInterface::class)) {
+            $container->bindSingleton(BootloaderRegistryInterface::class, [self::class, 'initBootloaderRegistry']);
+        }
+
         return new static(
             $container,
             $exceptionHandler,
@@ -164,11 +170,13 @@ abstract class AbstractKernel implements KernelInterface
             // will protect any against env overwrite action
             $this->container->runScope(
                 [EnvironmentInterface::class => $environment],
-                function (): void {
-                    $this->bootloader->bootload($this->defineSystemBootloaders());
+                function (Container $container): void {
+                    $registry = $container->get(BootloaderRegistryInterface::class);
+
+                    $this->bootloader->bootload($registry->getSystemBootloaders());
                     $this->fireCallbacks($this->runningCallbacks);
 
-                    $this->bootload();
+                    $this->bootload($registry->getLoadBootloaders());
                     $this->bootstrap();
 
                     $this->fireCallbacks($this->bootstrappedCallbacks);
@@ -335,11 +343,11 @@ abstract class AbstractKernel implements KernelInterface
     /**
      * Bootload all registered classes using BootloadManager.
      */
-    private function bootload(): void
+    private function bootload(array $bootloaders = []): void
     {
         $self = $this;
         $this->bootloader->bootload(
-            $this->defineBootloaders(),
+            $bootloaders,
             [
                 static function () use ($self): void {
                     $self->fireCallbacks($self->bootingCallbacks);
@@ -355,5 +363,13 @@ abstract class AbstractKernel implements KernelInterface
         return $this->container->has(EventDispatcherInterface::class)
             ? $this->container->get(EventDispatcherInterface::class)
             : null;
+    }
+
+    private function initBootloaderRegistry(): BootloaderRegistryInterface
+    {
+        return new BootloaderRegistry(
+            $this->defineSystemBootloaders(),
+            $this->defineBootloaders(),
+        );
     }
 }

--- a/src/Boot/src/AbstractKernel.php
+++ b/src/Boot/src/AbstractKernel.php
@@ -176,7 +176,7 @@ abstract class AbstractKernel implements KernelInterface
                     $this->bootloader->bootload($registry->getSystemBootloaders());
                     $this->fireCallbacks($this->runningCallbacks);
 
-                    $this->bootload($registry->getLoadBootloaders());
+                    $this->bootload($registry->getBootloaders());
                     $this->bootstrap();
 
                     $this->fireCallbacks($this->bootstrappedCallbacks);
@@ -367,9 +367,6 @@ abstract class AbstractKernel implements KernelInterface
 
     private function initBootloaderRegistry(): BootloaderRegistryInterface
     {
-        return new BootloaderRegistry(
-            $this->defineSystemBootloaders(),
-            $this->defineBootloaders(),
-        );
+        return new BootloaderRegistry($this->defineSystemBootloaders(), $this->defineBootloaders());
     }
 }

--- a/src/Boot/src/Bootloader/BootloaderRegistry.php
+++ b/src/Boot/src/Bootloader/BootloaderRegistry.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Bootloader;
+
+/**
+ * @psalm-import-type TClass from BootloaderRegistryInterface
+ */
+final class BootloaderRegistry implements BootloaderRegistryInterface
+{
+    private const SYSTEM = 'system';
+    private const LOAD = 'load';
+    private const APPLICATION = 'application';
+
+    /**
+     * @param array<TClass>|array<TClass, array<string, mixed>> $system
+     * @param array<TClass>|array<TClass, array<string, mixed>> $load
+     * @param array<TClass>|array<TClass, array<string, mixed>> $application
+     */
+    public function __construct(
+        private array $system = [],
+        private array $load = [],
+        private array $application = [],
+    ) {
+    }
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     */
+    public function addSystemBootloader(string|array $bootloader): void
+    {
+        $this->addBootloader($bootloader, self::SYSTEM);
+    }
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     */
+    public function addLoadBootloader(string|array $bootloader): void
+    {
+        $this->addBootloader($bootloader, self::LOAD);
+    }
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     */
+    public function addApplicationBootloader(string|array $bootloader): void
+    {
+        $this->addBootloader($bootloader, self::APPLICATION);
+    }
+
+    /**
+     * @return array<TClass>|array<TClass, array<string, mixed>>
+     */
+    public function getSystemBootloaders(): array
+    {
+        return $this->system;
+    }
+
+    /**
+     * @return array<TClass>|array<TClass, array<string, mixed>>
+     */
+    public function getLoadBootloaders(): array
+    {
+        return $this->load;
+    }
+
+    /**
+     * @return array<TClass>|array<TClass, array<string, mixed>>
+     */
+    public function getApplicationBootloaders(): array
+    {
+        return $this->application;
+    }
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     * @param 'system'|'load'|'application' $section
+     */
+    private function addBootloader(string|array $bootloader, string $section): void
+    {
+        if (\is_string($bootloader) && \in_array($bootloader, $this->{$section}, true)) {
+            return;
+        }
+
+        $this->{$section}[] = $bootloader;
+    }
+}

--- a/src/Boot/src/Bootloader/BootloaderRegistry.php
+++ b/src/Boot/src/Bootloader/BootloaderRegistry.php
@@ -5,48 +5,48 @@ declare(strict_types=1);
 namespace Spiral\Boot\Bootloader;
 
 /**
- * @psalm-import-type TClass from BootloaderRegistryInterface
+ * @psalm-import-type TClass from \Spiral\Boot\BootloadManagerInterface
  */
 final class BootloaderRegistry implements BootloaderRegistryInterface
 {
-    private const SYSTEM = 'system';
-    private const LOAD = 'load';
-    private const APPLICATION = 'application';
-
     /**
-     * @param array<TClass>|array<TClass, array<string, mixed>> $system
-     * @param array<TClass>|array<TClass, array<string, mixed>> $load
-     * @param array<TClass>|array<TClass, array<string, mixed>> $application
+     * @param array<TClass>|array<TClass, array<string, mixed>> $systemBootloaders
+     * @param array<TClass>|array<TClass, array<string, mixed>> $bootloaders
      */
     public function __construct(
-        private array $system = [],
-        private array $load = [],
-        private array $application = [],
+        private array $systemBootloaders = [],
+        private array $bootloaders = [],
     ) {
     }
 
     /**
      * @param TClass|array<TClass, array<string, mixed>> $bootloader
      */
-    public function addSystemBootloader(string|array $bootloader): void
+    public function registerSystem(string|array $bootloader): void
     {
-        $this->addBootloader($bootloader, self::SYSTEM);
+        if ($this->hasBootloader($bootloader)) {
+            return;
+        }
+
+        \is_string($bootloader)
+            ? $this->systemBootloaders[] = $bootloader
+            : $this->systemBootloaders[\array_key_first($bootloader)] = $bootloader[\array_key_first($bootloader)]
+        ;
     }
 
     /**
      * @param TClass|array<TClass, array<string, mixed>> $bootloader
      */
-    public function addLoadBootloader(string|array $bootloader): void
+    public function register(string|array $bootloader): void
     {
-        $this->addBootloader($bootloader, self::LOAD);
-    }
+        if ($this->hasBootloader($bootloader)) {
+            return;
+        }
 
-    /**
-     * @param TClass|array<TClass, array<string, mixed>> $bootloader
-     */
-    public function addApplicationBootloader(string|array $bootloader): void
-    {
-        $this->addBootloader($bootloader, self::APPLICATION);
+        \is_string($bootloader)
+            ? $this->bootloaders[] = $bootloader
+            : $this->bootloaders[\array_key_first($bootloader)] = $bootloader[\array_key_first($bootloader)]
+        ;
     }
 
     /**
@@ -54,39 +54,15 @@ final class BootloaderRegistry implements BootloaderRegistryInterface
      */
     public function getSystemBootloaders(): array
     {
-        return $this->system;
+        return $this->systemBootloaders;
     }
 
     /**
      * @return array<TClass>|array<TClass, array<string, mixed>>
      */
-    public function getLoadBootloaders(): array
+    public function getBootloaders(): array
     {
-        return $this->load;
-    }
-
-    /**
-     * @return array<TClass>|array<TClass, array<string, mixed>>
-     */
-    public function getApplicationBootloaders(): array
-    {
-        return $this->application;
-    }
-
-    /**
-     * @param TClass|array<TClass, array<string, mixed>> $bootloader
-     * @param 'system'|'load'|'application' $section
-     */
-    private function addBootloader(string|array $bootloader, string $section): void
-    {
-        if ($this->hasBootloader($bootloader)) {
-            return;
-        }
-
-        \is_string($bootloader)
-            ? $this->{$section}[] = $bootloader
-            : $this->{$section}[\array_key_first($bootloader)] = $bootloader[\array_key_first($bootloader)]
-        ;
+        return $this->bootloaders;
     }
 
     /**
@@ -99,8 +75,7 @@ final class BootloaderRegistry implements BootloaderRegistryInterface
         }
 
         return
-            \in_array($bootloader, $this->system, true) ||
-            \in_array($bootloader, $this->load, true) ||
-            \in_array($bootloader, $this->application, true);
+            \in_array($bootloader, $this->systemBootloaders, true) ||
+            \in_array($bootloader, $this->bootloaders, true);
     }
 }

--- a/src/Boot/src/Bootloader/BootloaderRegistry.php
+++ b/src/Boot/src/Bootloader/BootloaderRegistry.php
@@ -79,10 +79,28 @@ final class BootloaderRegistry implements BootloaderRegistryInterface
      */
     private function addBootloader(string|array $bootloader, string $section): void
     {
-        if (\is_string($bootloader) && \in_array($bootloader, $this->{$section}, true)) {
+        if ($this->hasBootloader($bootloader)) {
             return;
         }
 
-        $this->{$section}[] = $bootloader;
+        \is_string($bootloader)
+            ? $this->{$section}[] = $bootloader
+            : $this->{$section}[\array_key_first($bootloader)] = $bootloader[\array_key_first($bootloader)]
+        ;
+    }
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     */
+    private function hasBootloader(string|array $bootloader): bool
+    {
+        if (\is_array($bootloader)) {
+            return false;
+        }
+
+        return
+            \in_array($bootloader, $this->system, true) ||
+            \in_array($bootloader, $this->load, true) ||
+            \in_array($bootloader, $this->application, true);
     }
 }

--- a/src/Boot/src/Bootloader/BootloaderRegistryInterface.php
+++ b/src/Boot/src/Bootloader/BootloaderRegistryInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Boot\Bootloader;
+
+/**
+ * @psalm-type TClass = class-string<BootloaderInterface>
+ */
+interface BootloaderRegistryInterface
+{
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     *
+     * Examples:
+     *  1. SimpleBootloader::class,
+     *  2. [SimpleBootloader::class => ['option' => 'value']]
+     */
+    public function addSystemBootloader(string|array $bootloader): void;
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     *
+     * Examples:
+     *  1. SimpleBootloader::class,
+     *  2. [SimpleBootloader::class => ['option' => 'value']]
+     */
+    public function addLoadBootloader(string|array $bootloader): void;
+
+    /**
+     * @param TClass|array<TClass, array<string, mixed>> $bootloader
+     *
+     * Examples:
+     *  1. SimpleBootloader::class,
+     *  2. [SimpleBootloader::class => ['option' => 'value']]
+     */
+    public function addApplicationBootloader(string|array $bootloader): void;
+
+    /**
+     * @return array<TClass>|array<TClass, array<string, mixed>>
+     */
+    public function getSystemBootloaders(): array;
+
+    /**
+     * @return array<TClass>|array<TClass, array<string, mixed>>
+     */
+    public function getLoadBootloaders(): array;
+
+    /**
+     * @return array<TClass>|array<TClass, array<string, mixed>>
+     */
+    public function getApplicationBootloaders(): array;
+}

--- a/src/Boot/src/Bootloader/BootloaderRegistryInterface.php
+++ b/src/Boot/src/Bootloader/BootloaderRegistryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Boot\Bootloader;
 
 /**
- * @psalm-type TClass = class-string<BootloaderInterface>
+ * @psalm-import-type TClass from \Spiral\Boot\BootloadManagerInterface
  */
 interface BootloaderRegistryInterface
 {
@@ -16,7 +16,7 @@ interface BootloaderRegistryInterface
      *  1. SimpleBootloader::class,
      *  2. [SimpleBootloader::class => ['option' => 'value']]
      */
-    public function addSystemBootloader(string|array $bootloader): void;
+    public function registerSystem(string|array $bootloader): void;
 
     /**
      * @param TClass|array<TClass, array<string, mixed>> $bootloader
@@ -25,16 +25,7 @@ interface BootloaderRegistryInterface
      *  1. SimpleBootloader::class,
      *  2. [SimpleBootloader::class => ['option' => 'value']]
      */
-    public function addLoadBootloader(string|array $bootloader): void;
-
-    /**
-     * @param TClass|array<TClass, array<string, mixed>> $bootloader
-     *
-     * Examples:
-     *  1. SimpleBootloader::class,
-     *  2. [SimpleBootloader::class => ['option' => 'value']]
-     */
-    public function addApplicationBootloader(string|array $bootloader): void;
+    public function register(string|array $bootloader): void;
 
     /**
      * @return array<TClass>|array<TClass, array<string, mixed>>
@@ -44,10 +35,5 @@ interface BootloaderRegistryInterface
     /**
      * @return array<TClass>|array<TClass, array<string, mixed>>
      */
-    public function getLoadBootloaders(): array;
-
-    /**
-     * @return array<TClass>|array<TClass, array<string, mixed>>
-     */
-    public function getApplicationBootloaders(): array;
+    public function getBootloaders(): array;
 }

--- a/src/Boot/tests/Bootloader/BootloaderRegistryTest.php
+++ b/src/Boot/tests/Bootloader/BootloaderRegistryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Boot\Bootloader;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Boot\Bootloader\BootloaderRegistry;
+
+final class BootloaderRegistryTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $registry = new BootloaderRegistry();
+        $this->assertSame([], $registry->getSystemBootloaders());
+        $this->assertSame([], $registry->getBootloaders());
+
+        $registry = new BootloaderRegistry(
+            ['BootloaderA', 'BootloaderB'],
+            ['BootloaderC', 'BootloaderD'],
+        );
+
+        $this->assertSame(['BootloaderA', 'BootloaderB'], $registry->getSystemBootloaders());
+        $this->assertSame(['BootloaderC', 'BootloaderD'], $registry->getBootloaders());
+    }
+
+    public function testSystemBootloaders(): void
+    {
+        $registry = new BootloaderRegistry();
+        $this->assertSame([], $registry->getSystemBootloaders());
+
+        $registry->registerSystem('BootloaderA');
+        $registry->registerSystem(['BootloaderB' => ['option' => 'value']]);
+
+        $this->assertSame([
+            'BootloaderA',
+            'BootloaderB' => ['option' => 'value'],
+        ], $registry->getSystemBootloaders());
+    }
+
+    public function testBootloaders(): void
+    {
+        $registry = new BootloaderRegistry();
+        $this->assertSame([], $registry->getBootloaders());
+
+        $registry->register('BootloaderA');
+        $registry->register(['BootloaderB' => ['option' => 'value']]);
+
+        $this->assertSame([
+            'BootloaderA',
+            'BootloaderB' => ['option' => 'value'],
+        ], $registry->getBootloaders());
+    }
+
+    public function testDuplicateBootloader(): void
+    {
+        $registry = new BootloaderRegistry();
+        $registry->register('BootloaderA');
+        $registry->register('BootloaderA');
+        $registry->registerSystem('BootloaderA');
+
+        $this->assertSame(['BootloaderA'], $registry->getBootloaders());
+        $this->assertSame([], $registry->getSystemBootloaders());
+
+        $registry = new BootloaderRegistry();
+        $registry->registerSystem('BootloaderA');
+        $registry->registerSystem('BootloaderA');
+        $registry->register('BootloaderA');
+
+        $this->assertSame([], $registry->getBootloaders());
+        $this->assertSame(['BootloaderA'], $registry->getSystemBootloaders());
+    }
+}

--- a/src/Framework/Framework/Kernel.php
+++ b/src/Framework/Framework/Kernel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Framework;
 
 use Spiral\Boot\AbstractKernel;
-use Spiral\Boot\Bootloader\BootloaderRegistryInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
 use Spiral\Boot\Exception\BootException;
 use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
@@ -69,6 +68,8 @@ abstract class Kernel extends AbstractKernel
      * Get list of defined application bootloaders
      *
      * @return array<int, class-string>|array<class-string, array<non-empty-string, mixed>>
+     *
+     * @deprecated since v3.10 Use {@see defineBootloaders()} instead. Will be removed in v4.0
      */
     protected function defineAppBootloaders(): array
     {
@@ -80,14 +81,9 @@ abstract class Kernel extends AbstractKernel
      */
     protected function bootstrap(): void
     {
-        $registry = $this->container->get(BootloaderRegistryInterface::class);
-        foreach ($this->defineAppBootloaders() as $bootloader) {
-            $registry->addApplicationBootloader($bootloader);
-        }
-
         $self = $this;
         $this->bootloader->bootload(
-            $registry->getApplicationBootloaders(),
+            $this->defineAppBootloaders(),
             [
                 static function () use ($self): void {
                     $self->fireCallbacks($self->bootingCallbacks);

--- a/src/Framework/Framework/Kernel.php
+++ b/src/Framework/Framework/Kernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Framework;
 
 use Spiral\Boot\AbstractKernel;
+use Spiral\Boot\Bootloader\BootloaderRegistryInterface;
 use Spiral\Boot\Bootloader\CoreBootloader;
 use Spiral\Boot\Exception\BootException;
 use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
@@ -79,9 +80,14 @@ abstract class Kernel extends AbstractKernel
      */
     protected function bootstrap(): void
     {
+        $registry = $this->container->get(BootloaderRegistryInterface::class);
+        foreach ($this->defineAppBootloaders() as $bootloader) {
+            $registry->addApplicationBootloader($bootloader);
+        }
+
         $self = $this;
         $this->bootloader->bootload(
-            $this->defineAppBootloaders(),
+            $registry->getApplicationBootloaders(),
             [
                 static function () use ($self): void {
                     $self->fireCallbacks($self->bootingCallbacks);

--- a/tests/Framework/KernelTest.php
+++ b/tests/Framework/KernelTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Framework;
 
+use Spiral\Boot\Bootloader\BootloaderRegistry;
+use Spiral\Boot\Bootloader\BootloaderRegistryInterface;
 use Spiral\Boot\Exception\BootException;
 use Spiral\App\TestApp;
 use Spiral\Core\Container;
@@ -77,5 +79,21 @@ class KernelTest extends BaseTestCase
 
         $this->assertTrue($callback1);
         $this->assertTrue($callback2);
+    }
+
+    public function testBootloaderRegistryShouldBeBoundAsSingleton(): void
+    {
+        $this->assertContainerBoundAsSingleton(BootloaderRegistryInterface::class, BootloaderRegistry::class);
+    }
+
+    public function testCustomBootloaderRegistry(): void
+    {
+        $registry = $this->createMock(BootloaderRegistryInterface::class);
+        $container = new Container();
+        $container->bindSingleton(BootloaderRegistryInterface::class, $registry);
+
+        $kernel = TestApp::create(directories: ['root' => __DIR__. '/../'], container: $container);
+
+        $this->assertSame($registry, $kernel->getContainer()->get(BootloaderRegistryInterface::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### What was changed

Added the `Spiral\Boot\Bootloader\BootloaderRegistryInterface` interface and the implementation `Spiral\Boot\Bootloader\BootloaderRegistry` to streamline the bootloader registration process. This change allows for a more efficient and flexible bootloader registration mechanism within the Spiral Framework.

### Customization

In situations where customization is needed, you have the option to create your own implementation of the `BootloaderRegistryInterface`:

1. Create a new class that implements the `Spiral\Boot\Bootloader\BootloaderRegistryInterface`. Let's call it `CustomBootloaderRegistry` in this example.

2. Instantiate a container in your app.php.

3. Register your custom implementation in the container:

```php
// app.php
$container = new \Spiral\Core\Container();
$container->bindSingleton(
    \Spiral\Boot\Bootloader\BootloaderRegistryInterface::class,
    CustomBootloaderRegistry::class
);

$app = Kernel::create(
    directories: ['root' => __DIR__],
    container: $container
)->run();

