### PR TITLE
[spiral/router] Update Route list command for customization route class

### DIFF
--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -8,7 +8,7 @@ use Spiral\Boot\KernelInterface;
 use Spiral\Console\Command;
 use Spiral\Core\Attribute\Singleton;
 use Spiral\Router\GroupRegistry;
-use Spiral\Router\Route;
+use Spiral\Router\RouteInterface;
 use Spiral\Router\RouterInterface;
 use Spiral\Router\Target\Action;
 use Spiral\Router\Target\Controller;

--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -29,7 +29,7 @@ final class ListCommand extends Command
         $grid = $this->table(['Name:', 'Verbs:', 'Pattern:', 'Target:', 'Group:']);
 
         foreach ($router->getRoutes() as $name => $route) {
-            if ($route instanceof Route) {
+            if ($route instanceof RouteInterface) {
                 $grid->addRow(
                     [
                         $name,
@@ -62,9 +62,9 @@ final class ListCommand extends Command
         return $groups;
     }
 
-    private function getVerbs(Route $route): string
+    private function getVerbs(RouteInterface $route): string
     {
-        if ($route->getVerbs() === Route::VERBS) {
+        if ($route->getVerbs() === RouteInterface::VERBS) {
             return '*';
         }
 
@@ -82,7 +82,7 @@ final class ListCommand extends Command
         return \implode(', ', $result);
     }
 
-    private function getPattern(Route $route): string
+    private function getPattern(RouteInterface $route): string
     {
         $pattern = $this->getValue($route->getUriHandler(), 'pattern');
         $prefix = $this->getValue($route->getUriHandler(), 'prefix');
@@ -106,7 +106,7 @@ final class ListCommand extends Command
      *
      * @throws \ReflectionException
      */
-    private function getTarget(Route $route, KernelInterface $kernel): string
+    private function getTarget(RouteInterface $route, KernelInterface $kernel): string
     {
         $target = $this->getValue($route, 'target');
         switch (true) {


### PR DESCRIPTION
Changing the use of an implementation to an interface to implement a custom route

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️
| New feature?  | ❌ 

I have my own custom route class that inherits from RouteInterface just like the original class from the spiral/router package. However, the command to display routes does not work because it uses an implementation class rather than an interface in the types.
This PR is acknowledged to correct this.


