### PR TITLE
[spiral/core] Added the ability to bind the interface as a proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Other Features**
   - Added `Spiral\Scaffolder\Command\InfoCommand` console command for getting information about available scaffolder 
     commands.
+  - [spiral/core] Added the ability to bind the interface as a proxy via `Spiral\Core\Config\Proxy` or `Spiral\Core\Config\DeprecationProxy`.
 
 ## 3.11.1 - 2023-12-29
 

--- a/src/Core/src/Config/DeprecationProxy.php
+++ b/src/Core/src/Config/DeprecationProxy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+final class DeprecationProxy extends Proxy
+{
+    /**
+     * @param class-string $interface
+     */
+    public function __construct(
+        string $interface,
+        bool $singleton = false,
+        private readonly string|\BackedEnum|null $scope = null,
+        private readonly ?string $version = null,
+        private readonly ?string $message = null,
+    ) {
+        if (($scope === null || $version === null) && $message === null) {
+            throw new \InvalidArgumentException('Scope and version or custom message must be provided.');
+        }
+
+        parent::__construct($interface, $singleton);
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getInterface(): string
+    {
+        $message = $this->message ?? \sprintf(
+            'Using `%s` outside of the `%s` scope is deprecated and will be impossible in version %s.',
+            $this->interface,
+            $this->scope,
+            $this->version
+        );
+
+        @trigger_error($message, \E_USER_DEPRECATED);
+
+        return parent::getInterface();
+    }
+}

--- a/src/Core/src/Config/DeprecationProxy.php
+++ b/src/Core/src/Config/DeprecationProxy.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Config;
 
+/**
+ * @internal
+ */
 final class DeprecationProxy extends Proxy
 {
     /**

--- a/src/Core/src/Config/Proxy.php
+++ b/src/Core/src/Config/Proxy.php
@@ -15,16 +15,16 @@ class Proxy extends Binding
     ) {
     }
 
+    public function __toString(): string
+    {
+        return \sprintf('Proxy to `%s`', $this->interface);
+    }
+
     /**
      * @return class-string
      */
     public function getInterface(): string
     {
         return $this->interface;
-    }
-
-    public function __toString(): string
-    {
-        return \sprintf('Proxy to `%s`', $this->interface);
     }
 }

--- a/src/Core/src/Config/Proxy.php
+++ b/src/Core/src/Config/Proxy.php
@@ -13,6 +13,9 @@ class Proxy extends Binding
         protected readonly string $interface,
         public readonly bool $singleton = false,
     ) {
+        if (!\interface_exists($interface)) {
+            throw new \InvalidArgumentException(\sprintf('Interface `%s` does not exist.', $interface));
+        }
     }
 
     public function __toString(): string

