### PR TITLE
[spiral/console] Check that the stream is not null before calling the posix_isatty function

### DIFF
--- a/src/Console/src/Console.php
+++ b/src/Console/src/Console.php
@@ -156,7 +156,7 @@ final class Console
                 $inputStream = $input->getStream();
             }
 
-            if (!@posix_isatty($inputStream) && false === getenv('SHELL_INTERACTIVE')) {
+            if ($inputStream !== null && !@posix_isatty($inputStream) && false === getenv('SHELL_INTERACTIVE')) {
                 $input->setInteractive(false);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | #1032 
