### PR TITLE
Adding Listeners to the Tokenizer Info console command

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,7 +9,6 @@ enabled:
   - linebreak_after_opening_tag
   - single_quote
   - no_blank_lines_after_phpdoc
-  - unary_operator_spaces
   - no_useless_else
   - no_useless_return
   - trailing_comma_in_multiline_array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- **Other Features**
+    - Added Tokenizer Listeners to the `Spiral\Command\Tokenizer\InfoCommand` console command.
+
 ## 3.11.0 - 2023-12-21
 
 - **Other Features**

--- a/src/Framework/Command/Tokenizer/InfoCommand.php
+++ b/src/Framework/Command/Tokenizer/InfoCommand.php
@@ -77,7 +77,7 @@ final class InfoCommand extends Command
         foreach ($listeners as $listener) {
             $grid->addRow([
                 $listener,
-                \str_replace($dirs->get('root'), '', (new \ReflectionClass($listener))->getFileName())
+                \str_replace($dirs->get('root'), '', (new \ReflectionClass($listener))->getFileName()),
             ]);
         }
 

--- a/src/Framework/Command/Tokenizer/InfoCommand.php
+++ b/src/Framework/Command/Tokenizer/InfoCommand.php
@@ -7,14 +7,18 @@ namespace Spiral\Command\Tokenizer;
 use Spiral\Boot\DirectoriesInterface;
 use Spiral\Console\Command;
 use Spiral\Tokenizer\Config\TokenizerConfig;
+use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
 
 final class InfoCommand extends Command
 {
     protected const NAME = 'tokenizer:info';
     protected const DESCRIPTION = 'Get information about tokenizer directories to scan';
 
-    public function perform(TokenizerConfig $config, DirectoriesInterface $dirs): int
-    {
+    public function perform(
+        TokenizerConfig $config,
+        DirectoriesInterface $dirs,
+        TokenizerListenerRegistryInterface $listenerRegistry
+    ): int {
         $this->info('Included directories:');
         $grid = $this->table(['Directory', 'Scope']);
         foreach ($config->getDirectories() as $directory) {
@@ -61,6 +65,25 @@ final class InfoCommand extends Command
         );
 
         $grid->render();
+
+        $listeners = \method_exists($listenerRegistry, 'getListenerClasses')
+            ? $listenerRegistry->getListenerClasses()
+            : [];
+
+        $this->newLine();
+
+        $this->info('Listeners:');
+        $grid = $this->table(['Registered Listener', 'File']);
+        foreach ($listeners as $listener) {
+            $grid->addRow([
+                $listener,
+                \str_replace($dirs->get('root'), '', (new \ReflectionClass($listener))->getFileName())
+            ]);
+        }
+
+        $grid->render();
+
+        $this->newLine();
 
         $this->newLine();
         $this->info(

--- a/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
@@ -49,9 +49,13 @@ final class TokenizerListenerBootloader extends Bootloader implements
     /** @var TokenizationListenerInterface[] */
     private array $listeners = [];
 
+    /** @var array<class-string<TokenizationListenerInterface>> */
+    private array $listenerClasses = [];
+
     public function addListener(TokenizationListenerInterface $listener): void
     {
         $this->listeners[] = $listener;
+        $this->listenerClasses[] = $listener::class;
     }
 
     public function init(AbstractKernel $kernel): void
@@ -84,6 +88,14 @@ final class TokenizerListenerBootloader extends Bootloader implements
         TokenizerConfig $config,
     ): InterfacesLoaderInterface {
         return $this->makeCachedLoader($factory, $config, CachedInterfacesLoader::class);
+    }
+
+    /**
+     * @return array<class-string<TokenizationListenerInterface>>
+     */
+    public function getListenerClasses(): array
+    {
+        return $this->listenerClasses;
     }
 
     /**

--- a/src/Tokenizer/src/TokenizerListenerRegistryInterface.php
+++ b/src/Tokenizer/src/TokenizerListenerRegistryInterface.php
@@ -6,6 +6,7 @@ namespace Spiral\Tokenizer;
 
 /**
  * It contains all listeners that will be noticed about found classes by a class locator.
+ * @method getListenerClasses(): array
  */
 interface TokenizerListenerRegistryInterface
 {

--- a/tests/Framework/Console/Command/Tokenizer/InfoCommandTest.php
+++ b/tests/Framework/Console/Command/Tokenizer/InfoCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Console\Command\Tokenizer;
+
+use Spiral\Console\CommandLocatorListener;
+use Spiral\Prototype\PrototypeLocatorListener;
+use Spiral\Queue\JobHandlerLocatorListener;
+use Spiral\Queue\SerializerLocatorListener;
+use Spiral\Tests\Framework\ConsoleTestCase;
+
+final class InfoCommandTest extends ConsoleTestCase
+{
+    public function testInfoCommand(): void
+    {
+        $this->assertConsoleCommandOutputContainsStrings(command: 'tokenizer:info', strings: [
+            'Included directories:',
+            'app',
+            'Excluded directories:',
+            'app/resources/',
+            'app/config/',
+            'tests',
+            'migrations',
+            'Loaders:',
+            'Classes',
+            'enabled',
+            'Enums',
+            'disabled. To enable, add "TOKENIZER_LOAD_ENUMS=true" to your .env file.',
+            'Interfaces',
+            'disabled. To enable, add "TOKENIZER_LOAD_INTERFACES=true" to your .env file.',
+            'Listeners:',
+            CommandLocatorListener::class,
+            'Console/src/CommandLocatorListener.php',
+            JobHandlerLocatorListener::class,
+            'Queue/src/JobHandlerLocatorListener.php',
+            SerializerLocatorListener::class,
+            'Queue/src/SerializerLocatorListener.php',
+            PrototypeLocatorListener::class,
+            'Prototype/src/PrototypeLocatorListener.php',
+            'Tokenizer cache: disabled',
+            'To enable cache, add "TOKENIZER_CACHE_TARGETS=true" to your .env file.',
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Adding listeners to the console command `tokenizer:info`. This is useful for displaying information about which listeners are registered in the application.

Example:

<img width="970" alt="1" src="https://github.com/spiral/framework/assets/67324318/d17fa032-7e2f-402a-b610-a18061593cc1">


