### PR TITLE
[spiral/translator] Add a check for the existence of a message

### DIFF
--- a/src/Translator/src/Indexer.php
+++ b/src/Translator/src/Indexer.php
@@ -44,7 +44,9 @@ final class Indexer
         }
 
         //Automatically registering
-        $this->catalogue->set($domain, $string, $string);
+        if (!$this->catalogue->has($domain, $string)) {
+            $this->catalogue->set($domain, $string, $string);
+        }
 
         $this->getLogger()->debug(
             \sprintf('[%s]: `%s`', $domain, $string),

--- a/src/Translator/tests/IndexerTest.php
+++ b/src/Translator/tests/IndexerTest.php
@@ -72,6 +72,21 @@ class IndexerTest extends TestCase
         $this->assertTrue($catalogue->has('spiral', 'new-mess'));
     }
 
+    public function testRegisterMessageShouldNotOverrideMessages(): void
+    {
+        $catalogue = new Catalogue('fr');
+        $catalogue->set('messages', 'hello', 'Bonjour');
+
+        $indexer = new Indexer(new TranslatorConfig([
+            'domains' => ['spiral' => ['spiral-*'], 'messages' => ['*']]
+        ]), $catalogue);
+
+        $indexer->indexInvocations($this->tContainer()->get(InvocationsInterface::class));
+
+        $this->assertTrue($catalogue->has('messages', 'hello'));
+        $this->assertSame('Bonjour', $catalogue->get('messages', 'hello'));
+    }
+
     protected function tContainer(): Container
     {
         $container = new Container();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | #1060 

The code did not check whether the message already exists (loaded from the translation files). A check for the existence of the message in the translation catalogue has been added.