--- a/src/Core/src/Config/Proxy.php
+++ b/src/Core/src/Config/Proxy.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core\Config;
+
+class Proxy extends Binding
+{
+    /**
+     * @param class-string $interface
+     */
+    public function __construct(
+        protected readonly string $interface,
+        public readonly bool $singleton = false,
+    ) {
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getInterface(): string
+    {
+        return $this->interface;
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('Proxy to `%s`', $this->interface);
+    }
+}

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -8,12 +8,9 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract as ContextFunction;
 use ReflectionParameter;
-use Spiral\Core\Attribute\Finalize;
-use Spiral\Core\Attribute\Scope as ScopeAttribute;
-use Spiral\Core\Attribute\Singleton;
+use Spiral\Core\Attribute;
 use Spiral\Core\BinderInterface;
-use Spiral\Core\Config\Injectable;
-use Spiral\Core\Config\DeferredFactory;
+use Spiral\Core\Config;
 use Spiral\Core\Container\InjectorInterface;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\Exception\Container\AutowireException;
@@ -91,18 +88,20 @@ final class Factory implements FactoryInterface
 
             unset($this->state->bindings[$alias]);
             return match ($binding::class) {
-                \Spiral\Core\Config\Alias::class => $this->resolveAlias($binding, $alias, $context, $parameters),
-                \Spiral\Core\Config\Autowire::class => $this->resolveAutowire($binding, $alias, $context, $parameters),
-                DeferredFactory::class,
-                \Spiral\Core\Config\Factory::class => $this->resolveFactory($binding, $alias, $context, $parameters),
-                \Spiral\Core\Config\Shared::class => $this->resolveShared($binding, $alias, $context, $parameters),
-                Injectable::class => $this->resolveInjector(
+                Config\Alias::class => $this->resolveAlias($binding, $alias, $context, $parameters),
+                Config\Proxy::class,
+                Config\DeprecationProxy::class => $this->resolveProxy($binding, $alias, $context, $parameters),
+                Config\Autowire::class => $this->resolveAutowire($binding, $alias, $context, $parameters),
+                Config\DeferredFactory::class,
+                Config\Factory::class => $this->resolveFactory($binding, $alias, $context, $parameters),
+                Config\Shared::class => $this->resolveShared($binding, $alias, $context, $parameters),
+                Config\Injectable::class => $this->resolveInjector(
                     $binding,
                     new Ctx(alias: $alias, class: $alias, context: $context),
                     $parameters,
                 ),
-                \Spiral\Core\Config\Scalar::class => $binding->value,
-                \Spiral\Core\Config\WeakReference::class => $this
+                Config\Scalar::class => $binding->value,
+                Config\WeakReference::class => $this
                     ->resolveWeakReference($binding, $alias, $context, $parameters),
                 default => $binding,
             };
@@ -117,7 +116,7 @@ final class Factory implements FactoryInterface
      * @psalm-suppress UnusedParam
      * todo wat should we do with $arguments?
      */
-    private function resolveInjector(Injectable $binding, Ctx $ctx, array $arguments)
+    private function resolveInjector(Config\Injectable $binding, Ctx $ctx, array $arguments)
     {
         $context = $ctx->context;
         try {
@@ -174,7 +173,7 @@ final class Factory implements FactoryInterface
     }
 
     private function resolveAlias(
-        \Spiral\Core\Config\Alias $binding,
+        Config\Alias $binding,
         string $alias,
         Stringable|string|null $context,
         array $arguments,
@@ -194,8 +193,23 @@ final class Factory implements FactoryInterface
         return $result;
     }
 
+    private function resolveProxy(
+        Config\Proxy $binding,
+        string $alias,
+        Stringable|string|null $context,
+        array $arguments,
+    ): mixed {
+        $result = Proxy::create(new \ReflectionClass($binding->getInterface()), $context, new Attribute\Proxy());
+
+        if ($binding->singleton && $arguments === []) {
+            $this->state->singletons[$alias] = $result;
+        }
+
+        return $result;
+    }
+
     private function resolveShared(
-        \Spiral\Core\Config\Shared $binding,
+        Config\Shared $binding,
         string $alias,
         Stringable|string|null $context,
         array $arguments,
@@ -210,7 +224,7 @@ final class Factory implements FactoryInterface
     }
 
     private function resolveAutowire(
-        \Spiral\Core\Config\Autowire $binding,
+        Config\Autowire $binding,
         string $alias,
         Stringable|string|null $context,
         array $arguments,
@@ -222,14 +236,14 @@ final class Factory implements FactoryInterface
     }
 
     private function resolveFactory(
-        \Spiral\Core\Config\Factory|DeferredFactory $binding,
+        Config\Factory|Config\DeferredFactory $binding,
         string $alias,
         Stringable|string|null $context,
         array $arguments,
     ): mixed {
         $ctx = new Ctx(alias: $alias, class: $alias, context: $context, singleton: $binding->singleton);
         try {
-            $instance = $binding::class === \Spiral\Core\Config\Factory::class && $binding->getParametersCount() === 0
+            $instance = $binding::class === Config\Factory::class && $binding->getParametersCount() === 0
                 ? ($binding->factory)()
                 : $this->invoker->invoke($binding->factory, $arguments);
         } catch (NotCallableException $e) {
@@ -244,7 +258,7 @@ final class Factory implements FactoryInterface
     }
 
     private function resolveWeakReference(
-        \Spiral\Core\Config\WeakReference $binding,
+        Config\WeakReference $binding,
         string $alias,
         Stringable|string|null $context,
         array $arguments,
@@ -370,7 +384,7 @@ final class Factory implements FactoryInterface
     ): object {
         // Check scope name
         $ctx->reflection = new \ReflectionClass($instance);
-        $scopeName = ($ctx->reflection->getAttributes(ScopeAttribute::class)[0] ?? null)?->newInstance()->name;
+        $scopeName = ($ctx->reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
         if ($scopeName !== null && $scopeName !== $this->scope->getScopeName()) {
             throw new BadScopeException($scopeName, $instance::class);
         }
@@ -405,7 +419,7 @@ final class Factory implements FactoryInterface
         }
 
         // Check scope name
-        $scope = ($reflection->getAttributes(ScopeAttribute::class)[0] ?? null)?->newInstance()->name;
+        $scope = ($reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
         if ($scope !== null && $scope !== $this->scope->getScopeName()) {
             throw new BadScopeException($scope, $class);
         }
@@ -503,16 +517,16 @@ final class Factory implements FactoryInterface
             return true;
         }
 
-        return $ctx->reflection->getAttributes(Singleton::class) !== [];
+        return $ctx->reflection->getAttributes(Attribute\Singleton::class) !== [];
     }
 
     private function getFinalizer(Ctx $ctx, object $instance): ?callable
     {
         /**
          * @psalm-suppress UnnecessaryVarAnnotation
-         * @var Finalize|null $attribute
+         * @var Attribute\Finalize|null $attribute
          */
-        $attribute = ($ctx->reflection->getAttributes(Finalize::class)[0] ?? null)?->newInstance();
+        $attribute = ($ctx->reflection->getAttributes(Attribute\Finalize::class)[0] ?? null)?->newInstance();
         if ($attribute === null) {
             return null;
         }

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -90,7 +90,7 @@ final class Factory implements FactoryInterface
             return match ($binding::class) {
                 Config\Alias::class => $this->resolveAlias($binding, $alias, $context, $parameters),
                 Config\Proxy::class,
-                Config\DeprecationProxy::class => $this->resolveProxy($binding, $alias, $context, $parameters),
+                Config\DeprecationProxy::class => $this->resolveProxy($binding, $alias, $context),
                 Config\Autowire::class => $this->resolveAutowire($binding, $alias, $context, $parameters),
                 Config\DeferredFactory::class,
                 Config\Factory::class => $this->resolveFactory($binding, $alias, $context, $parameters),
@@ -193,15 +193,11 @@ final class Factory implements FactoryInterface
         return $result;
     }
 
-    private function resolveProxy(
-        Config\Proxy $binding,
-        string $alias,
-        Stringable|string|null $context,
-        array $arguments,
-    ): mixed {
+    private function resolveProxy(Config\Proxy $binding, string $alias, Stringable|string|null $context): mixed
+    {
         $result = Proxy::create(new \ReflectionClass($binding->getInterface()), $context, new Attribute\Proxy());
 
-        if ($binding->singleton && $arguments === []) {
+        if ($binding->singleton) {
             $this->state->singletons[$alias] = $result;
         }
 

--- a/src/Core/tests/Internal/Proxy/ProxyTest.php
+++ b/src/Core/tests/Internal/Proxy/ProxyTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Core\Internal\Proxy;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use Spiral\Core\Attribute\Proxy;
+use Spiral\Core\Config;
 use Spiral\Core\Container;
+use Spiral\Core\Exception\Container\ContainerException;
+use Spiral\Core\Scope;
 use Spiral\Tests\Core\Internal\Proxy\Stub\EmptyInterface;
 use Spiral\Tests\Core\Internal\Proxy\Stub\MockInterface;
 use Spiral\Tests\Core\Internal\Proxy\Stub\MockInterfaceImpl;
@@ -20,9 +25,7 @@ final class ProxyTest extends TestCase
         // yield [EmptyInterface::class, 'empty'];
     }
 
-    /**
-     * @dataProvider interfacesProvider
-     */
+    #[DataProvider('interfacesProvider')]
     public function testSimpleCases(string $interface, string $var): void
     {
         $root = new Container();
@@ -54,9 +57,7 @@ final class ProxyTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider interfacesProvider
-     */
+    #[DataProvider('interfacesProvider')]
     public function testExtraArguments(string $interface, string $var): void
     {
         $root = new Container();
@@ -76,9 +77,7 @@ final class ProxyTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider interfacesProvider
-     */
+    #[DataProvider('interfacesProvider')]
     public function testVariadic(string $interface, string $var): void
     {
         $root = new Container();
@@ -99,9 +98,7 @@ final class ProxyTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider interfacesProvider
-     */
+    #[DataProvider('interfacesProvider')]
     public function testReference(string $interface, string $var): void
     {
         $interface === EmptyInterface::class && self::markTestSkipped(
@@ -121,9 +118,7 @@ final class ProxyTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider interfacesProvider
-     */
+    #[DataProvider('interfacesProvider')]
     public function testReturnReference(string $interface, string $var): void
     {
         $interface === EmptyInterface::class && self::markTestSkipped(
@@ -146,9 +141,7 @@ final class ProxyTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider interfacesProvider
-     */
+    #[DataProvider('interfacesProvider')]
     public function testReferenceVariadic(string $interface, string $var): void
     {
         $interface === EmptyInterface::class && self::markTestSkipped(
@@ -187,5 +180,144 @@ final class ProxyTest extends TestCase
         $mock = $root->invoke(static fn(#[Proxy] MockInterface|EmptyInterface $mock) => $mock);
 
         self::assertInstanceOf(MockInterfaceImpl::class, $mock);
+    }
+
+    #[DataProvider('interfacesProvider')]
+    public function testProxyConfig(string $interface): void
+    {
+        $root = new Container();
+        $root->getBinder('foo')->bindSingleton($interface, Stub\MockInterfaceImpl::class);
+        $root->bindSingleton($interface, new Config\Proxy($interface, true));
+
+        $proxy = $root->get($interface);
+        $this->assertInstanceOf($interface, $proxy);
+        $this->assertNotInstanceOf(MockInterfaceImpl::class, $proxy);
+
+        $root->runScope(new Scope('foo'), static function (Container $container) use ($interface, $proxy) {
+            $proxy->bar(name: 'foo'); // Possible to run
+            self::assertSame('foo', $proxy->baz('foo', 42));
+            self::assertSame(123, $proxy->qux(age: 123));
+            self::assertSame(69, $proxy->space(test age: 69));
+
+            $real = $container->get($interface);
+            self::assertInstanceOf(MockInterfaceImpl::class, $real);
+
+            $real->bar(name: 'foo'); // Possible to run
+            self::assertSame('foo', $real->baz('foo', 42));
+            self::assertSame(123, $real->qux(age: 123));
+            self::assertSame(69, $real->space(test age: 69));
+        });
+    }
+
+    #[DataProvider('interfacesProvider')]
+    public function testProxyConfigOutOfProxyException(string $interface): void
+    {
+        $root = new Container();
+        $root->getBinder('foo')->bindSingleton($interface, Stub\MockInterfaceImpl::class);
+        $root->bindSingleton($interface, new Config\Proxy($interface, true));
+
+        $this->assertInstanceOf($interface, $root->get($interface));
+        $proxy = $root->get($interface);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('Proxy is out of scope.');
+        $proxy->bar(name: 'foo'); // Impossible to run
+    }
+
+    #[DataProvider('interfacesProvider')]
+    #[WithoutErrorHandler]
+    public function testDeprecationProxyConfig(string $interface): void
+    {
+        \set_error_handler(static function (int $errno, string $error) use ($interface): void {
+            self::assertSame(
+                \sprintf('Using `%s` outside of the `foo` scope is deprecated and will be ' .
+                    'impossible in version 4.0.', $interface),
+                $error
+            );
+        });
+
+        $root = new Container();
+        $root->getBinder('foo')->bindSingleton($interface, Stub\MockInterfaceImpl::class);
+        $root->bindSingleton($interface, new Config\DeprecationProxy($interface, true, 'foo', '4.0'));
+
+        $proxy = $root->get($interface);
+        $this->assertInstanceOf($interface, $proxy);
+
+        $root->runScope(new Scope('foo'), static function () use ($proxy) {
+            $proxy->bar(name: 'foo'); // Possible to run
+            self::assertSame('foo', $proxy->baz('foo', 42));
+            self::assertSame(123, $proxy->qux(age: 123));
+            self::assertSame(69, $proxy->space(test age: 69));
+        });
+
+        \restore_error_handler();
+    }
+
+    #[DataProvider('interfacesProvider')]
+    #[WithoutErrorHandler]
+    public function testDeprecationProxyConfigCustomMessage(string $interface): void
+    {
+        \set_error_handler(static function (int $errno, string $error) use ($interface): void {
+            self::assertSame(\sprintf('Using `%s` impossible', $interface), $error);
+        });
+
+        $root = new Container();
+        $root->getBinder('foo')->bindSingleton($interface, Stub\MockInterfaceImpl::class);
+        $root->bindSingleton($interface, new Config\DeprecationProxy(
+            interface: $interface,
+            message: \sprintf('Using `%s` impossible', $interface),
+        ));
+
+        $proxy = $root->get($interface);
+        $this->assertInstanceOf($interface, $proxy);
+
+        $root->runScope(new Scope('foo'), static function () use ($proxy) {
+            $proxy->bar(name: 'foo'); // Possible to run
+            self::assertSame('foo', $proxy->baz('foo', 42));
+            self::assertSame(123, $proxy->qux(age: 123));
+            self::assertSame(69, $proxy->space(test age: 69));
+        });
+
+        \restore_error_handler();
+    }
+
+    #[DataProvider('interfacesProvider')]
+    #[WithoutErrorHandler]
+    public function testDeprecationProxyConfigDontThrowIfNotConstructed(string $interface): void
+    {
+        \set_error_handler(static function (int $errno, string $error) use ($interface): void {
+            self::fail('Unexpected error: ' . $error);
+        });
+
+        $root = new Container();
+        $root->getBinder('foo')->bindSingleton($interface, Stub\MockInterfaceImpl::class);
+        $root->bindSingleton($interface, new Config\DeprecationProxy($interface, true, 'foo', '4.0'));
+
+        $root->runScope(new Scope('foo'), static function (Container $container) use ($interface) {
+            $proxy = $container->get($interface);
+
+            $proxy->bar(name: 'foo'); // Possible to run
+            self::assertSame('foo', $proxy->baz('foo', 42));
+            self::assertSame(123, $proxy->qux(age: 123));
+            self::assertSame(69, $proxy->space(test age: 69));
+        });
+
+        \restore_error_handler();
+    }
+
+    #[DataProvider('invalidDeprecationProxyArgsDataProvider')]
+    public function testDeprecationProxyConfigArgsRequiredException(string|null $scope, string|null $version): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('Scope and version or custom message must be provided.');
+
+        new Config\DeprecationProxy(interface: EmptyInterface::class, scope: $scope, version: $version);
+    }
+
+    public static function invalidDeprecationProxyArgsDataProvider(): \Traversable
+    {
+        yield [null, '4.0'];
+        yield ['foo', null];
+        yield [null, null];
     }
 }

--- a/src/Core/tests/Internal/Proxy/ProxyTest.php
+++ b/src/Core/tests/Internal/Proxy/ProxyTest.php
@@ -314,6 +314,21 @@ final class ProxyTest extends TestCase
         new Config\DeprecationProxy(interface: EmptyInterface::class, scope: $scope, version: $version);
     }
 
+    public function testProxyConfigToString(): void
+    {
+        $proxy = new Config\Proxy(EmptyInterface::class);
+
+        $this->assertSame(\sprintf('Proxy to `%s`', EmptyInterface::class), (string) $proxy);
+    }
+
+    public function testProxyConfigNotInterfaceException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Interface `%s` does not exist.', \stdClass::class));
+
+        new Config\Proxy(\stdClass::class);
+    }
+
     public static function invalidDeprecationProxyArgsDataProvider(): \Traversable
     {
         yield [null, '4.0'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️


### Proxy

Added the ability to bind an interface as a proxy using the `Spiral\Core\Config\Proxy` configuration. This is useful in cases where a service needs to be used within a specific scope but must be accessible within the container for other services in root or other scopes (so that a service requiring the dependency can be successfully created and used when needed in the correct scope).

```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Core\BinderInterface;
use Spiral\Core\Config\Proxy;
use Spiral\Framework\ScopeName;
use Spiral\Http\PaginationFactory;
use Spiral\Pagination\PaginationProviderInterface;

final class PaginationBootloader extends Bootloader
{
    public function __construct(
        private readonly BinderInterface $binder,
    ) {
    }
    
    public function defineSingletons(): array
    {
        $this->binder
            ->getBinder(ScopeName::Http)
            ->bindSingleton(PaginationProviderInterface::class, PaginationFactory::class);
        
        $this->binder->bind(
            PaginationProviderInterface::class,
            new Proxy(PaginationProviderInterface::class, true)  // <-------
        );

        return [];
    }
}
```

### DeprecationProxy

Similar to **Proxy**, but also allows outputting a deprecation message when attempting to retrieve a dependency from the container. In the example below, we use two bindings, one in scope and one out of scope with `Spiral\Core\Config\DeprecationProxy`. When requesting the interface in scope, we will receive the service, and when requesting it out of scope, we will receive the service and a deprecation message.

```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Core\BinderInterface;
use Spiral\Core\Config\DeprecationProxy;
use Spiral\Framework\ScopeName;
use Spiral\Http\PaginationFactory;
use Spiral\Pagination\PaginationProviderInterface;

final class PaginationBootloader extends Bootloader
{
    public function __construct(
        private readonly BinderInterface $binder,
    ) {
    }

    public function defineSingletons(): array
    {
        $this->binder
            ->getBinder(ScopeName::Http)
            ->bindSingleton(PaginationProviderInterface::class, PaginationFactory::class);

        $this->binder->bind(
            PaginationProviderInterface::class,
            new DeprecationProxy(PaginationProviderInterface::class, true, ScopeName::Http, '4.0') // <----------
        );

        return [];
    }
}
```

Psalm fixed in: #1076 
