### PR TITLE
Extended injector

### DIFF
--- a/src/Core/src/Attribute/Singleton.php
+++ b/src/Core/src/Attribute/Singleton.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Attribute;
 
-use Spiral\Core\Internal\Factory\Ctx;
-
 /**
  * Mark class as singleton.
  */

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -114,7 +114,7 @@ final class Container implements
      * @throws ContainerException
      * @throws \Throwable
      */
-    public function make(string $alias, array $parameters = [], string $context = null): mixed
+    public function make(string $alias, array $parameters = [], \Stringable|string|null $context = null): mixed
     {
         /** @psalm-suppress TooManyArguments */
         return $this->factory->make($alias, $parameters, $context);

--- a/src/Core/src/Container/InjectorInterface.php
+++ b/src/Core/src/Container/InjectorInterface.php
@@ -22,12 +22,11 @@ interface InjectorInterface
      * Parameter reflection can be used for dynamic class constructing, for example it can define
      * database name or config section to be used to construct requested instance.
      *
-     * @param \ReflectionClass $class Request class type.
+     * @param \ReflectionClass<TClass> $class Request class type.
      * @param string|null $context Parameter or alias name.
      *
      * @return TClass
      *
-     * @psalm-assert \ReflectionClass<TClass> $class
      * @throws ContainerException
      */
     public function createInjection(\ReflectionClass $class, ?string $context = null): object;

--- a/src/Core/src/Container/InjectorInterface.php
+++ b/src/Core/src/Container/InjectorInterface.php
@@ -24,10 +24,10 @@ interface InjectorInterface
      *
      * @param \ReflectionClass $class Request class type.
      * @param string|null $context Parameter or alias name.
-     * @psalm-assert \ReflectionClass<TClass> $class
      *
      * @return TClass
      *
+     * @psalm-assert \ReflectionClass<TClass> $class
      * @throws ContainerException
      */
     public function createInjection(\ReflectionClass $class, ?string $context = null): object;

--- a/src/Core/src/Internal/Container.php
+++ b/src/Core/src/Internal/Container.php
@@ -47,7 +47,7 @@ final class Container implements ContainerInterface
      * @throws ContainerException
      * @throws \Throwable
      */
-    public function get(string|Autowire $id, string $context = null): mixed
+    public function get(string|Autowire $id, \Stringable|string|null $context = null): mixed
     {
         if ($id instanceof Autowire) {
             return $id->resolve($this->factory);

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -140,7 +140,8 @@ final class Factory implements FactoryInterface
             // todo wat should we do with arguments?
             /** @var array<class-string<InjectorInterface>, \ReflectionMethod|false> $cache reflection for extended injectors */
             static $cache = [];
-            $extended = $cache[$injectorInstance::class] ??= (static fn(\ReflectionType $type): bool =>
+            $extended = $cache[$injectorInstance::class] ??= (
+                static fn (\ReflectionType $type): bool =>
                 $type::class === \ReflectionUnionType::class || (string)$type === 'mixed'
             )(
                 ($refMethod = new \ReflectionMethod($injectorInstance, 'createInjection'))

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -113,6 +113,10 @@ final class Factory implements FactoryInterface
         }
     }
 
+    /**
+     * @psalm-suppress UnusedParam
+     * todo wat should we do with $arguments?
+     */
     private function resolveInjector(Injectable $binding, Ctx $ctx, array $arguments)
     {
         $context = $ctx->context;
@@ -137,7 +141,6 @@ final class Factory implements FactoryInterface
                 );
             }
 
-            // todo wat should we do with arguments?
             /** @var array<class-string<InjectorInterface>, \ReflectionMethod|false> $cache reflection for extended injectors */
             static $cache = [];
             $extended = $cache[$injectorInstance::class] ??= (

--- a/src/Core/src/Internal/Factory/Ctx.php
+++ b/src/Core/src/Internal/Factory/Ctx.php
@@ -17,7 +17,7 @@ final class Ctx
     public function __construct(
         public readonly string $alias,
         public string $class,
-        public ?string $parameter = null,
+        public \Stringable|string|null $parameter = null,
         public ?bool $singleton = null,
         public ?\ReflectionClass $reflection = null,
     ) {

--- a/src/Core/src/Internal/Factory/Ctx.php
+++ b/src/Core/src/Internal/Factory/Ctx.php
@@ -17,7 +17,7 @@ final class Ctx
     public function __construct(
         public readonly string $alias,
         public string $class,
-        public \Stringable|string|null $parameter = null,
+        public \Stringable|string|null $context = null,
         public ?bool $singleton = null,
         public ?\ReflectionClass $reflection = null,
     ) {

--- a/src/Core/src/Internal/Resolver.php
+++ b/src/Core/src/Internal/Resolver.php
@@ -208,7 +208,7 @@ final class Resolver implements ResolverInterface
             $types = $reflectionType instanceof ReflectionNamedType ? [$reflectionType] : $reflectionType->getTypes();
             foreach ($types as $namedType) {
                 try {
-                    if (!$namedType->isBuiltin() && $this->resolveObject($state, $namedType, $parameter, $validate,)) {
+                    if (!$namedType->isBuiltin() && $this->resolveObject($state, $namedType, $parameter, $validate)) {
                         return true;
                     }
                 } catch (Throwable $e) {

--- a/src/Core/src/Internal/Resolver.php
+++ b/src/Core/src/Internal/Resolver.php
@@ -208,7 +208,7 @@ final class Resolver implements ResolverInterface
             $types = $reflectionType instanceof ReflectionNamedType ? [$reflectionType] : $reflectionType->getTypes();
             foreach ($types as $namedType) {
                 try {
-                    if ($this->resolveNamedType($state, $parameter, $namedType, $validate)) {
+                    if (!$namedType->isBuiltin() && $this->resolveObject($state, $namedType, $parameter, $validate,)) {
                         return true;
                     }
                 } catch (Throwable $e) {
@@ -238,44 +238,20 @@ final class Resolver implements ResolverInterface
     }
 
     /**
-     * Resolve single named type. Returns {@see true} if argument was resolved.
-     *
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     *
-     * @return bool
-     */
-    private function resolveNamedType(
-        ResolvingState $state,
-        ReflectionParameter $parameter,
-        ReflectionNamedType $typeRef,
-        bool $validate,
-    ) {
-        return !$typeRef->isBuiltin() && $this->resolveObjectParameter(
-            $state,
-            $typeRef->getName(),
-            $parameter->getName(),
-            $validate ? $parameter : null,
-        );
-    }
-
-    /**
      * Resolve argument by class name and context. Returns {@see true} if argument resolved.
      *
-     * @psalm-param class-string $class
-     *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    private function resolveObjectParameter(
+    private function resolveObject(
         ResolvingState $state,
-        string $class,
-        string $context,
-        ReflectionParameter $validateWith = null,
+        ReflectionNamedType $type,
+        ReflectionParameter $parameter,
+        bool $validateWith = false,
     ): bool {
         /** @psalm-suppress TooManyArguments */
-        $argument = $this->container->get($class, $context);
-        $this->processArgument($state, $argument, $validateWith);
+        $argument = $this->container->get($type->getName(), $parameter);
+        $this->processArgument($state, $argument, $validateWith ? $parameter : null);
         return true;
     }
 

--- a/src/Core/tests/ExceptionsTest.php
+++ b/src/Core/tests/ExceptionsTest.php
@@ -96,7 +96,7 @@ class ExceptionsTest extends TestCase
               signature: function (Psr\Container\ContainerInterface $container, Spiral\Tests\Core\Fixtures\InvalidClass $class)
               - action: 'autowire'
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
-                context: 'class'
+                context: Parameter #1 [ <required> Spiral\Tests\Core\Fixtures\InvalidClass $class ]
             MARKDOWN,
         );
 
@@ -207,7 +207,7 @@ class ExceptionsTest extends TestCase
               signature: function (Spiral\Tests\Core\Fixtures\InvalidClass $class)
               - action: 'autowire'
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
-                context: 'class'
+                context: Parameter #0 [ <required> Spiral\Tests\Core\Fixtures\InvalidClass $class ]
             MARKDOWN
         ];
         yield 'binding' => [
@@ -223,7 +223,7 @@ class ExceptionsTest extends TestCase
               - action: 'resolve from binding'
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
                 scope: 'root'
-                context: 'class'
+                context: Parameter #0 [ <required> Spiral\Tests\Core\Fixtures\InvalidClass $class ]
                 binding: Deferred factory 'invalid'->invalid()
                 - action: 'autowire'
                   alias: 'invalid'
@@ -243,11 +243,11 @@ class ExceptionsTest extends TestCase
               - action: 'resolve from binding'
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
                 scope: 'root'
-                context: 'class'
+                context: Parameter #0 [ <required> Spiral\Tests\Core\Fixtures\InvalidClass $class ]
                 binding: Alias to `Spiral\Tests\Core\Fixtures\WithPrivateConstructor`
                 - action: 'autowire'
                   alias: 'Spiral\Tests\Core\Fixtures\WithPrivateConstructor'
-                  context: 'class'
+                  context: Parameter #0 [ <required> Spiral\Tests\Core\Fixtures\InvalidClass $class ]
             MARKDOWN
         ];
         yield 'withClosure' => [
@@ -275,7 +275,7 @@ class ExceptionsTest extends TestCase
               - action: 'resolve from binding'
                 alias: 'Spiral\Tests\Core\Fixtures\InvalidClass'
                 scope: 'root'
-                context: 'class'
+                context: Parameter #0 [ <required> Spiral\Tests\Core\Fixtures\InvalidClass $class ]
                 binding: Factory from static function (Psr\Container\ContainerInterface $container)
                 - action: 'autowire'
                   alias: 'invalid'

--- a/src/Core/tests/Fixtures/ExtendedContextInjector.php
+++ b/src/Core/tests/Fixtures/ExtendedContextInjector.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Fixtures;
 
-use DateTimeInterface;
 use Spiral\Core\Container\InjectorInterface;
+use stdClass;
 
 /**
- * @implements InjectorInterface<DateTimeInterface>
+ * @implements InjectorInterface<stdClass>
  */
 class ExtendedContextInjector implements InjectorInterface
 {

--- a/src/Core/tests/Fixtures/ExtendedContextInjector.php
+++ b/src/Core/tests/Fixtures/ExtendedContextInjector.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Fixtures;
+
+use DateTimeInterface;
+use Spiral\Core\Container\InjectorInterface;
+
+/**
+ * @implements InjectorInterface<DateTimeInterface>
+ */
+class ExtendedContextInjector implements InjectorInterface
+{
+    public function createInjection(\ReflectionClass $class, \ReflectionParameter|string|null $context = null): object
+    {
+        return (object)['context' => $context];
+    }
+}

--- a/src/Core/tests/InjectableTest.php
+++ b/src/Core/tests/InjectableTest.php
@@ -13,6 +13,7 @@ use Spiral\Core\ConfigsInterface;
 use Spiral\Core\Container;
 use Spiral\Core\Exception\Container\AutowireException;
 use Spiral\Core\Exception\Container\InjectionException;
+use Spiral\Tests\Core\Fixtures\ExtendedContextInjector;
 use Spiral\Tests\Core\Fixtures\InjectableClassChildImplementation;
 use Spiral\Tests\Core\Fixtures\InjectableClassChildInterface;
 use Spiral\Tests\Core\Fixtures\InjectableClassInterface;
@@ -20,6 +21,7 @@ use Spiral\Tests\Core\Fixtures\InjectableClassImplementation;
 use Spiral\Tests\Core\Fixtures\InvalidInjector;
 use Spiral\Tests\Core\Fixtures\SampleClass;
 use Spiral\Tests\Core\Fixtures\TestConfig;
+use stdClass;
 
 class InjectableTest extends TestCase
 {
@@ -188,6 +190,17 @@ class InjectableTest extends TestCase
         $container->bindInjector(InjectableClassInterface::class, 'injector');
 
         $container->get($class);
+    }
+
+    public function testExtendedInjector(): void
+    {
+        $container = new Container();
+        $container->bindInjector(stdClass::class, ExtendedContextInjector::class);
+
+        $result = $container->invoke(fn(stdClass $dt) => $dt);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(\ReflectionParameter::class, $result->context);
     }
 
     /**

--- a/src/Core/tests/InjectableTest.php
+++ b/src/Core/tests/InjectableTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
+use Spiral\Core\Config\Injectable;
 use Spiral\Core\ConfigsInterface;
 use Spiral\Core\Container;
 use Spiral\Core\Exception\Container\AutowireException;
@@ -196,6 +197,38 @@ class InjectableTest extends TestCase
     {
         $container = new Container();
         $container->bindInjector(stdClass::class, ExtendedContextInjector::class);
+
+        $result = $container->invoke(fn(stdClass $dt) => $dt);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(\ReflectionParameter::class, $result->context);
+    }
+
+    public function testExtendedInjectorAnonClassObjectParam(): void
+    {
+        $container = new Container();
+        $container->bind(stdClass::class, new Injectable(new class implements Container\InjectorInterface {
+            public function createInjection(\ReflectionClass $class, object|string|null $context = null): object
+            {
+                return (object)['context' => $context];
+            }
+        }));
+
+        $result = $container->invoke(fn(stdClass $dt) => $dt);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertInstanceOf(\ReflectionParameter::class, $result->context);
+    }
+
+    public function testExtendedInjectorAnonClassMixedParam(): void
+    {
+        $container = new Container();
+        $container->bind(stdClass::class, new Injectable(new class implements Container\InjectorInterface {
+            public function createInjection(\ReflectionClass $class, mixed $context = null): object
+            {
+                return (object)['context' => $context];
+            }
+        }));
 
         $result = $container->invoke(fn(stdClass $dt) => $dt);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | Closes #888


## Container Factory

Now the container factory accepts a `Stringable` context. This can be either reflection or any other `Stringable`.

```php
$container->make('foo', new StringableContext());
```

Other container methods with an extended context will be available in a separate PR.

## Injectors

If the injector has an extended signature that allows passing an extended context (type of the `$context` parameter is `Stringable|string|null`, `mixed` or `ReflectionParameter|string|null`), the extended context will be passed.

```php
class ExtendedContextInjector implements InjectorInterface
{
    public function createInjection(\ReflectionClass $class, \ReflectionParameter|string|null $context = null): object
    {
        return (object)['context' => $context];
    }
}
```