### PR TITLE
[spiral/core] Added the ability to configure container via options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Added `Spiral\Scaffolder\Command\InfoCommand` console command for getting information about available scaffolder 
     commands.
   - [spiral/core] Added the ability to bind the interface as a proxy via `Spiral\Core\Config\Proxy` or `Spiral\Core\Config\DeprecationProxy`.
+  - [spiral/core] Added the ability to configure the container using `Spiral\Core\Options`. Added option **checkScope** 
+    to enable scope checking.
 
 ## 3.11.1 - 2023-12-29
 

--- a/src/Core/src/Attribute/Scope.php
+++ b/src/Core/src/Attribute/Scope.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Core\Attribute;
 
 /**
- * Set a scope in which the dependency can be resolved.
+ * Set the scope in which the dependency can be resolved.
  *
  * @internal We are testing this feature, it may be changed in the future.
  */

--- a/src/Core/src/Container.php
+++ b/src/Core/src/Container.php
@@ -60,6 +60,7 @@ final class Container implements
     public function __construct(
         private Config $config = new Config(),
         ?string $scopeName = self::DEFAULT_ROOT_SCOPE_NAME,
+        private Options $options = new Options(),
     ) {
         $this->initServices($this, $scopeName);
 
@@ -324,7 +325,7 @@ final class Container implements
         $constructor = new Internal\Common\Registry($container->config, [
             'state' => $state,
             'scope' => new Internal\Scope($scopeName),
-        ]);
+        ], $this->options);
 
         // Create container services
         foreach ($container->config as $property => $class) {
@@ -379,7 +380,7 @@ final class Container implements
     private function runIsolatedScope(Scope $config, callable $closure): mixed
     {
         // Open scope
-        $container = new self($this->config, $config->name);
+        $container = new self($this->config, $config->name, $this->options);
 
         // Configure scope
         $container->scope->setParent($this, $this->scope, $this->factory);

--- a/src/Core/src/Internal/Common/Registry.php
+++ b/src/Core/src/Internal/Common/Registry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Core\Internal\Common;
 
 use Spiral\Core\Config;
+use Spiral\Core\Options;
 
 /**
  * @internal
@@ -17,6 +18,7 @@ final class Registry
     public function __construct(
         private Config $config,
         private array $objects = [],
+        private Options $options = new Options(),
     ) {
     }
 
@@ -38,5 +40,10 @@ final class Registry
         $result = $this->objects[$name] ?? new $className($this);
         \assert($result instanceof $interface);
         return $result;
+    }
+
+    public function getOptions(): Options
+    {
+        return $this->options;
     }
 }

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -381,13 +381,15 @@ final class Factory implements FactoryInterface
         Ctx $ctx,
         array $arguments,
     ): object {
-        // Check scope name
-        $ctx->reflection = new \ReflectionClass($instance);
-        $scopeName = ($ctx->reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
-        if ($scopeName !== null && $this->options->checkScope) {
-            $scope = $this->scope;
-            while ($scope->getScopeName() !== $scopeName) {
-                $scope = $scope->getParentScope() ?? throw new BadScopeException($scopeName, $instance::class);
+        if ($this->options->checkScope) {
+            // Check scope name
+            $ctx->reflection = new \ReflectionClass($instance);
+            $scopeName = ($ctx->reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
+            if ($scopeName !== null) {
+                $scope = $this->scope;
+                while ($scope->getScopeName() !== $scopeName) {
+                    $scope = $scope->getParentScope() ?? throw new BadScopeException($scopeName, $instance::class);
+                }
             }
         }
 
@@ -421,9 +423,11 @@ final class Factory implements FactoryInterface
         }
 
         // Check scope name
-        $scope = ($reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
-        if ($this->options->checkScope && $scope !== null && $scope !== $this->scope->getScopeName()) {
-            throw new BadScopeException($scope, $class);
+        if ($this->options->checkScope) {
+            $scope = ($reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
+            if ($scope !== null && $scope !== $this->scope->getScopeName()) {
+                throw new BadScopeException($scope, $class);
+            }
         }
 
         // We have to construct class using external injector when we know the exact context

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -452,7 +452,7 @@ final class Factory implements FactoryInterface
             try {
                 $this->tracer->push(false, action: 'resolve arguments', signature: $constructor);
                 $this->tracer->push(true);
-                $args = $this->resolver->resolveArguments($constructor, $arguments);
+                $args = $this->resolver->resolveArguments($constructor, $arguments, $this->options->validateArguments);
             } catch (ValidationException $e) {
                 throw new ContainerException(
                     $this->tracer->combineTraceMessage(

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -26,6 +26,7 @@ use Spiral\Core\Internal\Common\DestructorTrait;
 use Spiral\Core\Internal\Common\Registry;
 use Spiral\Core\Internal\Factory\Ctx;
 use Spiral\Core\InvokerInterface;
+use Spiral\Core\Options;
 use Spiral\Core\ResolverInterface;
 use Stringable;
 use WeakReference;
@@ -44,6 +45,7 @@ final class Factory implements FactoryInterface
     private ResolverInterface $resolver;
     private Tracer $tracer;
     private Scope $scope;
+    private Options $options;
 
     public function __construct(Registry $constructor)
     {
@@ -56,6 +58,7 @@ final class Factory implements FactoryInterface
         $this->resolver = $constructor->get('resolver', ResolverInterface::class);
         $this->tracer = $constructor->get('tracer', Tracer::class);
         $this->scope = $constructor->get('scope', Scope::class);
+        $this->options = $constructor->getOptions();
     }
 
     /**
@@ -381,7 +384,7 @@ final class Factory implements FactoryInterface
         // Check scope name
         $ctx->reflection = new \ReflectionClass($instance);
         $scopeName = ($ctx->reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
-        if ($scopeName !== null) {
+        if ($scopeName !== null && $this->options->checkScope) {
             $scope = $this->scope;
             while ($scope->getScopeName() !== $scopeName) {
                 $scope = $scope->getParentScope() ?? throw new BadScopeException($scopeName, $instance::class);
@@ -419,7 +422,7 @@ final class Factory implements FactoryInterface
 
         // Check scope name
         $scope = ($reflection->getAttributes(Attribute\Scope::class)[0] ?? null)?->newInstance()->name;
-        if ($scope !== null && $scope !== $this->scope->getScopeName()) {
+        if ($this->options->checkScope && $scope !== null && $scope !== $this->scope->getScopeName()) {
             throw new BadScopeException($scope, $class);
         }
 

--- a/src/Core/src/Internal/Invoker.php
+++ b/src/Core/src/Internal/Invoker.php
@@ -10,6 +10,7 @@ use Spiral\Core\Exception\Container\NotCallableException;
 use Spiral\Core\Internal\Common\DestructorTrait;
 use Spiral\Core\Internal\Common\Registry;
 use Spiral\Core\InvokerInterface;
+use Spiral\Core\Options;
 use Spiral\Core\ResolverInterface;
 
 /**
@@ -23,6 +24,7 @@ final class Invoker implements InvokerInterface
 
     private ContainerInterface $container;
     private ResolverInterface $resolver;
+    private Options $options;
 
     public function __construct(Registry $constructor)
     {
@@ -30,6 +32,7 @@ final class Invoker implements InvokerInterface
 
         $this->container = $constructor->get('container', ContainerInterface::class);
         $this->resolver = $constructor->get('resolver', ResolverInterface::class);
+        $this->options = $constructor->getOptions();
     }
 
     /**
@@ -72,7 +75,7 @@ final class Invoker implements InvokerInterface
 
             // Invoking Closure with resolved arguments
             return $reflection->invokeArgs(
-                $this->resolver->resolveArguments($reflection, $parameters)
+                $this->resolver->resolveArguments($reflection, $parameters, $this->options->validateArguments),
             );
         }
 

--- a/src/Core/src/Options.php
+++ b/src/Core/src/Options.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core;
+
+use Spiral\Core\Exception\Scope\BadScopeException;
+
+class Options
+{
+    /**
+     * Enables checking of scopes when creating an object. If the check is enabled and the object is created outside
+     * the required scope, an exception {@see BadScopeException} will be thrown.
+     * By default, checking is disabled. Will be enabled by default in version 4.0
+     */
+    public bool $checkScope = false;
+}

--- a/src/Core/src/Options.php
+++ b/src/Core/src/Options.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Core;
 
+use Spiral\Core\Container\InjectorInterface;
 use Spiral\Core\Exception\Scope\BadScopeException;
 
 class Options
@@ -19,7 +20,8 @@ class Options
     public bool $checkScope = false;
 
     /**
-     * Validate autowired arguments in Container services.
+     * Validate resolved arguments in Container services, for example in {@see FactoryInterface::make()},
+     * {@see InjectorInterface::invoke()} and {@see ConfigsInterface::get()}.
      * This occurs when the {@see ResolverInterface::resolveArguments()} resolves parameters
      * from the Container or predefined arguments.
      */

--- a/src/Core/src/Options.php
+++ b/src/Core/src/Options.php
@@ -17,4 +17,11 @@ class Options
      * Will be set to true by default since version 4.0
      */
     public bool $checkScope = false;
+
+    /**
+     * Validate autowired arguments in Container services.
+     * This occurs when the {@see ResolverInterface::resolveArguments()} resolves parameters
+     * from the Container or predefined arguments.
+     */
+    public bool $validateArguments = true;
 }

