### PR TITLE
[spiral/filters] Add error handling when performing casting

### DIFF
--- a/src/Filters/src/Attribute/CastingErrorMessage.php
+++ b/src/Filters/src/Attribute/CastingErrorMessage.php
@@ -12,6 +12,9 @@ class CastingErrorMessage
 {
     protected ?\Closure $callback = null;
 
+    /**
+     * @param callable(SetterException $exception, mixed $value): string $callback
+     */
     public function __construct(
         protected ?string $message = null,
         ?callable $callback = null

--- a/src/Filters/src/Attribute/CastingErrorMessage.php
+++ b/src/Filters/src/Attribute/CastingErrorMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Filters\Attribute;
+
+use Spiral\Attributes\NamedArgumentConstructor;
+use Spiral\Filters\Exception\SetterException;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY), NamedArgumentConstructor]
+class CastingErrorMessage
+{
+    protected ?\Closure $callback = null;
+
+    public function __construct(
+        protected ?string $message = null,
+        ?callable $callback = null
+    ) {
+        if ($callback !== null) {
+            $this->callback = $callback(...);
+        }
+    }
+
+    public function getMessage(SetterException $exception, mixed $value = null): ?string
+    {
+        if ($this->callback instanceof \Closure) {
+            return ($this->callback)($exception, $value);
+        }
+
+        return $this->message;
+    }
+}

--- a/src/Filters/src/Exception/SetterException.php
+++ b/src/Filters/src/Exception/SetterException.php
@@ -6,8 +6,11 @@ namespace Spiral\Filters\Exception;
 
 class SetterException extends FilterException
 {
-    public function __construct(\Throwable $previous = null)
+    public function __construct(\Throwable $previous = null, ?string $message = null)
     {
-        parent::__construct(message: 'Unable to set value. The given data was invalid.', previous: $previous);
+        parent::__construct(
+            message: $message ?? 'Unable to set value. The given data was invalid.',
+            previous: $previous,
+        );
     }
 }

--- a/src/Filters/src/Model/Mapper/DefaultCaster.php
+++ b/src/Filters/src/Model/Mapper/DefaultCaster.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Filters\Model\Mapper;
 
+use Spiral\Filters\Exception\SetterException;
 use Spiral\Filters\Model\FilterInterface;
 
 final class DefaultCaster implements CasterInterface
@@ -15,6 +16,13 @@ final class DefaultCaster implements CasterInterface
 
     public function setValue(FilterInterface $filter, \ReflectionProperty $property, mixed $value): void
     {
-        $property->setValue($filter, $value);
+        try {
+            $property->setValue($filter, $value);
+        } catch (\Throwable $e) {
+            throw new SetterException(
+                previous: $e,
+                message: \sprintf('Unable to set value. %s', $e->getMessage()),
+            );
+        }
     }
 }

--- a/src/Filters/src/Model/Mapper/EnumCaster.php
+++ b/src/Filters/src/Model/Mapper/EnumCaster.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Filters\Model\Mapper;
 
+use Spiral\Filters\Exception\SetterException;
 use Spiral\Filters\Model\FilterInterface;
 
 final class EnumCaster implements CasterInterface
@@ -25,6 +26,13 @@ final class EnumCaster implements CasterInterface
          */
         $enum = $type->getName();
 
-        $property->setValue($filter, $value instanceof $enum ? $value : $enum::from($value));
+        try {
+            $property->setValue($filter, $value instanceof $enum ? $value : $enum::from($value));
+        } catch (\Throwable $e) {
+            throw new SetterException(
+                previous: $e,
+                message: \sprintf('Unable to set enum value. %s', $e->getMessage()),
+            );
+        }
     }
 }

--- a/src/Filters/src/Model/Mapper/UuidCaster.php
+++ b/src/Filters/src/Model/Mapper/UuidCaster.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Filters\Model\Mapper;
 
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
+use Spiral\Filters\Exception\SetterException;
 use Spiral\Filters\Model\FilterInterface;
 
 final class UuidCaster implements CasterInterface
@@ -22,10 +24,14 @@ final class UuidCaster implements CasterInterface
 
     public function setValue(FilterInterface $filter, \ReflectionProperty $property, mixed $value): void
     {
-        $property->setValue(
-            $filter,
-            $value instanceof UuidInterface ? $value : \Ramsey\Uuid\Uuid::fromString($value)
-        );
+        try {
+            $property->setValue($filter, $value instanceof UuidInterface ? $value : Uuid::fromString($value));
+        } catch (\Throwable $e) {
+            throw new SetterException(
+                previous: $e,
+                message: \sprintf('Unable to set UUID value. %s', $e->getMessage()),
+            );
+        }
     }
 
     private function implements(string $haystack, string $interface): bool

--- a/src/Filters/src/Model/Schema/AttributeMapper.php
+++ b/src/Filters/src/Model/Schema/AttributeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Filters\Model\Schema;
 
 use Spiral\Attributes\ReaderInterface;
