### PR TITLE
Enable reading annotations by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "google/protobuf": "^3.25",
         "symplify/monorepo-builder": "^10.2.7",
         "vimeo/psalm": "^5.9",
-        "doctrine/annotations": "^1.12 || ^2.0"
+        "doctrine/annotations": "^2.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,8 @@
         "spiral/validator": "^1.3",
         "google/protobuf": "^3.25",
         "symplify/monorepo-builder": "^10.2.7",
-        "vimeo/psalm": "^5.9"
+        "vimeo/psalm": "^5.9",
+        "doctrine/annotations": "^1.12 || ^2.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Framework/Bootloader/Attributes/AttributesBootloader.php
+++ b/src/Framework/Bootloader/Attributes/AttributesBootloader.php
@@ -76,14 +76,12 @@ class AttributesBootloader extends Bootloader
         $supportAnnotations = $config->isAnnotationsReaderEnabled();
 
         if ($supportAnnotations) {
-            /** @psalm-suppress UndefinedClass */
             if (!\interface_exists(DoctrineReaderInterface::class)) {
                 throw new InitializationException(
                     'Doctrine annotations reader is not available, please install "doctrine/annotations" package',
                 );
             }
 
-            /** @psalm-suppress UndefinedClass, InvalidArgument */
             $reader = new SelectiveReader([
                 $reader,
                 new AnnotationReader(new DoctrineAnnotationReader()),

--- a/src/Framework/Bootloader/Attributes/AttributesBootloader.php
+++ b/src/Framework/Bootloader/Attributes/AttributesBootloader.php
@@ -39,7 +39,7 @@ class AttributesBootloader extends Bootloader
             AttributesConfig::CONFIG,
             [
                 'annotations' => [
-                    'support' => $env->get('SUPPORT_ANNOTATIONS', false),
+                    'support' => $env->get('SUPPORT_ANNOTATIONS', true),
                 ],
                 'cache' => [
                     'storage' => $env->get('ATTRIBUTES_CACHE_STORAGE', null),

--- a/src/Framework/Bootloader/Attributes/AttributesBootloader.php
+++ b/src/Framework/Bootloader/Attributes/AttributesBootloader.php
@@ -39,7 +39,7 @@ class AttributesBootloader extends Bootloader
             AttributesConfig::CONFIG,
             [
                 'annotations' => [
-                    'support' => $env->get('SUPPORT_ANNOTATIONS', true),
+                    'support' => $env->get('SUPPORT_ANNOTATIONS', \interface_exists(DoctrineReaderInterface::class)),
                 ],
                 'cache' => [
                     'storage' => $env->get('ATTRIBUTES_CACHE_STORAGE', null),

--- a/src/Framework/Bootloader/Attributes/AttributesConfig.php
+++ b/src/Framework/Bootloader/Attributes/AttributesConfig.php
@@ -18,7 +18,7 @@ final class AttributesConfig extends InjectableConfig
      */
     protected array $config = [
         'annotations' => [
-            'support' => false,
+            'support' => true,
         ],
         'cache' => [
             'storage' => null,

--- a/tests/Framework/Bootloader/Attributes/AttributesBootloaderTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesBootloaderTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Framework\Bootloader\Attributes;
 
-use Spiral\Attributes\AttributeReader;
+use Spiral\Attributes\Composite\SelectiveReader;
+use Spiral\Attributes\Internal\Instantiator\Facade;
 use Spiral\Attributes\Internal\Instantiator\InstantiatorInterface;
-use Spiral\Attributes\Internal\Instantiator\NamedArgumentsInstantiator;
 use Spiral\Attributes\ReaderInterface;
 use Spiral\Bootloader\Attributes\AttributesConfig;
 use Spiral\Tests\Framework\BaseTestCase;
@@ -15,12 +15,12 @@ final class AttributesBootloaderTest extends BaseTestCase
 {
     public function testReaderBinding(): void
     {
-        $this->assertContainerBoundAsSingleton(ReaderInterface::class, AttributeReader::class);
+        $this->assertContainerBoundAsSingleton(ReaderInterface::class, SelectiveReader::class);
     }
 
     public function testInstantiatorBinding(): void
     {
-        $this->assertContainerBoundAsSingleton(InstantiatorInterface::class, NamedArgumentsInstantiator::class);
+        $this->assertContainerBoundAsSingleton(InstantiatorInterface::class, Facade::class);
     }
 
     public function testIsCacheEnabledShouldBeFalse(): void

--- a/tests/Framework/Bootloader/Attributes/AttributesConfigTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesConfigTest.php
@@ -11,9 +11,9 @@ final class AttributesConfigTest extends TestCase
 {
     public function testIsAnnotationsReaderEnabled(): void
     {
-        $this->assertFalse((new AttributesConfig())->isAnnotationsReaderEnabled());
-        $this->assertTrue(
-            (new AttributesConfig(['annotations' => ['support' => true]]))->isAnnotationsReaderEnabled()
+        $this->assertTrue((new AttributesConfig())->isAnnotationsReaderEnabled());
+        $this->assertFalse(
+            (new AttributesConfig(['annotations' => ['support' => false]]))->isAnnotationsReaderEnabled()
         );
     }
 

--- a/tests/Framework/Bootloader/Attributes/AttributesWithoutAnnotationsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesWithoutAnnotationsBootloaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Framework\Bootloader\Attributes;
 
 use Spiral\Attributes\AttributeReader;
+use Spiral\Attributes\Composite\SelectiveReader;
 use Spiral\Attributes\Psr16CachedReader;
 use Spiral\Attributes\ReaderInterface;
 use Spiral\Testing\Attribute\Env;
@@ -12,15 +13,22 @@ use Spiral\Tests\Framework\BaseTestCase;
 
 final class AttributesWithoutAnnotationsBootloaderTest extends BaseTestCase
 {
+    #[Env('SUPPORT_ANNOTATIONS', false)]
     public function testReaderBindingWithoutCache(): void
     {
         $this->assertContainerBoundAsSingleton(ReaderInterface::class, AttributeReader::class);
     }
 
-    #[Env('SUPPORT_ANNOTATIONS', 'false')]
-    #[Env('ATTRIBUTES_CACHE_ENABLED', 'true')]
+    #[Env('SUPPORT_ANNOTATIONS', false)]
+    #[Env('ATTRIBUTES_CACHE_ENABLED', true)]
     public function testReaderBindingWithCache(): void
     {
         $this->assertContainerBoundAsSingleton(ReaderInterface::class, Psr16CachedReader::class);
+    }
+
+    #[Env('SUPPORT_ANNOTATIONS', true)]
+    public function testSelectiveReaderBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(ReaderInterface::class, SelectiveReader::class);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

The default reading of annotations has been reverted. After updating the framework to version **3.12.0**, need to explicitly add the **doctrine/annotations** dependency to a project to enable annotations. No settings need to be changed. Annotations will be completely removed in version 4.0.