### PR TITLE
Update TranslatorConfig.php

### DIFF
--- a/src/Translator/src/Config/TranslatorConfig.php
+++ b/src/Translator/src/Config/TranslatorConfig.php
@@ -102,10 +102,17 @@ final class TranslatorConfig extends InjectableConfig
     public function getLocaleDirectory(string $locale, ?string $directory = null): string
     {
         if ($directory !== null) {
-            return \rtrim($directory, '/') . '/' . $locale . '/';
+            return \rtrim($directory, \DIRECTORY_SEPARATOR) 
+                . \DIRECTORY_SEPARATOR 
+                . $locale 
+                . \DIRECTORY_SEPARATOR;
         }
 
-        return \trim($this->getLocalesDirectory(), '/') . '/' . $locale . '/';
+        return \DIRECTORY_SEPARATOR 
+            . \trim($this->getLocalesDirectory(), \DIRECTORY_SEPARATOR)
+            . \DIRECTORY_SEPARATOR 
+            . $locale 
+            . \DIRECTORY_SEPARATOR;
     }
 
     /**


### PR DESCRIPTION
After installation or after executing the 'php app.php configure' command, the directory with the locale is not created correctly
<img width="397" alt="Снимок экрана 2024-02-03 в 19 11 28" src="https://github.com/spiral/framework/assets/1861327/67cb4edf-db17-4562-b2b3-de3aba73ce8e">


| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
