### PR TITLE
[spiral/translator] Fixed `getLocaleDirectory` method

### DIFF
--- a/src/Translator/src/Config/TranslatorConfig.php
+++ b/src/Translator/src/Config/TranslatorConfig.php
@@ -105,7 +105,7 @@ final class TranslatorConfig extends InjectableConfig
             return \rtrim($directory, '/') . '/' . $locale . '/';
         }
 
-        return \trim($this->getLocalesDirectory(), '/') . '/' . $locale . '/';
+        return \rtrim($this->getLocalesDirectory(), '/') . '/' . $locale . '/';
     }
 
     /**

--- a/src/Translator/tests/ConfigTest.php
+++ b/src/Translator/tests/ConfigTest.php
@@ -101,6 +101,15 @@ class ConfigTest extends TestCase
         $this->assertSame('directory/en/', $config->getLocaleDirectory('en', 'directory/'));
     }
 
+    public function testLocaleDirectoryLeadingSlash(): void
+    {
+        $config = new TranslatorConfig([
+            'directory' => '/directory/locale'
+        ]);
+
+        $this->assertSame('/directory/locale/en/', $config->getLocaleDirectory('en'));
+    }
+
     public function testDomains(): void
     {
         $config = new TranslatorConfig([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌

In the `getLocaleDirectory` method, the **trim** function call has been replaced with **rtrim**.

Replaces: #1073 