--- a/src/Core/src/Options.php
+++ b/src/Core/src/Options.php
@@ -9,9 +9,12 @@ use Spiral\Core\Exception\Scope\BadScopeException;
 class Options
 {
     /**
-     * Enables checking of scopes when creating an object. If the check is enabled and the object is created outside
+     * Check that object is created in the correct scope.
+     * The scope is defined by the {@see \Spiral\Core\Attribute\Scope} attribute.
+     * If the check is enabled and the object is created outside
      * the required scope, an exception {@see BadScopeException} will be thrown.
-     * By default, checking is disabled. Will be enabled by default in version 4.0
+     *
+     * Will be set to true by default since version 4.0
      */
     public bool $checkScope = false;
 }

--- a/src/Core/tests/Internal/Common/CommonTest.php
+++ b/src/Core/tests/Internal/Common/CommonTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Internal\Common;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\Container;
+use Spiral\Core\Exception\Container\ContainerException;
+use Spiral\Core\Exception\Resolver\InvalidArgumentException;
+use Spiral\Core\Exception\Resolver\WrongTypeException;
+use Spiral\Core\Options;
+use Spiral\Tests\Core\Fixtures\Bucket;
+use TypeError;
+
+final class CommonTest extends TestCase
+{
+    public function testDisableArgumentsValidationWithFactory(): void
+    {
+        $options = new Options();
+        $options->validateArguments = false;
+        $container = new Container(options: $options);
+
+        $this->expectException(WrongTypeException::class);
+
+        $container->make(Bucket::class, [
+            'name' => 123,
+        ]);
+    }
+
+    public function testEnableArgumentsValidationWithFactory(): void
+    {
+        $options = new Options();
+        $options->validateArguments = true;
+        $container = new Container(options: $options);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/Can\'t resolve /');
+        $this->expectExceptionMessageMatches('/Invalid argument value type for the `name`/');
+
+        $container->make(Bucket::class, [
+            'name' => 123,
+        ]);
+    }
+
+    public function testDisableArgumentsValidationWithInvoker(): void
+    {
+        $options = new Options();
+        $options->validateArguments = false;
+        $container = new Container(options: $options);
+
+        $this->expectException(TypeError::class);
+
+        $container->invoke(fn (int $x): int => $x, [
+            'x' => 'string',
+        ]);
+    }
+
+    public function testEnableArgumentsValidationWithInvoker(): void
+    {
+        $options = new Options();
+        $options->validateArguments = true;
+        $container = new Container(options: $options);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $container->invoke(fn (int $x): int => $x, [
+            'x' => 'string',
+        ]);
+    }
+}

