### PR TITLE
Freeze phpunit on v10.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "league/flysystem-aws-s3-v3": "^2.0",
         "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^10.1",
+        "phpunit/phpunit": "10.5.3",
         "ramsey/collection": "^1.2",
         "ramsey/uuid": "^4.2.3",
         "rector/rector": "0.18.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

Freeze phpunit on v10.5.3 to avoid fails in CI 