### PR TITLE
[spiral/queue] Add `Proxy` to the InvokerInterface in JobHandler

### DIFF
--- a/src/Queue/src/JobHandler.php
+++ b/src/Queue/src/JobHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Queue;
 
+use Spiral\Core\Attribute\Proxy;
 use Spiral\Core\InvokerInterface;
 use Spiral\Queue\Exception\JobException;
 
@@ -18,7 +19,7 @@ abstract class JobHandler implements HandlerInterface
     protected const HANDLE_FUNCTION = 'invoke';
 
     public function __construct(
-        protected InvokerInterface $invoker,
+        #[Proxy] protected InvokerInterface $invoker,
     ) {
     }
 

--- a/tests/Framework/Queue/QueueRegistryTest.php
+++ b/tests/Framework/Queue/QueueRegistryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Framework\Queue;
+
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Spiral\App\Job\SampleJob;
+use Spiral\App\Job\Task;
+use Spiral\App\Job\TaskInterface;
+use Spiral\Framework\Spiral;
+use Spiral\Queue\Interceptor\Consume\Handler;
+use Spiral\Testing\Attribute\TestScope;
+use Spiral\Tests\Framework\BaseTestCase;
+
+final class QueueRegistryTest extends BaseTestCase
+{
+    #[TestScope(Spiral::Queue, [TaskInterface::class => Task::class])]
+    #[DoesNotPerformAssertions]
+    public function testHandleJobWithDependencyInScope(): void
+    {
+        /** @var Handler $handler */
+        $handler = $this->getContainer()->get(Handler::class);
+
+        /**
+         * Method invoke in SampleJob requires TaskInterface and it's available only in queue scope.
+         */
+        $handler->handle(SampleJob::class, '', '', '', '');
+    }
+}

--- a/tests/app/src/Job/SampleJob.php
+++ b/tests/app/src/Job/SampleJob.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Job;
+
+use Spiral\Queue\JobHandler;
+
+final class SampleJob extends JobHandler
+{
+    public function invoke(TaskInterface $task): void
+    {
+    }
+}

--- a/tests/app/src/Job/Task.php
+++ b/tests/app/src/Job/Task.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Job;
+
+final class Task implements TaskInterface
+{
+}

--- a/tests/app/src/Job/TaskInterface.php
+++ b/tests/app/src/Job/TaskInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Job;
+
+interface TaskInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### What's changed

Added a proxy to `Spiral\Core\InvokerInterface` in `Spiral\Queue\JobHandler` so that it receives the required scope when calling the handler method.