--- a/src/Core/tests/Internal/Common/RegistryTest.php
+++ b/src/Core/tests/Internal/Common/RegistryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Internal\Common;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\Config;
+use Spiral\Core\Internal\Common\Registry;
+use Spiral\Core\Options;
+
+final class RegistryTest extends TestCase
+{
+    #[DataProvider('configDataProvider')]
+    public function testGetConfig(Options $options): void
+    {
+        $registry = new Registry(
+            config: $this->createMock(Config::class),
+            options: $options
+        );
+
+        $this->assertSame($options, $registry->getOptions());
+    }
+
+    public static function configDataProvider(): \Traversable
+    {
+        yield [new Options()];
+
+        $option = new Options();
+        $option->checkScope = true;
+        yield [$option];
+
+        $option = new class extends Options {
+            public int $customOption = 3;
+        };
+        $option->customOption = 5;
+        $option->checkScope = true;
+        yield [$option];
+    }
+}

--- a/src/Core/tests/Scope/BaseTestCase.php
+++ b/src/Core/tests/Scope/BaseTestCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Spiral\Tests\Core\Scope;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Core\Container;
+use Spiral\Core\Options;
 use WeakMap;
 
 abstract class BaseTestCase extends TestCase
@@ -21,5 +23,13 @@ abstract class BaseTestCase extends TestCase
     {
         self::assertEmpty($this->weakMap, 'Weak map is not empty.');
         parent::tearDown();
+    }
+
+    protected static function makeContainer(bool $checkScope = true): Container
+    {
+        $options = new Options();
+        $options->checkScope = $checkScope;
+
+        return new Container(options: $options);
     }
 }

