### PR TITLE
[spiral/core] Parent scopes in the `has` method

### DIFF
--- a/src/Core/src/Internal/Container.php
+++ b/src/Core/src/Internal/Container.php
@@ -20,6 +20,7 @@ final class Container implements ContainerInterface
 
     private State $state;
     private FactoryInterface|Factory $factory;
+    private Scope $scope;
 
     public function __construct(Registry $constructor)
     {
@@ -27,6 +28,7 @@ final class Container implements ContainerInterface
 
         $this->state = $constructor->get('state', State::class);
         $this->factory = $constructor->get('factory', FactoryInterface::class);
+        $this->scope = $constructor->get('scope', Scope::class);
     }
 
     /**
@@ -59,6 +61,12 @@ final class Container implements ContainerInterface
 
     public function has(string $id): bool
     {
-        return \array_key_exists($id, $this->state->bindings) || \array_key_exists($id, $this->state->singletons);
+        if (\array_key_exists($id, $this->state->bindings) || \array_key_exists($id, $this->state->singletons)) {
+            return true;
+        }
+
+        $parent = $this->scope->getParent();
+
+        return $parent !== null && $parent->has($id);
     }
 }

--- a/src/Framework/Console/Logger/DebugListener.php
+++ b/src/Framework/Console/Logger/DebugListener.php
@@ -73,9 +73,7 @@ final class DebugListener
      */
     public function enable(): self
     {
-        if (!empty($this->listenerRegistry)) {
-            $this->listenerRegistry->addListener($this);
-        }
+        $this->listenerRegistry->addListener($this);
 
         return $this;
     }
@@ -86,9 +84,7 @@ final class DebugListener
      */
     public function disable(): self
     {
-        if (!empty($this->listenerRegistry)) {
-            $this->listenerRegistry->removeListener($this);
-        }
+        $this->listenerRegistry->removeListener($this);
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 


Before these changes, the `has` method of the container did not check for the existence of a binding in parent scopes. This has been fixed.