### PR TITLE
Implement Custom Path Segment Encoding in Router

### DIFF
--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -61,7 +61,7 @@ final class UriHandler
         $this->patternRegistry = $patternRegistry ?? new DefaultPatternRegistry();
 
         $slugify ??= new Slugify();
-        $this->pathSegmentEncoder = static fn(string $segment): string => $slugify->slugify($segment);
+        $this->pathSegmentEncoder = static fn (string $segment): string => $slugify->slugify($segment);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a significant improvement to the router component, particularly in handling URIs with parameters containing non-Latin characters, like Cyrillic symbols.

**Background:**
Previously, the router component had a limitation where path parameters with non-Latin characters were automatically transliterated into Latin characters. This behavior was not always desirable, especially in cases where maintaining the original character set in the URI was crucial (e.g., for SEO or multilingual applications).

Here is an example of a problem:

```php
$router->setRoute(
  'page',
  new Route('/page/<path>', ....),
);

$uri = $router->uri('page', ['path' => 'some-path']);

// Generates
// /page/some-path

$uri = $router->uri('page', ['path' => 'некоторый-путь']); 

// Generates
// /page/nekotoiy-put
```

**Change Summary:**
- A method has been added to allow custom path segment encoding.
- Users can now specify their own function for encoding path segments.
- This enhancement makes the router more flexible and capable of handling a wide range of character sets in URIs.

**Implementation Details:**
The change includes an option to replace the default URI handler for a route with a custom encoding function. This is done by using the `withPathSegmentEncoder` method, which accepts a user-defined function for segment encoding.

**Example Usage:**

```php
$router->setRoute(
  'page',
  new Route('/page/<path>', ....),
);
$route = $router->getRoute('group');

$uriHandler = $route->getUriHandler()->withPathSegmentEncoder(
  fn(string $segment) => \rawurlencode($segment)
);

$route = $route->withUriHandler($uriHandler);

$uri = $router->uri('page', ['path' => 'некоторый-путь']); 

// Generates
// /page/%D0%BD%D0%B5%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D1%8B%D0%B9-%D0%BF%D1%83%D1%82%D1%8C
```

The UriHandler can be bound into an application container via Bootloader:

```php
<?php

declare(strict_types=1);

namespace App\Application\Bootloader;

use Psr\Http\Message\UriFactoryInterface;
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Router\UriHandler;

final class AppBootloader extends Bootloader
{
    public function defineSingletons(): array
    {
        return [
            UriHandler::class => function (UriFactoryInterface $uriFactory) {
                return (new UriHandler($uriFactory))->withPathSegmentEncoder(
                    static fn(string $segment): string => \rawurlencode($segment)
                );
            },
        ];
    }
}
```

This update offers a more inclusive and adaptable routing solution, accommodating a broader range of languages and character sets in URIs. It's a crucial step towards enhancing the framework's usability in global and multilingual contexts.

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
