### PR TITLE
[spiral/console] Add the ability to use enum as console option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Other Features**
     - The `Spiral\Debug\Config\DebugConfig` has been added for easy addition of **tags** and **collectors**.
+    - [spiral/console] The ability to use **enum** as an option in a console command when configuring it with attributes has been added.
 
 ## 3.10.0 - 2023-11-24
 

--- a/src/Console/src/Configurator/Attribute/Parser.php
+++ b/src/Console/src/Configurator/Attribute/Parser.php
@@ -179,12 +179,15 @@ final class Parser
             return $value;
         }
 
-        return match ($type->getName()) {
-            'int' => (int) $value,
-            'string' => (string) $value,
-            'bool' => (bool) $value,
-            'float' => (float) $value,
-            'array' => (array) $value,
+        $typeName = $type->getName();
+
+        return match (true) {
+            $typeName === 'int' => (int) $value,
+            $typeName === 'string' => (string) $value,
+            $typeName === 'bool' => (bool) $value,
+            $typeName === 'float' => (float) $value,
+            $typeName === 'array' => (array) $value,
+            \enum_exists($typeName) => $typeName::from($value),
             default => $value
         };
     }
@@ -209,6 +212,10 @@ final class Parser
                     return $type;
                 }
             }
+        }
+
+        if (!$type->isBuiltin() && \enum_exists($type->getName())) {
+            return $type;
         }
 
         if ($type instanceof \ReflectionNamedType && $type->isBuiltin() && $type->getName() !== 'object') {

--- a/src/Console/tests/Configurator/Attribute/FillPropertiesTest.php
+++ b/src/Console/tests/Configurator/Attribute/FillPropertiesTest.php
@@ -11,6 +11,7 @@ use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Attribute\Option;
 use Spiral\Console\Command;
 use Spiral\Console\Configurator\Attribute\Parser;
+use Spiral\Tests\Console\Fixtures\Status;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -126,6 +127,37 @@ final class FillPropertiesTest extends TestCase
         $this->assertSame(0.5, $command->floatVal);
         $this->assertTrue($command->boolVal);
         $this->assertTrue($command->otherBoolVal);
+    }
+
+    public function testEnumOption(): void
+    {
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->expects($this->exactly(3))
+            ->method('hasOption')
+            ->willReturn(true);
+
+        $input
+            ->expects($this->exactly(3))
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(1, null, 0);
+
+        $command = new #[AsCommand('foo')] class extends Command {
+            #[Option(mode: InputOption::VALUE_REQUIRED)]
+            public Status $required;
+
+            #[Option(mode: InputOption::VALUE_OPTIONAL)]
+            public ?Status $nullable = null;
+
+            #[Option(mode: InputOption::VALUE_OPTIONAL)]
+            public ?Status $nullableFilled = null;
+        };
+
+        $this->parser->fillProperties($command, $input);
+
+        $this->assertEquals(Status::Active, $command->required);
+        $this->assertNull($command->nullable);
+        $this->assertEquals(Status::Inactive, $command->nullableFilled);
     }
 
     public function testSkipPropertyIfOptionNotDefined(): void

--- a/src/Console/tests/Fixtures/Status.php
+++ b/src/Console/tests/Fixtures/Status.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Console\Fixtures;
+
+enum Status: int
+{
+    case Active = 1;
+    case Inactive = 0;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

The ability to use Enum as an option in a console command when configuring it with attributes has been added. For example, option Status in the example below:

```php
use App\Domain\User\Status;
use Spiral\Console\Attribute\Argument;
use Spiral\Console\Attribute\AsCommand;
use Spiral\Console\Attribute\Option;
use Spiral\Console\Attribute\Question;
use Spiral\Console\Command;

#[AsCommand(name: 'app:create-user', description: 'Create user')]
final class CreateUser extends Command
{
    #[Argument(description: 'User email')]
    #[Question(question: 'Provide user email')]
    private string $email;

    #[Option(description: 'User status')]
    private Status $status;

    public function __invoke(): int
    {
        // ...
    }
}
```