### PR TITLE
Disable scoped container leak check; dedeprecate method `runScope()`

### DIFF
--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -158,8 +158,6 @@ final class Container implements
 
     /**
      * @throws \Throwable
-     *
-     * @deprecated use {@see runScoped()} instead.
      */
     public function runScope(array $bindings, callable $scope): mixed
     {
@@ -211,35 +209,26 @@ final class Container implements
         // Open scope
         $container = new self($this->config, $name);
 
-        try {
-            // Configure scope
-            $container->scope->setParent($this, $this->scope);
+        // Configure scope
+        $container->scope->setParent($this, $this->scope);
 
-            // Add specific bindings
-            foreach ($bindings as $alias => $resolver) {
-                $container->binder->bind($alias, $resolver);
-            }
-
-            return ContainerScope::runScope(
-                $container,
-                static function (self $container) use ($autowire, $closure): mixed {
-                    try {
-                        return $autowire
-                            ? $container->invoke($closure)
-                            : $closure($container);
-                    } finally {
-                        $container->closeScope();
-                    }
-                }
-            );
-        } finally {
-            // Check the container has not been leaked
-            $link = \WeakReference::create($container);
-            unset($container);
-            if ($link->get() !== null) {
-                throw new ScopeContainerLeakedException($name, $this->scope->getParentScopeNames());
-            }
+        // Add specific bindings
+        foreach ($bindings as $alias => $resolver) {
+            $container->binder->bind($alias, $resolver);
         }
+
+        return ContainerScope::runScope(
+            $container,
+            static function (self $container) use ($autowire, $closure): mixed {
+                try {
+                    return $autowire
+                        ? $container->invoke($closure)
+                        : $closure($container);
+                } finally {
+                    $container->closeScope();
+                }
+            }
+        );
     }
 
     /**

--- a/src/Core/tests/Scope/UseCaseTest.php
+++ b/src/Core/tests/Scope/UseCaseTest.php
@@ -37,8 +37,10 @@ final class UseCaseTest extends BaseTestCase
     }
 
     /**
+     * Todo: may be uncommented when politics about container leak will be decided.
+     *
      * Child container must be destroyed after scope completion and mustn't be leaked
-     */
+     *
     public function testChildContainerDestruction(): void
     {
         $root = new Container();
@@ -50,7 +52,7 @@ final class UseCaseTest extends BaseTestCase
         $root->runScoped(function (ContainerInterface $c1): callable {
             return fn() => $c1->get('foo');
         });
-    }
+    } */
 
     /**
      * A child scope bindings are not singleton.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | Closes #1037

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->
