### PR TITLE
Adds `scaffolder:info` console command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - **Medium Impact Changes**
   - [spiral/core] Interface `Spiral\Core\Container\SingletonInterface` is deprecated,
     use `Spiral\Core\Attribute\Singleton` instead. Will be removed in v4.0.
+- **Other Features**
+  - Added `Spiral\Scaffolder\Command\InfoCommand` console command for getting information about available scaffolder 
+    commands.
 
 ## 3.11.1 - 2023-12-29
 

--- a/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php
+++ b/src/Scaffolder/src/Bootloader/ScaffolderBootloader.php
@@ -9,6 +9,7 @@ use Cocur\Slugify\SlugifyInterface;
 use ReflectionClass;
 use ReflectionException;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\KernelInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
@@ -29,8 +30,9 @@ class ScaffolderBootloader extends Bootloader
     ) {
     }
 
-    public function init(ConsoleBootloader $console): void
+    public function init(ConsoleBootloader $console, DirectoriesInterface $dir): void
     {
+        $console->addCommand(Command\InfoCommand::class);
         $console->addCommand(Command\BootloaderCommand::class);
         $console->addCommand(Command\CommandCommand::class);
         $console->addCommand(Command\ConfigCommand::class);
@@ -56,7 +58,7 @@ class ScaffolderBootloader extends Bootloader
              * Base directory for generated classes, class will be automatically localed into sub directory
              * using given namespace.
              */
-            'directory' => directory('app') . 'src/',
+            'directory' => $dir->get('app') . 'src/',
 
             /*
              * Default namespace to be applied for every generated class. By default uses Kernel namespace
@@ -83,7 +85,7 @@ class ScaffolderBootloader extends Bootloader
                         'postfix' => 'Config',
                         'class' => Declaration\ConfigDeclaration::class,
                         'options' => [
-                            'directory' => directory('config'),
+                            'directory' => $dir->get('config'),
                         ],
                     ],
                     Declaration\ControllerDeclaration::TYPE => [
@@ -98,7 +100,7 @@ class ScaffolderBootloader extends Bootloader
                     ],
                     Declaration\MiddlewareDeclaration::TYPE => [
                         'namespace' => 'Middleware',
-                        'postfix' => '',
+                        'postfix' => 'Middleware',
                         'class' => Declaration\MiddlewareDeclaration::class,
                     ],
                     Declaration\CommandDeclaration::TYPE => [
@@ -117,7 +119,7 @@ class ScaffolderBootloader extends Bootloader
     }
 
     /**
-     * Register new Scaffolder declaration.
+     * Register a new Scaffolder declaration.
      *
      * @param non-empty-string $name
      */

--- a/src/Scaffolder/src/Command/InfoCommand.php
+++ b/src/Scaffolder/src/Command/InfoCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Scaffolder\Command;
+
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Command;
+use Spiral\Console\Console;
+use Spiral\Scaffolder\Config\ScaffolderConfig;
+use Symfony\Component\Console\Helper\TableSeparator;
+
+#[AsCommand(name: 'scaffolder:info', description: 'Show information about available scaffolder commands.')]
+final class InfoCommand extends Command
+{
+    #[Argument(description: 'Class name')]
+    private string $name = 'Example';
+
+    public function perform(ScaffolderConfig $config, DirectoriesInterface $dirs, Console $console): int
+    {
+        $this->output->title('Scaffolder commands');
+        $this->writeln(
+            'Scaffolder enables developers to quickly and easily generate application code for various classes, using a set of console commands',
+        );
+
+        $this->newLine();
+
+        $table = $this->table(['Command', 'Target']);
+        $rootDir = $dirs->get('root');
+        $available = $config->getDeclarations();
+
+        $i = 0;
+        foreach ($available as $name) {
+            $command = 'create:' . $name;
+
+            if (!$console->getApplication()->has($command)) {
+                continue;
+            }
+
+            $command = $console->getApplication()->get($command);
+
+            if ($i > 0) {
+                $table->addRow(new TableSeparator());
+            }
+            $declaration = $config->getDeclaration($name);
+
+            $options = [];
+            foreach ($declaration['options'] ?? [] as $key => $value) {
+                $options[] = $key . ': <fg=yellow>' . \json_encode(\str_replace($rootDir, '', $value)) . '</>';
+            }
+
+            $file = \str_replace($rootDir, '', $config->classFilename($name, $this->name));
+            $namespace = $config->classNamespace($name, $this->name);
+            $table->addRow([
+                $command->getName() . "\n<fg=gray>{$command->getDescription()}</>",
+                <<<TARGET
+path: <fg=green>/$file</>
+namespace: <fg=yellow>$namespace</>
+TARGET
+                .
+                ($options !== [] ? "\n" . \implode("\n", $options) : ''),
+            ]);
+
+            $i++;
+        }
+
+        $randomName = $available[\array_rand($available)];
+        $this->writeln(
+            "<info>Use `<fg=yellow>php app.php create:{$randomName} {$this->name}</>` command to generate desired class. Below is a list of available commands:</info>",
+        );
+
+        $table->render();
+
+        $this->writeln(
+            '<info>Use `<fg=yellow>php app.php create:*** --help</>` command to see available options.</info>',
+        );
+
+        $this->writeln('Read more about scaffolder in <fg=yellow>https://spiral.dev/docs/basics-scaffolding</> documentation section.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Scaffolder/src/Config/ScaffolderConfig.php
+++ b/src/Scaffolder/src/Config/ScaffolderConfig.php
@@ -16,11 +16,11 @@ class ScaffolderConfig extends InjectableConfig
     public const CONFIG = 'scaffolder';
 
     protected array $config = [
-        'header'       => [],
-        'directory'    => '',
-        'namespace'    => '',
+        'header' => [],
+        'directory' => '',
+        'namespace' => '',
         'declarations' => [],
-        'defaults'     => [
+        'defaults' => [
             'declarations' => [],
         ],
     ];
@@ -36,6 +36,16 @@ class ScaffolderConfig extends InjectableConfig
     public function baseDirectory(): string
     {
         return $this->config['directory'];
+    }
+
+    /**
+     * @return non-empty-string[]
+     */
+    public function getDeclarations(): array
+    {
+        return \array_keys($this->config['defaults']['declarations'] ?? []) + \array_keys(
+                $this->config['declarations'],
+            );
     }
 
     /**
@@ -109,7 +119,7 @@ class ScaffolderConfig extends InjectableConfig
 
         if (empty($class)) {
             throw new ScaffolderException(
-                \sprintf("Unable to scaffold '%s', no declaration class found", $element)
+                \sprintf("Unable to scaffold '%s', no declaration class found", $element),
             );
         }
 
@@ -183,7 +193,7 @@ class ScaffolderConfig extends InjectableConfig
         $declaration = $this->getDeclaration($element);
 
         if (\array_key_exists('baseNamespace', $declaration)) {
-            return \trim((string) $this->getOption($element, 'baseNamespace', ''), '\\');
+            return \trim((string)$this->getOption($element, 'baseNamespace', ''), '\\');
         }
 
         return \trim($this->config['namespace'], '\\');
@@ -213,9 +223,11 @@ class ScaffolderConfig extends InjectableConfig
     }
 
     /**
+     * Get declaration options by element name.
+     *
      * @param non-empty-string $element
      */
-    private function getDeclaration(string $element): array
+    public function getDeclaration(string $element): array
     {
         $default = $this->config['defaults']['declarations'][$element] ?? [];
         $declaration = $this->config['declarations'][$element] ?? [];

--- a/src/Scaffolder/tests/Command/InfoCommandTest.php
+++ b/src/Scaffolder/tests/Command/InfoCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Command;
+
+use Spiral\Tests\Scaffolder\Command\AbstractCommandTestCase;
+
+final class InfoCommandTest extends AbstractCommandTestCase
+{
+    public function testInfo(): void
+    {
+        $result = $this->console()->run('scaffolder:info')->getOutput()->fetch();
+
+        $strings = [
+            'Scaffolder commands',
+            'create:controller',
+            'create:bootloader',
+            'create:config',
+            'create:filter',
+            'create:command',
+            'create:middleware',
+            'create:jobHandler',
+        ];
+
+        foreach ($strings as $string) {
+            $this->assertStringContainsString($string, $result);
+        }
+    }
+}

--- a/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
+++ b/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
@@ -32,7 +32,7 @@ final class ScaffolderBootloaderTest extends BaseTestCase
 
         $this->assertSame(
             ['foo' => ['bar' => 'baz']],
-            $configs->getConfig(ScaffolderConfig::CONFIG)['defaults']['declarations']
+            $configs->getConfig(ScaffolderConfig::CONFIG)['defaults']['declarations'],
         );
     }
 
@@ -73,7 +73,7 @@ final class ScaffolderBootloaderTest extends BaseTestCase
                     ],
                     Declaration\MiddlewareDeclaration::TYPE => [
                         'namespace' => 'Middleware',
-                        'postfix' => '',
+                        'postfix' => 'Middleware',
                         'class' => Declaration\MiddlewareDeclaration::class,
                     ],
                     Declaration\CommandDeclaration::TYPE => [
@@ -87,7 +87,7 @@ final class ScaffolderBootloaderTest extends BaseTestCase
                         'class' => Declaration\JobHandlerDeclaration::class,
                     ],
                 ],
-            ]
+            ],
         ], $config);
     }
 }


### PR DESCRIPTION
![image](https://github.com/spiral/framework/assets/773481/6eba55e0-7949-49bd-8d0f-80c7385f22e9)


| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #1063