+use Spiral\Filters\Attribute\CastingErrorMessage;
 use Spiral\Filters\Attribute\Input\AbstractInput;
 use Spiral\Filters\Attribute\NestedArray;
 use Spiral\Filters\Attribute\NestedFilter;
@@ -43,10 +44,11 @@ final class AttributeMapper
             /** @var object $attribute */
             foreach ($this->reader->getPropertyMetadata($property) as $attribute) {
                 if ($attribute instanceof AbstractInput) {
+                    $value = $attribute->getValue($input, $property);
                     try {
-                        $this->setValue($filter, $property, $attribute->getValue($input, $property));
+                        $this->setValue($filter, $property, $value);
                     } catch (SetterException $e) {
-                        $errors[$property->getName()] = $e->getMessage();
+                        $errors[$property->getName()] = $this->createErrorMessage($e, $property, $value);
                     }
                     $schema[$property->getName()] = $attribute->getSchema($property);
                 } elseif ($attribute instanceof NestedFilter) {
@@ -60,7 +62,7 @@ final class AttributeMapper
                         try {
                             $this->setValue($filter, $property, $value);
                         } catch (SetterException $e) {
-                            $errors[$property->getName()] = $e->getMessage();
+                            $errors[$property->getName()] = $this->createErrorMessage($e, $property, $value);
                         }
                     } catch (ValidationException $e) {
                         if ($this->allowsNull($property)) {
@@ -92,11 +94,7 @@ final class AttributeMapper
                         }
                     }
 
-                    try {
-                        $this->setValue($filter, $property, $propertyValues);
-                    } catch (SetterException $e) {
-                        $errors[$property->getName()] = $e->getMessage();
-                    }
+                    $this->setValue($filter, $property, $propertyValues);
                     $schema[$property->getName()] = [$attribute->class, $prefix . '.*'];
                 } elseif ($attribute instanceof Setter) {
                     $setters[$property->getName()][] = $attribute;
@@ -127,5 +125,15 @@ final class AttributeMapper
         $type = $property->getType();
 
         return $type === null || $type->allowsNull();
+    }
+
+    private function createErrorMessage(
+        SetterException $exception,
+        \ReflectionProperty $property,
+        mixed $value = null
+    ): string {
+        $attribute = $this->reader->firstPropertyMetadata($property, CastingErrorMessage::class);
+
+        return $attribute !== null ? $attribute->getMessage($exception, $value) : $exception->getMessage();
     }
 }

--- a/src/Filters/src/Model/Schema/AttributeMapper.php
+++ b/src/Filters/src/Model/Schema/AttributeMapper.php
@@ -134,6 +134,10 @@ final class AttributeMapper
     ): string {
         $attribute = $this->reader->firstPropertyMetadata($property, CastingErrorMessage::class);
 
-        return $attribute !== null ? $attribute->getMessage($exception, $value) : $exception->getMessage();
+        if ($attribute === null) {
+            return $exception->getMessage();
+        }
+
+        return $attribute->getMessage($exception, $value) ?? $exception->getMessage();
     }
 }

--- a/src/Filters/tests/Mapper/DefaultCasterTest.php
+++ b/src/Filters/tests/Mapper/DefaultCasterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Filters\Mapper;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Filters\Exception\SetterException;
 use Spiral\Filters\Model\Mapper\DefaultCaster;
 use Spiral\Tests\Filters\Fixtures\AddressFilter;
 
@@ -23,5 +24,20 @@ final class DefaultCasterTest extends TestCase
 
         $setter->setValue($filter, $property, 'foo');
         $this->assertSame('foo', $property->getValue($filter));
+    }
+
+    public function testSetValueException(): void
+    {
+        $setter = new DefaultCaster();
+        $filter = $this->createMock(AddressFilter::class);
+        $property = new \ReflectionProperty($filter, 'city');
+
+        $this->expectException(SetterException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Unable to set value. Cannot assign %s to property %s::$city of type string',
+            \stdClass::class,
+            AddressFilter::class
+        ));
+        $setter->setValue($filter, $property, new \stdClass());
     }
 }

--- a/src/Filters/tests/Mapper/EnumCasterTest.php
+++ b/src/Filters/tests/Mapper/EnumCasterTest.php
@@ -36,9 +36,6 @@ final class EnumCasterTest extends TestCase
         $property = new \ReflectionProperty($filter, 'status');
 
         $this->expectException(SetterException::class);
-        $this->expectExceptionMessage(
-            \sprintf('Unable to set enum value. "foo" is not a valid backing value for enum %s', Status::class)
-        );
         $setter->setValue($filter, $property, 'foo');
     }
 

--- a/src/Filters/tests/Mapper/EnumCasterTest.php
+++ b/src/Filters/tests/Mapper/EnumCasterTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Filters\Mapper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Spiral\Filters\Exception\SetterException;
 use Spiral\Filters\Model\Mapper\EnumCaster;
 use Spiral\Tests\Filters\Fixtures\Status;
 use Spiral\Tests\Filters\Fixtures\UserFilter;
