### PR TITLE
[spiral/core] Add `Singleton` attribute instead of `SingletonInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+- **Medium Impact Changes**
+  - [spiral/core] Interface `Spiral\Core\Container\SingletonInterface` is deprecated,
+    use `Spiral\Core\Attribute\Singleton` instead. Will be removed in v4.0.
+
 ## 3.11.1 - 2023-12-29
 
 - **Bug Fixes**

--- a/src/AnnotatedRoutes/src/Bootloader/AnnotatedRoutesBootloader.php
+++ b/src/AnnotatedRoutes/src/Bootloader/AnnotatedRoutesBootloader.php
@@ -7,7 +7,7 @@ namespace Spiral\Router\Bootloader;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Bootloader\Attributes\AttributesBootloader;
 use Spiral\Bootloader\Http\RouterBootloader;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Router\RouteLocatorListener;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
 use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
@@ -15,7 +15,8 @@ use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
 /**
  * Configures application routes using annotations and pre-defined configuration groups.
  */
-final class AnnotatedRoutesBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class AnnotatedRoutesBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         RouterBootloader::class,

--- a/src/Boot/src/BootloadManager/AbstractBootloadManager.php
+++ b/src/Boot/src/BootloadManager/AbstractBootloadManager.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Spiral\Boot\BootloadManager;
 
 use Spiral\Boot\BootloadManagerInterface;
-use Spiral\Core\Container;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\ScopeInterface;
 
 /**
  * Provides ability to bootload service providers.
  */
-abstract class AbstractBootloadManager implements BootloadManagerInterface, Container\SingletonInterface
+#[Singleton]
+abstract class AbstractBootloadManager implements BootloadManagerInterface
 {
     public function __construct(
         private readonly ScopeInterface $scope,

--- a/src/Boot/src/BootloadManager/ClassesRegistry.php
+++ b/src/Boot/src/BootloadManager/ClassesRegistry.php
@@ -6,13 +6,14 @@ namespace Spiral\Boot\BootloadManager;
 
 use Spiral\Boot\BootloadManagerInterface;
 use Spiral\Boot\Exception\BootloaderAlreadyBootedException;
-use Spiral\Core\Container;
+use Spiral\Core\Attribute\Singleton;
 
 /**
  * @internal
  * @psalm-import-type TClass from BootloadManagerInterface
  */
-final class ClassesRegistry implements Container\SingletonInterface
+#[Singleton]
+final class ClassesRegistry
 {
     /** @var TClass[] */
     private array $classes = [];

--- a/src/Boot/src/BootloadManager/Initializer.php
+++ b/src/Boot/src/BootloadManager/Initializer.php
@@ -15,8 +15,8 @@ use Spiral\Boot\BootloadManager\Checker\CheckerRegistry;
 use Spiral\Boot\BootloadManager\Checker\ClassExistsChecker;
 use Spiral\Boot\BootloadManager\Checker\ConfigChecker;
 use Spiral\Boot\BootloadManagerInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
-use Spiral\Core\Container;
 use Spiral\Core\ResolverInterface;
 
 /**
@@ -24,7 +24,8 @@ use Spiral\Core\ResolverInterface;
  * @psalm-import-type TClass from BootloadManagerInterface
  * @psalm-import-type TFullBinding from BootloaderInterface
  */
-class Initializer implements InitializerInterface, Container\SingletonInterface
+#[Singleton]
+class Initializer implements InitializerInterface
 {
     protected ?BootloaderCheckerInterface $checker = null;
 

--- a/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
+++ b/src/Bridge/Monolog/src/Bootloader/MonologBootloader.php
@@ -16,12 +16,14 @@ use Spiral\Boot\EnvironmentInterface;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container;
 use Spiral\Logger\LogsInterface;
 use Spiral\Monolog\Config\MonologConfig;
 use Spiral\Monolog\LogFactory;
 
-final class MonologBootloader extends Bootloader implements Container\SingletonInterface
+#[Singleton]
+final class MonologBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         LogsInterface::class => LogFactory::class,

--- a/src/Bridge/Stempler/src/Bootloader/StemplerBootloader.php
+++ b/src/Bridge/Stempler/src/Bootloader/StemplerBootloader.php
@@ -8,8 +8,8 @@ use Psr\Container\ContainerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container\Autowire;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Stempler\Builder;
 use Spiral\Stempler\Config\StemplerConfig;
 use Spiral\Stempler\Directive;
@@ -28,7 +28,8 @@ use Spiral\Views\ProcessorInterface;
 /**
  * Initiates stempler engine, it's cache and directives.
  */
-final class StemplerBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class StemplerBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         StemplerEngine::class => [self::class, 'stemplerEngine'],

--- a/src/Bridge/Stempler/src/Directive/RouteDirective.php
+++ b/src/Bridge/Stempler/src/Directive/RouteDirective.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Spiral\Stempler\Directive;
 
 use Psr\Container\ContainerInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Router\Exception\RouterException;
 use Spiral\Router\Exception\UndefinedRouteException;
 use Spiral\Router\RouterInterface;
 use Spiral\Stempler\Exception\DirectiveException;
 use Spiral\Stempler\Node\Dynamic\Directive;
 
-final class RouteDirective extends AbstractDirective implements SingletonInterface
+#[Singleton]
+final class RouteDirective extends AbstractDirective
 {
     public function __construct(
         private readonly ContainerInterface $container

--- a/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
+++ b/src/Broadcasting/src/Bootloader/WebsocketsBootloader.php
@@ -11,10 +11,11 @@ use Spiral\Bootloader\Http\HttpBootloader;
 use Spiral\Broadcasting\BroadcastInterface;
 use Spiral\Broadcasting\Config\BroadcastConfig;
 use Spiral\Broadcasting\Middleware\AuthorizationMiddleware;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
-use Spiral\Core\Container\SingletonInterface;
 
-final class WebsocketsBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class WebsocketsBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         HttpBootloader::class,

--- a/src/Broadcasting/src/BroadcastManager.php
+++ b/src/Broadcasting/src/BroadcastManager.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Spiral\Broadcasting;
 
 use Spiral\Broadcasting\Config\BroadcastConfig;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\FactoryInterface;
 
-final class BroadcastManager implements BroadcastManagerInterface, SingletonInterface
+#[Singleton]
+final class BroadcastManager implements BroadcastManagerInterface
 {
     /** @var BroadcastInterface[] */
     private array $connections = [];

--- a/src/Cache/src/CacheManager.php
+++ b/src/Cache/src/CacheManager.php
@@ -7,10 +7,11 @@ namespace Spiral\Cache;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\SimpleCache\CacheInterface;
 use Spiral\Cache\Config\CacheConfig;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\FactoryInterface;
 
-class CacheManager implements CacheStorageProviderInterface, SingletonInterface
+#[Singleton]
+class CacheManager implements CacheStorageProviderInterface
 {
     /** @var CacheInterface[] */
     private array $storages = [];

--- a/src/Config/src/ConfigManager.php
+++ b/src/Config/src/ConfigManager.php
@@ -6,7 +6,7 @@ namespace Spiral\Config;
 
 use Spiral\Config\Exception\ConfigDeliveredException;
 use Spiral\Config\Exception\PatchException;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ConfiguratorException;
 
 /**
@@ -15,7 +15,8 @@ use Spiral\Core\Exception\ConfiguratorException;
  *
  * @implements ConfiguratorInterface<object>
  */
-final class ConfigManager implements ConfiguratorInterface, SingletonInterface
+#[Singleton]
+final class ConfigManager implements ConfiguratorInterface
 {
     private array $data = [];
     private array $defaults = [];

--- a/src/Console/src/Bootloader/ConsoleBootloader.php
+++ b/src/Console/src/Bootloader/ConsoleBootloader.php
@@ -15,7 +15,7 @@ use Spiral\Console\Console;
 use Spiral\Console\ConsoleDispatcher;
 use Spiral\Console\Sequence\CallableSequence;
 use Spiral\Console\Sequence\CommandSequence;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Tokenizer\Bootloader\TokenizerListenerBootloader;
@@ -24,7 +24,8 @@ use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
 /**
  * Bootloads console and provides ability to register custom bootload commands.
  */
-final class ConsoleBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class ConsoleBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         TokenizerListenerBootloader::class,

--- a/src/Console/tests/Fixtures/TestCommand.php
+++ b/src/Console/tests/Fixtures/TestCommand.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Spiral\Tests\Console\Fixtures;
 
 use Spiral\Console\Command;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 
-class TestCommand extends Command implements SingletonInterface
+#[Singleton]
+class TestCommand extends Command
 {
     public const NAME = 'test';
     public const DESCRIPTION = 'Test Command';

--- a/src/Core/src/Container/SingletonInterface.php
+++ b/src/Core/src/Container/SingletonInterface.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Container;
 
+use Spiral\Core\Attribute\Singleton;
+
 /**
  * Class treated as singleton will only be constructed once in spiral IoC.
+ * @deprecated Use {@see Singleton} attribute instead. Will be removed in v4.0.
  */
 interface SingletonInterface
 {

--- a/src/Core/tests/Fixtures/DeclarativeSingleton.php
+++ b/src/Core/tests/Fixtures/DeclarativeSingleton.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Fixtures;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 
-class DeclarativeSingleton implements SingletonInterface
+#[Singleton]
+class DeclarativeSingleton
 {
 }

--- a/src/Core/tests/Internal/Config/StateBinderTest.php
+++ b/src/Core/tests/Internal/Config/StateBinderTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Internal\Config;
 
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\Exception\Binder\SingletonOverloadException;
 use Spiral\Core\FactoryInterface;
 use Spiral\Tests\Core\Fixtures\SampleClass;
@@ -46,7 +46,7 @@ final class StateBinderTest extends BaseTestCase
         $binder = $this->constructor->get('binder', BinderInterface::class);
         $factory = $this->constructor->get('factory', FactoryInterface::class);
 
-        $this->bindSingleton('test', new class implements SingletonInterface {});
+        $this->bindSingleton('test', new #[Singleton] class {});
         $factory->make('test');
 
         $this->assertTrue($binder->hasInstance('test'));

--- a/src/Core/tests/ScopesTest.php
+++ b/src/Core/tests/ScopesTest.php
@@ -6,8 +6,8 @@ namespace Spiral\Tests\Core;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\ContainerScope;
 use Spiral\Core\Exception\RuntimeException;
 use Spiral\Tests\Core\Fixtures\Bucket;
@@ -136,7 +136,7 @@ class ScopesTest extends TestCase
     public function testHasInstanceAfterMakeWithoutAliasInScope(): void
     {
         $container = new Container();
-        $container->bindSingleton('test', new class implements SingletonInterface {});
+        $container->bindSingleton('test', new #[Singleton] class {});
         $container->make('test');
 
         $container->runScoped(function (Container $container) {

--- a/src/Core/tests/SingletonsTest.php
+++ b/src/Core/tests/SingletonsTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Tests\Core\Fixtures\DeclarativeSingleton;
 use Spiral\Tests\Core\Fixtures\Factory;
 use Spiral\Tests\Core\Fixtures\SampleClass;
@@ -188,7 +187,7 @@ class SingletonsTest extends TestCase
     public function testHasShouldReturnTrueWhenSingletonIsAlreadyConstructed(): void
     {
         $container = new Container();
-        $class = new class implements SingletonInterface {};
+        $class = new #[Singleton] class {};
 
         $this->assertFalse($container->has($class::class));
 

--- a/src/Encrypter/src/EncrypterFactory.php
+++ b/src/Encrypter/src/EncrypterFactory.php
@@ -6,8 +6,8 @@ namespace Spiral\Encrypter;
 
 use Defuse\Crypto\Exception\CryptoException;
 use Defuse\Crypto\Key;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container\InjectorInterface;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Encrypter\Config\EncrypterConfig;
 use Spiral\Encrypter\Exception\EncrypterException;
 
@@ -16,7 +16,8 @@ use Spiral\Encrypter\Exception\EncrypterException;
  *
  * @implements InjectorInterface<EncrypterInterface>
  */
-final class EncrypterFactory implements InjectorInterface, EncryptionInterface, SingletonInterface
+#[Singleton]
+final class EncrypterFactory implements InjectorInterface, EncryptionInterface
 {
     public function __construct(
         private readonly EncrypterConfig $config

--- a/src/Events/src/ListenerProcessorRegistry.php
+++ b/src/Events/src/ListenerProcessorRegistry.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Events;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Events\Processor\ProcessorInterface;
 
-final class ListenerProcessorRegistry implements ProcessorInterface, SingletonInterface
+#[Singleton]
+final class ListenerProcessorRegistry implements ProcessorInterface
 {
     /** @var ProcessorInterface[] */
     private array $processors = [];

--- a/src/Framework/Auth/TokenStorageScope.php
+++ b/src/Framework/Auth/TokenStorageScope.php
@@ -7,10 +7,11 @@ namespace Spiral\Auth;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Spiral\Auth\Exception\TokenStorageException;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ScopeException;
 
-final class TokenStorageScope implements TokenStorageInterface, SingletonInterface
+#[Singleton]
+final class TokenStorageScope implements TokenStorageInterface
 {
     public function __construct(
         private readonly ContainerInterface $container

--- a/src/Framework/Bootloader/Auth/AuthBootloader.php
+++ b/src/Framework/Bootloader/Auth/AuthBootloader.php
@@ -9,14 +9,15 @@ use Spiral\Auth\AuthScope;
 use Spiral\Auth\Exception\AuthException;
 use Spiral\Auth\TokenInterface;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container\Autowire;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\FactoryInterface;
 
 /**
  * Manages the set of actor providers.
  */
-final class AuthBootloader extends Bootloader implements ActorProviderInterface, SingletonInterface
+#[Singleton]
+final class AuthBootloader extends Bootloader implements ActorProviderInterface
 {
     protected const SINGLETONS = [
         AuthScope::class => AuthScope::class,

--- a/src/Framework/Bootloader/Auth/HttpAuthBootloader.php
+++ b/src/Framework/Bootloader/Auth/HttpAuthBootloader.php
@@ -19,15 +19,16 @@ use Spiral\Boot\EnvironmentInterface;
 use Spiral\Bootloader\Http\HttpBootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container\Autowire;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Http\Config\HttpConfig;
 
 /**
  * Enables Auth middleware and http transports to read and write tokens in PSR-7 request/response.
  */
-final class HttpAuthBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class HttpAuthBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         AuthBootloader::class,

--- a/src/Framework/Bootloader/DebugBootloader.php
+++ b/src/Framework/Bootloader/DebugBootloader.php
@@ -7,8 +7,8 @@ namespace Spiral\Bootloader;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container\Autowire;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Core\InvokerInterface;
 use Spiral\Debug\Config\DebugConfig;
@@ -22,7 +22,8 @@ use Spiral\Debug\StateInterface;
  * @psalm-import-type TCollector from DebugConfig
  * @psalm-import-type TTag from DebugConfig
  */
-final class DebugBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class DebugBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         EnvironmentCollector::class => EnvironmentCollector::class,

--- a/src/Framework/Bootloader/Http/CookiesBootloader.php
+++ b/src/Framework/Bootloader/Http/CookiesBootloader.php
@@ -10,10 +10,11 @@ use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
 use Spiral\Cookies\Config\CookiesConfig;
 use Spiral\Cookies\CookieQueue;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ScopeException;
 
-final class CookiesBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class CookiesBootloader extends Bootloader
 {
     protected const BINDINGS = [
         CookieQueue::class => [self::class, 'cookieQueue'],

--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -11,8 +11,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Container\Autowire;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Http\Config\HttpConfig;
 use Spiral\Http\Http;
 use Spiral\Http\Pipeline;
@@ -22,7 +22,8 @@ use Spiral\Telemetry\TracerFactoryInterface;
 /**
  * Configures Http dispatcher.
  */
-final class HttpBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class HttpBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
         TelemetryBootloader::class,

--- a/src/Framework/Bootloader/I18nBootloader.php
+++ b/src/Framework/Bootloader/I18nBootloader.php
@@ -10,7 +10,7 @@ use Spiral\Boot\Environment\DebugMode;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Translator\Catalogue\CacheInterface;
 use Spiral\Translator\Catalogue\CatalogueLoader;
 use Spiral\Translator\Catalogue\CatalogueManager;
@@ -28,7 +28,8 @@ use Symfony\Component\Translation\Loader;
  * Attention, the default language would not be automatically reset in finalizers. Make sure to properly design your
  * middleware.
  */
-final class I18nBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class I18nBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         \Symfony\Contracts\Translation\TranslatorInterface::class => TranslatorInterface::class,

--- a/src/Framework/Bootloader/Security/FiltersBootloader.php
+++ b/src/Framework/Bootloader/Security/FiltersBootloader.php
@@ -9,6 +9,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
 use Spiral\Core\Container;
 use Spiral\Core\CoreInterceptorInterface;
@@ -31,7 +32,8 @@ use Spiral\Filters\Model\Mapper\UuidCaster;
 /**
  * @implements Container\InjectorInterface<FilterInterface>
  */
-final class FiltersBootloader extends Bootloader implements Container\InjectorInterface, Container\SingletonInterface
+#[Singleton]
+final class FiltersBootloader extends Bootloader implements Container\InjectorInterface
 {
     protected const SINGLETONS = [
         FilterProviderInterface::class => [self::class, 'initFilterProvider'],

--- a/src/Framework/Command/CleanCommand.php
+++ b/src/Framework/Command/CleanCommand.php
@@ -6,10 +6,11 @@ namespace Spiral\Command;
 
 use Spiral\Boot\DirectoriesInterface;
 use Spiral\Console\Command;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Files\FilesInterface;
 
-final class CleanCommand extends Command implements SingletonInterface
+#[Singleton]
+final class CleanCommand extends Command
 {
     protected const NAME        = 'cache:clean';
     protected const DESCRIPTION = 'Clean application runtime cache';

--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -6,7 +6,7 @@ namespace Spiral\Command\Router;
 
 use Spiral\Boot\KernelInterface;
 use Spiral\Console\Command;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Router\GroupRegistry;
 use Spiral\Router\Route;
 use Spiral\Router\RouterInterface;
@@ -15,7 +15,8 @@ use Spiral\Router\Target\Controller;
 use Spiral\Router\Target\Group;
 use Spiral\Router\Target\Namespaced;
 
-final class ListCommand extends Command implements SingletonInterface
+#[Singleton]
+final class ListCommand extends Command
 {
     protected const NAME = 'route:list';
     protected const DESCRIPTION = 'List application routes';

--- a/src/Framework/Command/Translator/ExportCommand.php
+++ b/src/Framework/Command/Translator/ExportCommand.php
@@ -6,7 +6,7 @@ namespace Spiral\Command\Translator;
 
 use Spiral\Console\Attribute\Question;
 use Spiral\Console\Command;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Translator\Catalogue\CatalogueManager;
 use Spiral\Translator\CatalogueInterface;
 use Spiral\Translator\Config\TranslatorConfig;
@@ -22,7 +22,8 @@ use Symfony\Component\Translation\MessageCatalogue;
     question: 'What is the path to where you would like to export the translations?',
     argument: 'path'
 )]
-final class ExportCommand extends Command implements SingletonInterface
+#[Singleton]
+final class ExportCommand extends Command
 {
     protected const NAME        = 'i18n:export';
     protected const DESCRIPTION = 'Dump given locale using specified dumper and path';

--- a/src/Framework/Command/Translator/IndexCommand.php
+++ b/src/Framework/Command/Translator/IndexCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Command\Translator;
 
 use Spiral\Console\Command;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Tokenizer\ScopedClassesInterface;
 use Spiral\Tokenizer\InvocationsInterface;
 use Spiral\Translator\Catalogue\CatalogueManager;
@@ -13,7 +13,8 @@ use Spiral\Translator\Config\TranslatorConfig;
 use Spiral\Translator\Indexer;
 use Symfony\Component\Console\Input\InputArgument;
 
-final class IndexCommand extends Command implements SingletonInterface
+#[Singleton]
+final class IndexCommand extends Command
 {
     protected const NAME        = 'i18n:index';
     protected const DESCRIPTION = 'Index all declared translation strings and usages';

--- a/src/Framework/Command/Translator/ResetCommand.php
+++ b/src/Framework/Command/Translator/ResetCommand.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Spiral\Command\Translator;
 
 use Spiral\Console\Command;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Translator\Catalogue\CatalogueManager;
 
-final class ResetCommand extends Command implements SingletonInterface
+#[Singleton]
+final class ResetCommand extends Command
 {
     protected const NAME        = 'i18n:reset';
     protected const DESCRIPTION = 'Reset translation cache';

--- a/src/Framework/Cookies/CookieManager.php
+++ b/src/Framework/Cookies/CookieManager.php
@@ -7,13 +7,14 @@ namespace Spiral\Cookies;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ScopeException;
 
 /**
  * Cookies manages provides the ability to write and read cookies from the active request/response scope.
  */
-final class CookieManager implements SingletonInterface
+#[Singleton]
+final class CookieManager
 {
     public function __construct(
         private readonly ContainerInterface $container

--- a/src/Framework/Domain/GuardPermissionsProvider.php
+++ b/src/Framework/Domain/GuardPermissionsProvider.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Spiral\Domain;
 
 use Spiral\Attributes\ReaderInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ControllerException;
 use Spiral\Core\Exception\InterceptorException;
 use Spiral\Domain\Annotation\Guarded;
 use Spiral\Domain\Annotation\GuardNamespace;
 
-final class GuardPermissionsProvider implements PermissionsProviderInterface, SingletonInterface
+#[Singleton]
+final class GuardPermissionsProvider implements PermissionsProviderInterface
 {
     private const FAILURE_MAP = [
         'unauthorized' => ControllerException::UNAUTHORIZED,

--- a/src/Framework/Session/SessionScope.php
+++ b/src/Framework/Session/SessionScope.php
@@ -6,13 +6,14 @@ namespace Spiral\Session;
 
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ScopeException;
 
 /**
  * Provides access to the currently active session scope.
  */
-final class SessionScope implements SessionInterface, SingletonInterface
+#[Singleton]
+final class SessionScope implements SessionInterface
 {
     /** Locations for unnamed segments i.e. default segment. */
     private const DEFAULT_SECTION = '_DEFAULT';

--- a/src/Http/src/Request/InputManager.php
+++ b/src/Http/src/Request/InputManager.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\Exception\ScopeException;
 use Spiral\Http\Config\HttpConfig;
 use Spiral\Http\Exception\InputException;
@@ -47,7 +47,8 @@ use Spiral\Http\Header\AcceptHeader;
  * @method mixed server(string $name, mixed $default = null)
  * @method mixed attribute(string $name, mixed $default = null)
  */
-final class InputManager implements SingletonInterface
+#[Singleton]
+final class InputManager
 {
     /**
      * Associations between bags and representing class/request method.

--- a/src/Prototype/src/Bootloader/PrototypeBootloader.php
+++ b/src/Prototype/src/Bootloader/PrototypeBootloader.php
@@ -12,7 +12,7 @@ use Spiral\Bootloader\Attributes\AttributesBootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
 use Spiral\Console\Bootloader\ConsoleBootloader;
-use Spiral\Core\Container;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Prototype\Command;
 use Spiral\Prototype\Config\PrototypeConfig;
 use Spiral\Prototype\PrototypeLocatorListener;
@@ -23,7 +23,8 @@ use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
 /**
  * Manages ide-friendly container injections via PrototypeTrait.
  */
-final class PrototypeBootloader extends Bootloader\Bootloader implements Container\SingletonInterface
+#[Singleton]
+final class PrototypeBootloader extends Bootloader\Bootloader
 {
     protected const DEPENDENCIES = [
         Bootloader\CoreBootloader::class,

--- a/src/Prototype/src/PrototypeRegistry.php
+++ b/src/Prototype/src/PrototypeRegistry.php
@@ -6,12 +6,13 @@ namespace Spiral\Prototype;
 
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
-use Spiral\Core\Container;
+use Spiral\Core\Attribute\Singleton;
 
 /**
  * Contains aliases and targets for all declared prototype dependencies.
  */
-final class PrototypeRegistry implements Container\SingletonInterface
+#[Singleton]
+final class PrototypeRegistry
 {
     /** @var Dependency[] */
     private array $dependencies = [];

--- a/src/Security/src/PermissionManager.php
+++ b/src/Security/src/PermissionManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Security;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Security\Exception\PermissionException;
 use Spiral\Security\Exception\RoleException;
 use Spiral\Security\Rule\AllowRule;
@@ -21,7 +21,8 @@ use Spiral\Security\Rule\ForbidRule;
  * $associations->associate('editor', 'posts.*', Allows::class);
  * $associations->associate('user', 'posts.*', Forbid::class);
  */
-final class PermissionManager implements PermissionsInterface, SingletonInterface
+#[Singleton]
+final class PermissionManager implements PermissionsInterface
 {
     /**
      * Roles associated with their permissions.

--- a/src/Security/src/Rule/AllowRule.php
+++ b/src/Security/src/Rule/AllowRule.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Spiral\Security\Rule;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Security\ActorInterface;
 use Spiral\Security\RuleInterface;
 
 /**
  * Always positive rule.
  */
-final class AllowRule implements RuleInterface, SingletonInterface
+#[Singleton]
+final class AllowRule implements RuleInterface
 {
     public function allows(ActorInterface $actor, string $permission, array $context): bool
     {

--- a/src/Security/src/Rule/ForbidRule.php
+++ b/src/Security/src/Rule/ForbidRule.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Spiral\Security\Rule;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Security\ActorInterface;
 use Spiral\Security\RuleInterface;
 
 /**
  * Always negative rule.
  */
-final class ForbidRule implements RuleInterface, SingletonInterface
+#[Singleton]
+final class ForbidRule implements RuleInterface
 {
     public function allows(ActorInterface $actor, string $permission, array $context): bool
     {

--- a/src/Security/src/RuleManager.php
+++ b/src/Security/src/RuleManager.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Spiral\Security;
 
 use Psr\Container\ContainerInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Security\Exception\RuleException;
 use Spiral\Security\Rule\CallableRule;
 
 /**
  * Provides ability to request permissions rules based on it's name. Rules are being fetched from container.
  */
-final class RuleManager implements RulesInterface, SingletonInterface
+#[Singleton]
+final class RuleManager implements RulesInterface
 {
     private array $rules = [];
 

--- a/src/Session/src/SessionFactory.php
+++ b/src/Session/src/SessionFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Session;
 
 use Psr\Container\ContainerExceptionInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\FactoryInterface;
 use Spiral\Session\Config\SessionConfig;
 use Spiral\Session\Exception\MultipleSessionException;
@@ -14,7 +14,8 @@ use Spiral\Session\Exception\SessionException;
 /**
  * Initiates session instance and configures session handlers.
  */
-final class SessionFactory implements SessionFactoryInterface, SingletonInterface
+#[Singleton]
+final class SessionFactory implements SessionFactoryInterface
 {
     public function __construct(
         private readonly SessionConfig $config,

--- a/src/Tokenizer/src/Bootloader/TokenizerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerBootloader.php
@@ -9,8 +9,8 @@ use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
-use Spiral\Core\Container\SingletonInterface;
 use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Tokenizer\ClassLocator;
 use Spiral\Tokenizer\ClassLocatorInjector;
@@ -31,7 +31,8 @@ use Spiral\Tokenizer\ScopedEnumsInterface;
 use Spiral\Tokenizer\ScopedInterfaceLocator;
 use Spiral\Tokenizer\ScopedInterfacesInterface;
 
-final class TokenizerBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class TokenizerBootloader extends Bootloader
 {
     protected const BINDINGS = [
         ScopedClassesInterface::class => ScopedClassLocator::class,

--- a/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
+++ b/src/Tokenizer/src/Bootloader/TokenizerListenerBootloader.php
@@ -8,7 +8,7 @@ use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\Memory;
 use Spiral\Bootloader\Attributes\AttributesBootloader;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\FactoryInterface;
 use Spiral\Tokenizer\ClassesInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
@@ -30,9 +30,8 @@ use Spiral\Tokenizer\TokenizerListenerRegistryInterface;
  * Secondly, it allows to cache the result of the analysis for each listener and use it in the future.
  * If you want to have better performance during the application boot, you should use this bootloader.
  */
-final class TokenizerListenerBootloader extends Bootloader implements
-    SingletonInterface,
-    TokenizerListenerRegistryInterface
+#[Singleton]
+final class TokenizerListenerBootloader extends Bootloader implements TokenizerListenerRegistryInterface
 {
     protected const DEPENDENCIES = [
         AttributesBootloader::class,

--- a/src/Tokenizer/src/Tokenizer.php
+++ b/src/Tokenizer/src/Tokenizer.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Spiral\Tokenizer;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Symfony\Component\Finder\Finder;
 
 /**
  * Manages automatic container injections of class and invocation locators.
  */
-final class Tokenizer implements SingletonInterface
+#[Singleton]
+final class Tokenizer
 {
     /**
      * Token array constants.

--- a/src/Translator/src/Translator.php
+++ b/src/Translator/src/Translator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Translator;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Translator\Config\TranslatorConfig;
 use Spiral\Translator\Event\LocaleUpdated;
 use Spiral\Translator\Exception\LocaleException;
@@ -16,7 +16,8 @@ use Symfony\Component\Translation\IdentityTranslator;
  * Implementation of Symfony\TranslatorInterface with memory caching, automatic message
  * registration and bundle/domain grouping.
  */
-final class Translator implements TranslatorInterface, SingletonInterface
+#[Singleton]
+final class Translator implements TranslatorInterface
 {
     private string $locale;
 

--- a/src/Validation/src/Bootloader/ValidationBootloader.php
+++ b/src/Validation/src/Bootloader/ValidationBootloader.php
@@ -7,14 +7,15 @@ namespace Spiral\Validation\Bootloader;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Set;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Validation\Config\ValidationConfig;
 use Spiral\Validation\Exception\ValidationException;
 use Spiral\Validation\ValidationInterface;
 use Spiral\Validation\ValidationProvider;
 use Spiral\Validation\ValidationProviderInterface;
 
-final class ValidationBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class ValidationBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         ValidationProviderInterface::class => ValidationProvider::class,

--- a/src/Validation/src/ValidationProvider.php
+++ b/src/Validation/src/ValidationProvider.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Spiral\Validation;
 
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\InvokerInterface;
 use Spiral\Validation\Exception\ValidationException;
 
-final class ValidationProvider implements ValidationProviderInterface, SingletonInterface
+#[Singleton]
+final class ValidationProvider implements ValidationProviderInterface
 {
     /** @var array<non-empty-string, \Closure> */
     private array $resolvers = [];

--- a/src/Views/src/Bootloader/ViewsBootloader.php
+++ b/src/Views/src/Bootloader/ViewsBootloader.php
@@ -10,7 +10,7 @@ use Spiral\Boot\Environment\DebugMode;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
-use Spiral\Core\Container\SingletonInterface;
+use Spiral\Core\Attribute\Singleton;
 use Spiral\Views\Config\ViewsConfig;
 use Spiral\Views\DependencyInterface;
 use Spiral\Views\Engine\Native\NativeEngine;
@@ -22,7 +22,8 @@ use Spiral\Views\ViewLoader;
 use Spiral\Views\ViewManager;
 use Spiral\Views\ViewsInterface;
 
-final class ViewsBootloader extends Bootloader implements SingletonInterface
+#[Singleton]
+final class ViewsBootloader extends Bootloader
 {
     protected const SINGLETONS = [
         ViewsInterface::class => ViewManager::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

The `Spiral\Core\Container\SingletonInterface` interface is marked as deprecated. It is recommended to use the `Spiral\Core\Attribute\Singleton` attribute instead. In all classes, the usage of SingletonInterface has been replaced with the attribute.