--- a/src/Core/tests/Scope/FinalizeAttributeTest.php
+++ b/src/Core/tests/Scope/FinalizeAttributeTest.php
@@ -19,7 +19,7 @@ final class FinalizeAttributeTest extends BaseTestCase
      */
     public function testFinalizerHasBeenRegisteredAndRun(): void
     {
-        $root = new Container();
+        $root = self::makeContainer();
 
         $obj = $root->runScoped(static function (Container $c1) {
             $obj = $c1->runScoped(static function (Container $c2) {
@@ -42,7 +42,7 @@ final class FinalizeAttributeTest extends BaseTestCase
      */
     public function testFinalizerAutowiringOnCall(): void
     {
-        $root = new Container();
+        $root = self::makeContainer();
         $root->bindSingleton(LoggerInterface::class, FileLogger::class);
 
         $obj2 = null;
@@ -73,7 +73,7 @@ final class FinalizeAttributeTest extends BaseTestCase
      */
     public function testFinalizerWithoutConcreteScope(): void
     {
-        $root = new Container();
+        $root = self::makeContainer();
         $root->bindSingleton(LoggerInterface::class, FileLogger::class);
 
         $obj2 = null;
@@ -104,7 +104,7 @@ final class FinalizeAttributeTest extends BaseTestCase
      */
     public function testFinalizerWithoutConcreteScopeInRoot(): void
     {
-        $root = new Container();
+        $root = self::makeContainer();
         $root->bindSingleton(LoggerInterface::class, FileLogger::class);
 
         $obj = $root->get(AttrFinalize::class);
@@ -119,7 +119,7 @@ final class FinalizeAttributeTest extends BaseTestCase
     #[Group('scrutinizer-ignore')]
     public function testExceptionOnDestroy()
     {
-        $root = new Container();
+        $root = self::makeContainer();
 
         self::expectException(FinalizersException::class);
         self::expectExceptionMessage('An exception has been thrown during finalization of the scope `foo`');
@@ -148,7 +148,7 @@ final class FinalizeAttributeTest extends BaseTestCase
     #[Group('scrutinizer-ignore')]
     public function testManyExceptionsOnDestroy()
     {
-        $root = new Container();
+        $root = self::makeContainer();
 
         self::expectException(FinalizersException::class);
         self::expectExceptionMessage('3 exceptions have been thrown during finalization of the scope `foo`');

--- a/src/Core/tests/Scope/ScopeAttributeTest.php
+++ b/src/Core/tests/Scope/ScopeAttributeTest.php
@@ -28,7 +28,7 @@ final class ScopeAttributeTest extends BaseTestCase
 
     public function testBadScopeWithDisabledChecking(): void
     {
-        $root = self::makeContainer(false);
+        $root = self::makeContainer(checkScope: false);
         $this->assertInstanceOf(AttrScopeFooSingleton::class, $root->make(AttrScopeFooSingleton::class));
     }
 
@@ -78,7 +78,7 @@ final class ScopeAttributeTest extends BaseTestCase
 
     public function testAllParentNamedScopesNotContainsNeededScopeWithDisabledChecking(): void
     {
-        $root = self::makeContainer(false);
+        $root = self::makeContainer(checkScope: false);
         $root->getBinder('bar')->bindSingleton('binding', static fn () => new AttrScopeFoo());
 
         $root->runScoped(static function (Container $fooScope) {
@@ -111,7 +111,7 @@ final class ScopeAttributeTest extends BaseTestCase
     #[Group('scrutinizer-ignore')]
     public function testRequestObjectFromValidScopeUsingFactoryFromWrongScopeWithDisabledChecking(): void
     {
-        $root = self::makeContainer(false);
+        $root = self::makeContainer(checkScope: false);
         $root->bind('foo', self::makeFooScopeObject(...));
 
         $root->runScoped(static function (Container $c1) {
@@ -143,7 +143,7 @@ final class ScopeAttributeTest extends BaseTestCase
     #[Group('scrutinizer-ignore')]
     public function testNamedScopeUseFactoryInWrongParentScopeWithDisabledChecking(): void
     {
-        $root = self::makeContainer(false);
+        $root = self::makeContainer(checkScope: false);
         $root->bind('foo', self::makeFooScopeObject(...));
 
         $root->runScoped(static function (Container $c1) {

--- a/src/Core/tests/Scope/ScopeAttributeTest.php
+++ b/src/Core/tests/Scope/ScopeAttributeTest.php
@@ -10,7 +10,6 @@ use Spiral\Core\Container;
 use Spiral\Core\Exception\Container\NotFoundException;
 use Spiral\Core\Exception\Scope\BadScopeException;
 use Spiral\Core\Exception\Scope\NamedScopeDuplicationException;
-use Spiral\Core\Options;
 use Spiral\Tests\Core\Scope\Stub\AttrScopeFoo;
 use Spiral\Tests\Core\Scope\Stub\AttrScopeFooSingleton;
 
@@ -205,13 +204,5 @@ final class ScopeAttributeTest extends BaseTestCase
     private static function makeFooScopeObject(): AttrScopeFoo
     {
         return new AttrScopeFoo();
-    }
-
-    private static function makeContainer(bool $checkScope = true): Container
-    {
-        $options = new Options();
-        $options->checkScope = $checkScope;
-
-        return new Container(options: $options);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

Added the ability to configure the container using `Spiral\Core\Options`. Added option **checkScope** to enable scope checking.

https://github.com/spiral/framework/blob/e2aa38debc9de14c58d627268390c2f851b15fa6/src/Core/src/Options.php#L12-L28