### PR TITLE
[spiral/exceptions] Add non-reportable exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "league/flysystem-aws-s3-v3": "^2.0",
         "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^10.1",
+        "phpunit/phpunit": "10.5.3",
         "ramsey/collection": "^1.2",
         "ramsey/uuid": "^4.2.3",
         "rector/rector": "0.18.1",

--- a/src/Exceptions/src/Attribute/NonReportable.php
+++ b/src/Exceptions/src/Attribute/NonReportable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Exceptions\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class NonReportable
+{
+}

--- a/src/Exceptions/src/ExceptionHandler.php
+++ b/src/Exceptions/src/ExceptionHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Exceptions;
 
 use Closure;
+use Spiral\Exceptions\Attribute\NonReportable;
 use Spiral\Exceptions\Renderer\PlainRenderer;
 use Spiral\Filters\Exception\AuthorizationException;
 use Spiral\Filters\Exception\ValidationException;
@@ -189,6 +190,8 @@ class ExceptionHandler implements ExceptionHandlerInterface
             }
         }
 
-        return false;
+        $attribute = (new \ReflectionClass($exception))->getAttributes(NonReportable::class)[0] ?? null;
+
+        return $attribute !== null;
     }
 }

--- a/src/Exceptions/src/ExceptionHandler.php
+++ b/src/Exceptions/src/ExceptionHandler.php
@@ -6,6 +6,9 @@ namespace Spiral\Exceptions;
 
 use Closure;
 use Spiral\Exceptions\Renderer\PlainRenderer;
+use Spiral\Filters\Exception\AuthorizationException;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Http\Exception\ClientException;
 
 /**
  * The class is responsible for:
@@ -24,6 +27,11 @@ class ExceptionHandler implements ExceptionHandlerInterface
     /** @var array<int, ExceptionReporterInterface|Closure> */
     protected array $reporters = [];
     protected mixed $output = null;