@@ -26,6 +27,19 @@ final class EnumCasterTest extends TestCase
 
         $setter->setValue($filter, $property, 'active');
         $this->assertEquals(Status::Active, $property->getValue($filter));
+    }
+
+    public function testSetValueException(): void
+    {
+        $setter = new EnumCaster();
+        $filter = $this->createMock(UserFilter::class);
+        $property = new \ReflectionProperty($filter, 'status');
+
+        $this->expectException(SetterException::class);
+        $this->expectExceptionMessage(
+            \sprintf('Unable to set enum value. "foo" is not a valid backing value for enum %s', Status::class)
+        );
+        $setter->setValue($filter, $property, 'foo');
     }
 
     public static function supportsDataProvider(): \Traversable

--- a/src/Filters/tests/Mapper/UuidCasterTest.php
+++ b/src/Filters/tests/Mapper/UuidCasterTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Filters\Mapper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Spiral\Filters\Exception\SetterException;
 use Spiral\Filters\Model\Mapper\UuidCaster;
 use Spiral\Tests\Filters\Fixtures\UserFilter;
 
@@ -25,6 +26,17 @@ final class UuidCasterTest extends TestCase
 
         $setter->setValue($filter, $property, '11111111-1111-1111-1111-111111111111');
         $this->assertSame('11111111-1111-1111-1111-111111111111', $property->getValue($filter)->toString());
+    }
+
+    public function testSetValueException(): void
+    {
+        $setter = new UuidCaster();
+        $filter = $this->createMock(UserFilter::class);
+        $ref = new \ReflectionProperty($filter, 'friendUuid');
+
+        $this->expectException(SetterException::class);
+        $this->expectExceptionMessage('Unable to set UUID value. Invalid UUID string: foo');
+        $setter->setValue($filter, $ref, 'foo');
     }
 
     public static function supportsDataProvider(): \Traversable

--- a/tests/Framework/Filter/Model/CastingErrorMessagesTest.php
+++ b/tests/Framework/Filter/Model/CastingErrorMessagesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Filter\Model;
+
+use Spiral\App\Request\CastingErrorMessages;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Tests\Framework\Filter\FilterTestCase;
+
+final class CastingErrorMessagesTest extends FilterTestCase
+{
+    public function testValidationMessages(): void
+    {
+        try {
+            $this->getFilter(CastingErrorMessages::class, [
+                'uuid' => 'foo',
+                'uuidWithValidationMessage' => 'foo',
+                'uuidWithValidationMessageCallback' => 'foo',
+            ]);
+        } catch (ValidationException $e) {
+            $this->assertSame([
+                'uuid' => 'Unable to set UUID value. Invalid UUID string: foo',
+                'uuidWithValidationMessage' => 'Invalid UUID',
+                'uuidWithValidationMessageCallback' => 'Invalid UUID: foo. Error: Unable to set UUID value. Invalid UUID string: foo',
+            ], $e->errors);
+        }
+    }
+}

--- a/tests/app/src/Request/CastingErrorMessages.php
+++ b/tests/app/src/Request/CastingErrorMessages.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Request;
+
+use Ramsey\Uuid\UuidInterface;
+use Spiral\Filters\Attribute\Input\Post;
+use Spiral\Filters\Attribute\CastingErrorMessage;
+use Spiral\Filters\Model\Filter;
+
+final class CastingErrorMessages extends Filter
+{
+    #[Post]
+    public UuidInterface $uuid;
+
+    #[Post]
+    #[CastingErrorMessage('Invalid UUID')]
+    public UuidInterface $uuidWithValidationMessage;
+
+    #[Post]
+    #[CastingErrorMessage(callback: [self::class, 'validationMessageCallback'])]
+    public UuidInterface $uuidWithValidationMessageCallback;
+
+    public static function validationMessageCallback(\Throwable $e, mixed $value): string
+    {
+        return \sprintf('Invalid UUID: %s. Error: %s', $value, $e->getMessage());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### What was changed

Added exception handling for errors occurring during value casting using `Spiral\Filters\Model\Mapper\EnumCaster`, `Spiral\Filters\Model\Mapper\UuidCaster`, and `Spiral\Filters\Model\Mapper\DefaultCaster`. Now, in the event of errors, a `Spiral\Filters\Exception\SetterException` will be thrown.

Introduced the `Spiral\Filters\Attribute\CastingErrorMessage` attribute, allowing the specification of an error message for enhanced error handling.

```php
use Ramsey\Uuid\UuidInterface;
use Spiral\Filters\Attribute\Input\Post;
use Spiral\Filters\Attribute\CastingErrorMessage;
use Spiral\Filters\Model\Filter;

final class CreateUser extends Filter
{
    #[Post]
    public string $name;

    #[Post]
    #[CastingErrorMessage('Invalid UUID')]
    public UuidInterface $groupUuid;
}
```
