### PR TITLE
[spiral/core] Add the ability to use `BackedEnum` as a scope name

### DIFF
--- a/src/Core/src/Attribute/Scope.php
+++ b/src/Core/src/Attribute/Scope.php
@@ -16,6 +16,6 @@ final class Scope implements Plugin
 
     public function __construct(string|\BackedEnum $name)
     {
-        $this->name = $name instanceof \BackedEnum ? (string) $name->value : $name;
+        $this->name = \is_object($name) ? (string) $name->value : $name;
     }
 }

--- a/src/Core/src/Attribute/Scope.php
+++ b/src/Core/src/Attribute/Scope.php
@@ -12,10 +12,10 @@ namespace Spiral\Core\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class Scope implements Plugin
 {
-    public string $name;
+    public readonly string $name;
 
     public function __construct(string|\BackedEnum $name)
     {
-        $this->name = $name instanceof \BackedEnum ? $name->value : $name;
+        $this->name = $name instanceof \BackedEnum ? (string) $name->value : $name;
     }
 }

--- a/src/Core/src/Attribute/Scope.php
+++ b/src/Core/src/Attribute/Scope.php
@@ -12,8 +12,10 @@ namespace Spiral\Core\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class Scope implements Plugin
 {
-    public function __construct(
-        public string $name,
-    ) {
+    public string $name;
+
+    public function __construct(string|\BackedEnum $name)
+    {
+        $this->name = $name instanceof \BackedEnum ? $name->value : $name;
     }
 }

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -59,8 +59,12 @@ final class Container implements
      */
     public function __construct(
         private Config $config = new Config(),
-        ?string $scopeName = self::DEFAULT_ROOT_SCOPE_NAME,
+        string|\BackedEnum|null $scopeName = self::DEFAULT_ROOT_SCOPE_NAME,
     ) {
+        if (\is_object($scopeName)) {
+            $scopeName = (string) $scopeName->value;
+        }
+
         $this->initServices($this, $scopeName);
 
         /** @psalm-suppress RedundantPropertyInitializationCheck */
@@ -381,7 +385,7 @@ final class Container implements
     private function runIsolatedScope(Scope $config, callable $closure): mixed
     {
         // Open scope
-        $container = new self($this->config, \is_object($config->name) ? (string) $config->name->value : $config->name);
+        $container = new self($this->config, $config->name);
 
         // Configure scope
         $container->scope->setParent($this, $this->scope);

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -160,7 +160,7 @@ final class Container implements
      */
     public function getBinder(string|\BackedEnum|null $scope = null): BinderInterface
     {
-        $scope = $scope instanceof \BackedEnum ? (string) $scope->value : $scope;
+        $scope = \is_object($scope) ? (string) $scope->value : $scope;
 
         return $scope === null
             ? $this->binder
@@ -381,10 +381,7 @@ final class Container implements
     private function runIsolatedScope(Scope $config, callable $closure): mixed
     {
         // Open scope
-        $container = new self(
-            $this->config,
-            $config->name instanceof \BackedEnum ? (string) $config->name->value : $config->name
-        );
+        $container = new self($this->config, \is_object($config->name) ? (string) $config->name->value : $config->name);
 
         // Configure scope
         $container->scope->setParent($this, $this->scope);

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -379,7 +379,10 @@ final class Container implements
     private function runIsolatedScope(Scope $config, callable $closure): mixed
     {
         // Open scope
-        $container = new self($this->config, $config->name);
+        $container = new self(
+            $this->config,
+            $config->name instanceof \BackedEnum ? $config->name->value : $config->name
+        );
 
         // Configure scope
         $container->scope->setParent($this, $this->scope);

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -160,7 +160,7 @@ final class Container implements
      */
     public function getBinder(string|\BackedEnum|null $scope = null): BinderInterface
     {
-        $scope = $scope instanceof \BackedEnum ? $scope->value : $scope;
+        $scope = $scope instanceof \BackedEnum ? (string) $scope->value : $scope;
 
         return $scope === null
             ? $this->binder
@@ -383,7 +383,7 @@ final class Container implements
         // Open scope
         $container = new self(
             $this->config,
-            $config->name instanceof \BackedEnum ? $config->name->value : $config->name
+            $config->name instanceof \BackedEnum ? (string) $config->name->value : $config->name
         );
 
         // Configure scope

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -153,13 +153,15 @@ final class Container implements
     /**
      * Make a Binder proxy to configure bindings for a specific scope.
      *
-     * @param null|string $scope Scope name.
+     * @param null|\BackedEnum|string $scope Scope name.
      *        If {@see null}, binder for the current working scope will be returned.
      *        If {@see string}, the default binder for the given scope will be returned. Default bindings won't affect
      *        already created Container instances except the case with the root one.
      */
-    public function getBinder(?string $scope = null): BinderInterface
+    public function getBinder(string|\BackedEnum|null $scope = null): BinderInterface
     {
+        $scope = $scope instanceof \BackedEnum ? $scope->value : $scope;
+
         return $scope === null
             ? $this->binder
             : new StateBinder($this->config->scopedBindings->getState($scope));

--- a/src/Core/src/Scope.php
+++ b/src/Core/src/Scope.php
@@ -14,13 +14,13 @@ namespace Spiral\Core;
 final class Scope
 {
     /**
-     * @param null|string $name Scope name. Named scopes can have individual bindings and constrains.
+     * @param null|string|\BackedEnum $name Scope name. Named scopes can have individual bindings and constrains.
      * @param array<non-empty-string, TResolver> $bindings Custom bindings for the new scope.
      * @param bool $autowire If {@see false}, closure will be invoked with just only the passed Container
      *        as the first argument. Otherwise, {@see InvokerInterface::invoke()} will be used to invoke the closure.
      */
     public function __construct(
-        public readonly ?string $name = null,
+        public readonly string|\BackedEnum|null $name = null,
         public readonly array $bindings = [],
         public readonly bool $autowire = true,
     ) {

--- a/src/Core/tests/Attribute/ScopeTest.php
+++ b/src/Core/tests/Attribute/ScopeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Attribute;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\Attribute\Scope;
+use Spiral\Framework\ScopeName;
+use Spiral\Tests\Core\Fixtures\ScopeEnum;
+
+final class ScopeTest extends TestCase
+{
+    #[DataProvider('scopeNameDataProvider')]
+    public function testScope(string|\BackedEnum $name, string $expected): void
+    {
+        $scope = new Scope($name);
+
+        $this->assertSame($expected, $scope->name);
+    }
+
+    public static function scopeNameDataProvider(): \Traversable
+    {
+        yield ['foo', 'foo'];
+        yield [ScopeName::HttpRequest, 'http.request'];
+        yield [ScopeEnum::A, 'a'];
+    }
+}

--- a/src/Core/tests/Fixtures/ScopeEnum.php
+++ b/src/Core/tests/Fixtures/ScopeEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Fixtures;
+
+enum ScopeEnum: string
+{
+    case A = 'a';
+}

--- a/src/Core/tests/Scope/UseCaseTest.php
+++ b/src/Core/tests/Scope/UseCaseTest.php
@@ -8,9 +8,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Container\ContainerInterface;
 use Spiral\Core\Config\Shared;
 use Spiral\Core\Container;
+use Spiral\Core\Scope;
+use Spiral\Framework\ScopeName;
 use Spiral\Tests\Core\Fixtures\Bucket;
 use Spiral\Tests\Core\Fixtures\Factory;
 use Spiral\Tests\Core\Fixtures\SampleClass;
+use Spiral\Tests\Core\Fixtures\ScopeEnum;
 use Spiral\Tests\Core\Scope\Stub\FileLogger;
 use Spiral\Tests\Core\Scope\Stub\KVLogger;
 use Spiral\Tests\Core\Scope\Stub\LoggerInjector;
@@ -288,5 +291,24 @@ final class UseCaseTest extends BaseTestCase
         });
 
         $root->make('foo');
+    }
+
+    #[DataProvider('scopeEnumDataProvider')]
+    public function testScopeWithEnum(\BackedEnum $scope): void
+    {
+        $root = new Container();
+        $root->getBinder($scope)->bindSingleton('foo', SampleClass::class);
+
+        $root->runScope(new Scope($scope), function (Container $container) {
+            $this->assertTrue($container->has('foo'));
+            $this->assertInstanceOf(SampleClass::class, $container->get('foo'));
+        });
+        $this->assertFalse($root->has('foo'));
+    }
+
+    public static function scopeEnumDataProvider(): \Traversable
+    {
+        yield [ScopeName::HttpRequest, 'http.request'];
+        yield [ScopeEnum::A, 'a'];
     }
 }

--- a/src/Framework/Framework/ScopeName.php
+++ b/src/Framework/Framework/ScopeName.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Framework;
+
+enum ScopeName: string
+{
+    case HttpRequest = 'http.request';
+    case QueueTask = 'queue.task';
+    case TemporalActivity = 'temporal.activity';
+    case GrpcRequest = 'grpc.request';
+    case CentrifugoRequest = 'centrifugo.request';
+    case TcpPacket = 'tcp.packet';
+    case ConsoleCommand = 'console.command';
+}

--- a/src/Framework/Framework/ScopeName.php
+++ b/src/Framework/Framework/ScopeName.php
@@ -6,11 +6,18 @@ namespace Spiral\Framework;
 
 enum ScopeName: string
 {
+    case Http = 'http';
     case HttpRequest = 'http.request';
+    case Queue = 'queue';
     case QueueTask = 'queue.task';
+    case Temporal = 'temporal';
     case TemporalActivity = 'temporal.activity';
+    case Grpc = 'grpc';
     case GrpcRequest = 'grpc.request';
+    case Centrifugo = 'centrifugo';
     case CentrifugoRequest = 'centrifugo.request';
+    case Tcp = 'tcp';
     case TcpPacket = 'tcp.packet';
+    case Console = 'console';
     case ConsoleCommand = 'console.command';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added the ability to use `BackedEnum` as a scope name. Introduced the `Spiral\Framework\ScopeName` enum with default scopes.

```php
enum ScopeName: string
{
    case Http = 'http';
    case HttpRequest = 'http.request';
    case Queue = 'queue';
    case QueueTask = 'queue.task';
    case Temporal = 'temporal';
    case TemporalActivity = 'temporal.activity';
    case Grpc = 'grpc';
    case GrpcRequest = 'grpc.request';
    case Centrifugo = 'centrifugo';
    case CentrifugoRequest = 'centrifugo.request';
    case Tcp = 'tcp';
    case TcpPacket = 'tcp.packet';
    case Console = 'console';
    case ConsoleCommand = 'console.command';
}
```