### PR TITLE
Add doctrine/annotations to require-dev instead of require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "cocur/slugify": "^3.2 || ^4.0",
         "codedungeon/php-cli-colors": "^1.11",
         "defuse/php-encryption": "^2.2",
-        "doctrine/annotations": "^1.12 || ^2.0",
         "doctrine/inflector": "^1.4|^2.0",
         "league/flysystem": "^2.3.1 || ^3.0",
         "monolog/monolog": "^2.9.2 || ^3.5",
@@ -140,7 +139,8 @@
         "spiral/validator": "^1.3",
         "google/protobuf": "^3.25",
         "symplify/monorepo-builder": "^10.2.7",
-        "vimeo/psalm": "^5.9"
+        "vimeo/psalm": "^5.9",
+        "doctrine/annotations": "^1.12 || ^2.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

The dependency on `doctrine/annotations` has been moved to the **require-dev** section because it is only requested by the `spiral/queue` component in the **require-dev** section.