+    protected array $nonReportableExceptions = [
+        ClientException::class,
+        AuthorizationException::class,
+        ValidationException::class,
+    ];
 
     public function __construct()
     {
@@ -64,6 +72,10 @@ class ExceptionHandler implements ExceptionHandlerInterface
 
     public function report(\Throwable $exception): void
     {
+        if ($this->shouldNotReport($exception)) {
+            return;
+        }
+
         foreach ($this->reporters as $reporter) {
             try {
                 if ($reporter instanceof ExceptionReporterInterface) {
@@ -104,6 +116,14 @@ class ExceptionHandler implements ExceptionHandlerInterface
     public function addRenderer(ExceptionRendererInterface $renderer): void
     {
         \array_unshift($this->renderers, $renderer);
+    }
+
+    /**
+     * @param class-string<\Throwable> $exception
+     */
+    public function dontReport(string $exception): void
+    {
+        $this->nonReportableExceptions[] = $exception;
     }
 
     /**
@@ -159,5 +179,16 @@ class ExceptionHandler implements ExceptionHandlerInterface
     protected function bootBasicHandlers(): void
     {
         $this->addRenderer(new PlainRenderer());
+    }
+
+    protected function shouldNotReport(\Throwable $exception): bool
+    {
+        foreach ($this->nonReportableExceptions as $nonReportableException) {
+            if ($exception instanceof $nonReportableException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Exceptions/tests/ExceptionHandlerTest.php
+++ b/src/Exceptions/tests/ExceptionHandlerTest.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Spiral\Tests\Exceptions;
 
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Spiral\Exceptions\ExceptionHandler;
 use Spiral\Exceptions\ExceptionRendererInterface;
 use Spiral\Exceptions\ExceptionReporterInterface;
+use Spiral\Filters\Exception\AuthorizationException;
+use Spiral\Filters\Exception\ValidationException;
+use Spiral\Http\Exception\ClientException;
+use Spiral\Http\Exception\ClientException\ForbiddenException;
+use Spiral\Http\Exception\ClientException\NotFoundException;
+use Spiral\Http\Exception\ClientException\UnauthorizedException;
 
 class ExceptionHandlerTest extends TestCase
 {
@@ -91,6 +98,38 @@ class ExceptionHandlerTest extends TestCase
         $this->assertTrue(true);
     }
 
+    #[DataProvider('nonReportableExceptionsDataProvider')]
+    public function testNonReportableExceptions(\Throwable $exception): void
+    {
+        $reporter = $this->createMock(ExceptionReporterInterface::class);
+        $reporter->expects($this->never())->method('report');
+
+        $handler = $this->makeEmptyErrorHandler();
+        $handler->addReporter($reporter);
+
+        $handler->report($exception);
+    }
+
+    public function testAddNonReportableExceptions(): void
+    {
+        $handler = $this->makeEmptyErrorHandler();
+        $ref = new \ReflectionProperty($handler, 'nonReportableExceptions');
+        $this->assertSame([
+            ClientException::class,
+            AuthorizationException::class,
+            ValidationException::class,
+        ], $ref->getValue($handler));
+
+        $handler->dontReport(\DomainException::class);
+
+        $this->assertSame([
+            ClientException::class,
+            AuthorizationException::class,
+            ValidationException::class,
+            \DomainException::class
+        ], $ref->getValue($handler));
+    }
+
     private function makeEmptyErrorHandler(): ExceptionHandler
     {
         return new class extends ExceptionHandler {
@@ -103,5 +142,20 @@ class ExceptionHandlerTest extends TestCase
     private function makeErrorHandler(): ExceptionHandler
     {
         return new ExceptionHandler();
+    }
+
+    public static function nonReportableExceptionsDataProvider(): \Traversable
+    {
+        yield [new class extends ClientException {}];
+        yield [new NotFoundException()];
+        yield [new class extends NotFoundException {}];
+        yield [new ForbiddenException()];
+        yield [new class extends ForbiddenException {}];
+        yield [new UnauthorizedException()];
+        yield [new class extends UnauthorizedException {}];
+        yield [new AuthorizationException()];
+        yield [new class extends AuthorizationException {}];
+        yield [new ValidationException([])];
+        yield [new class([]) extends ValidationException {}];
     }
 }

--- a/src/Exceptions/tests/ExceptionHandlerTest.php
+++ b/src/Exceptions/tests/ExceptionHandlerTest.php
@@ -17,6 +17,7 @@ use Spiral\Http\Exception\ClientException;
 use Spiral\Http\Exception\ClientException\ForbiddenException;
 use Spiral\Http\Exception\ClientException\NotFoundException;
 use Spiral\Http\Exception\ClientException\UnauthorizedException;
+use Spiral\Tests\Exceptions\Fixtures\TestException;
 
 class ExceptionHandlerTest extends TestCase
 {
@@ -157,5 +158,6 @@ class ExceptionHandlerTest extends TestCase
         yield [new class extends AuthorizationException {}];
         yield [new ValidationException([])];
         yield [new class([]) extends ValidationException {}];
+        yield [new TestException()];
     }
 }

--- a/src/Exceptions/tests/Fixtures/TestException.php
+++ b/src/Exceptions/tests/Fixtures/TestException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Exceptions\Fixtures;
+
+use Spiral\Exceptions\Attribute\NonReportable;
+
+#[NonReportable]
+class TestException extends \Exception
+{
+}

--- a/src/Http/src/Exception/ClientException/ServerErrorException.php
+++ b/src/Http/src/Exception/ClientException/ServerErrorException.php
@@ -8,7 +8,7 @@ use Spiral\Http\Exception\ClientException;
 
 /**
  * HTTP 500 exception.
- * @deprecated since v3.11.1.
+ * @deprecated since v3.12
  */
 class ServerErrorException extends ClientException
 {

--- a/src/Http/src/Exception/ClientException/ServerErrorException.php
+++ b/src/Http/src/Exception/ClientException/ServerErrorException.php
@@ -8,6 +8,7 @@ use Spiral\Http\Exception\ClientException;
 
 /**
  * HTTP 500 exception.
+ * @deprecated since v3.11.1.
  */
 class ServerErrorException extends ClientException
 {

--- a/src/Http/tests/ExceptionsTest.php
+++ b/src/Http/tests/ExceptionsTest.php
@@ -11,7 +11,6 @@ use Spiral\Http\Exception\ClientException;
 use Spiral\Http\Exception\ClientException\BadRequestException;
 use Spiral\Http\Exception\ClientException\ForbiddenException;
 use Spiral\Http\Exception\ClientException\NotFoundException;
-use Spiral\Http\Exception\ClientException\ServerErrorException;
 use Spiral\Http\Exception\ClientException\UnauthorizedException;
 
 class ExceptionsTest extends TestCase
@@ -46,12 +45,6 @@ class ExceptionsTest extends TestCase
         $this->assertSame(401, $e->getCode());
     }
 
-    public function testServerError(): void
-    {
-        $e = new ServerErrorException();
-        $this->assertSame(500, $e->getCode());
-    }
-
     #[DataProvider('allExceptionsWithPreviousSet')]
     public function testPreviousSetter(\Throwable $exception): void
     {
@@ -63,7 +56,6 @@ class ExceptionsTest extends TestCase
         yield [new Exception\ClientException\BadRequestException('', new \Exception())];
         yield [new Exception\ClientException\ForbiddenException('', new \Exception())];
         yield [new Exception\ClientException\NotFoundException('', new \Exception())];
-        yield [new Exception\ClientException\ServerErrorException('', new \Exception())];
         yield [new Exception\ClientException\UnauthorizedException('', new \Exception())];
         yield [new Exception\ClientException(0, '', new \Exception())];
         yield [new Exception\DotNotFoundException('', 0, new \Exception())];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### Non-reportable exceptions

The ability to exclude reporting of certain exceptions has been added. By default, `Spiral\Http\Exception\ClientException`, `Spiral\Filters\Exception\ValidationException`, and `Spiral\Filters\Exception\AuthorizationException` are ignored. 

Exceptions can be excluded from the report in several different ways:

#### Attribute `NonReportable`

To exclude an exception from the report, you need to add the `Spiral\Exceptions\Attribute\NonReportable` attribute to the exception class.

```php
use Spiral\Exceptions\Attribute\NonReportable;

#[NonReportable]
class AccessDeniedException extends \Exception
{
    // ...
}
```

#### Method `dontReport`

Invoke the `dontReport` method in the `Spiral\Exceptions\ExceptionHandler` class. This can be done using the bootloader.

```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Exceptions\ExceptionHandler;

final class AppBootloader extends Bootloader
{
    public function init(ExceptionHandler $handler): void
    {
        $handler->dontReport(EntityNotFoundException::class);
    }
}
```

#### Overriding the property `nonReportableExceptions`

You can override the **nonReportableExceptions** property with predefined exceptions.

### Deprecation of `Spiral\Http\Exception\ClientException\ServerErrorException`

The `Spiral\Http\Exception\ClientException\ServerErrorException` exception is marked as deprecated. It is currently only used in tests. Typically, 500 errors require capture by the error handling system and do not need to be wrapped into a single exception like ServerErrorException.

