### PR TITLE
[spiral/core] Using the mixed type in the parameters of the Proxy class methods

### DIFF
--- a/src/Core/src/Internal/Proxy/ProxyClassRenderer.php
+++ b/src/Core/src/Internal/Proxy/ProxyClassRenderer.php
@@ -142,7 +142,7 @@ final class ProxyClassRenderer
         return \ltrim(
             \sprintf(
                 '%s %s%s%s%s',
-                $param->hasType() ? self::renderParameterTypes($param->getType(), $param->getDeclaringClass()) : '',
+                $param->hasType() ? 'mixed' : '',
                 $param->isPassedByReference() ? '&' : '',
                 $param->isVariadic() ? '...' : '',
                 '$' . $param->getName(),

--- a/src/Core/tests/Internal/Proxy/ProxyClassRendererTest.php
+++ b/src/Core/tests/Internal/Proxy/ProxyClassRendererTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Core\Internal\Proxy;
 
 use ArrayAccess;
 use Countable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Spiral\Core\Attribute\Proxy;
 use Spiral\Core\Internal\Proxy\ProxyClassRenderer;
@@ -50,41 +51,40 @@ final class ProxyClassRendererTest extends TestCase
 
         yield [$from(fn($string) => 0), '$string'];
         yield [$from(fn($string = '') => 0), '$string = \'\''];
-        yield [$from(fn(string $string = "\n\\'\"") => 0), "string \$string = '\n\\\\\\'\"'"];
-        yield [$from(fn(string $string = '123') => 0), 'string $string = \'123\''];
-        yield [$from(fn(string $string = self::STRING_CONST) => 0), 'string $string = self::STRING_CONST'];
+        yield [$from(fn(string $string = "\n\\'\"") => 0), "mixed \$string = '\n\\\\\\'\"'"];
+        yield [$from(fn(string $string = '123') => 0), 'mixed $string = \'123\''];
+        yield [$from(fn(string $string = self::STRING_CONST) => 0), 'mixed $string = self::STRING_CONST'];
         yield [
             $from(fn(string $string = ProxyClassRendererTest::STRING_CONST) => 0),
-            'string $string = \\' . self::class . '::STRING_CONST',
+            'mixed $string = \\' . self::class . '::STRING_CONST',
         ];
-        yield [$from(fn(string|int $string = self::INT_CONST) => 0), 'string|int $string = self::INT_CONST'];
+        yield [$from(fn(string|int $string = self::INT_CONST) => 0), 'mixed $string = self::INT_CONST'];
         yield [$from(fn(mixed $string = 42) => 0), 'mixed $string = 42'];
-        yield [$from(fn(int $string = 42) => 0), 'int $string = 42'];
-        yield [$from(fn(float $string = 42) => 0), 'float $string = 42.0'];
-        yield [$from(fn(?bool $string = false) => 0), '?bool $string = false'];
-        yield [$from(fn(bool|null $string = true) => 0), '?bool $string = true'];
-        yield [$from(fn(object $string = null) => 0), '?object $string = NULL'];
-        yield [$from(fn(iterable $string = null) => 0), '?iterable $string = NULL'];
-        yield [$from(fn(Countable&ArrayAccess $val) => 0), '\Countable&\ArrayAccess $val'];
-        yield [$from(fn(string ...$val) => 0), 'string ...$val'];
-        yield [$from(fn(string|int ...$val) => 0), 'string|int ...$val'];
-        yield [$from(fn(string|int &$link) => 0), 'string|int &$link'];
-        yield [$from(self::withSelf(...)), \sprintf('\%s $self = new self()', self::class)];
-        yield [$from(fn(object $link = new \stdClass()) => 0), 'object $link = new \stdClass()'];
+        yield [$from(fn(int $string = 42) => 0), 'mixed $string = 42'];
+        yield [$from(fn(float $string = 42) => 0), 'mixed $string = 42.0'];
+        yield [$from(fn(?bool $string = false) => 0), 'mixed $string = false'];
+        yield [$from(fn(bool|null $string = true) => 0), 'mixed $string = true'];
+        yield [$from(fn(object $string = null) => 0), 'mixed $string = NULL'];
+        yield [$from(fn(iterable $string = null) => 0), 'mixed $string = NULL'];
+        yield [$from(fn(Countable&ArrayAccess $val) => 0), 'mixed $val'];
+        yield [$from(fn(string ...$val) => 0), 'mixed ...$val'];
+        yield [$from(fn(string|int ...$val) => 0), 'mixed ...$val'];
+        yield [$from(fn(string|int &$link) => 0), 'mixed &$link'];
+        yield [$from(self::withSelf(...)), 'mixed $self = new self()'];
+        yield [$from(fn(object $link = new \stdClass()) => 0), 'mixed $link = new \stdClass()'];
         yield [
             $from(fn(#[Proxy] float|int|\stdClass|null $string = new \stdClass(1, 2, bar: "\n'zero")) => 0),
-            "\stdClass|int|float|null \$string = new \stdClass(1, 2, bar: '\n\'zero')",
+            "mixed \$string = new \stdClass(1, 2, bar: '\n\'zero')",
         ];
         yield [
             $from(fn(SimpleEnum $val = SimpleEnum::B) => 0),
-            \sprintf('\%s $val = \%s::B', SimpleEnum::class, SimpleEnum::class),
+            \sprintf('mixed $val = \%s::B', SimpleEnum::class),
         ];
     }
 
     /**
      * @dataProvider provideRenderParameter
      * @covers ::renderParameter
-     * @covers ::renderParameterTypes
      */
     public function testRenderParameter(\ReflectionParameter $param, $expected): void
     {
@@ -98,9 +98,9 @@ final class ProxyClassRendererTest extends TestCase
 
             #[ExpectedAttribute('public function test1(...$variadic)')]
             public function test1(...$variadic) {}
-            #[ExpectedAttribute('public function test2(string|int $string = self::INT_CONST): string|int')]
+            #[ExpectedAttribute('public function test2(mixed $string = self::INT_CONST): string|int')]
             public function test2(string|int $string = self::INT_CONST): string|int {}
-            #[ExpectedAttribute('public function test3(object $obj = new \stdClass(new \stdClass(), new \stdClass()))')]
+            #[ExpectedAttribute('public function test3(mixed $obj = new \stdClass(new \stdClass(), new \stdClass()))')]
             public function test3(object $obj = new stdClass(new stdClass(), new stdClass())) {}
             #[ExpectedAttribute('public function test4(): \\' . ProxyClassRendererTest::class)]
             public function test4(): ProxyClassRendererTest {}
@@ -126,6 +126,41 @@ final class ProxyClassRendererTest extends TestCase
         $rendered = ProxyClassRenderer::renderMethod($param);
         $signature = \trim(\substr($rendered, 0, \strrpos($rendered, '{') - 1));
         self::assertSame($expected, $signature);
+    }
+
+    #[DataProvider('provideRenderParameterTypes')]
+    public function testRenderParameterTypes(\ReflectionParameter $param, string $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            ProxyClassRenderer::renderParameterTypes($param->getType(), $param->getDeclaringClass())
+        );
+    }
+
+    /**
+     * @psalm-suppress UnusedClosureParam
+     */
+    public static function provideRenderParameterTypes(): iterable
+    {
+        $from = static fn(\Closure $closure): \ReflectionParameter => new \ReflectionParameter($closure, 0);
+
+        yield [$from(fn(string $string) => 0), 'string'];
+        yield [$from(fn(string|int $string) => 0), 'string|int'];
+        yield [$from(fn(mixed $string) => 0), 'mixed'];
+        yield [$from(fn(int $string) => 0), 'int'];
+        yield [$from(fn(float $string) => 0), 'float'];
+        yield [$from(fn(?bool $string) => 0), '?bool'];
+        yield [$from(fn(bool|null $string) => 0), '?bool'];
+        yield [$from(fn(object $string) => 0), 'object'];
+        yield [$from(fn(iterable $string) => 0), 'iterable'];
+        yield [$from(fn(Countable&ArrayAccess $val) => 0), '\Countable&\ArrayAccess'];
+        yield [$from(fn(string ...$val) => 0), 'string'];
+        yield [$from(fn(string|int ...$val) => 0), 'string|int'];
+        yield [$from(fn(string|int &$link) => 0), 'string|int'];
+        yield [$from(self::withSelf(...)), '\\' . self::class];
+        yield [$from(fn(object $link) => 0), 'object'];
+        yield [$from(fn(#[Proxy] float|int|\stdClass|null $string) => 0), '\stdClass|int|float|null'];
+        yield [$from(fn(SimpleEnum $val) => 0), '\\' . SimpleEnum::class];
     }
 
     private static function withSelf(self $self = new self()): void

--- a/src/Core/tests/Scope/Stub/User.php
+++ b/src/Core/tests/Scope/Stub/User.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Scope\Stub;
+
+final class User implements UserInterface
+{
+    public function __construct(
+        private string $name,
+    ) {
+    }
+
+    public function setName(string|\Stringable $name): void
+    {
+        $this->name = (string) $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Core/tests/Scope/Stub/UserInterface.php
+++ b/src/Core/tests/Scope/Stub/UserInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Scope\Stub;
+
+interface UserInterface
+{
+    public function setName(string $name): void;
+
+    public function getName(): string;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

In the implementation of the class, the parameter types can be broader than those of the interface. Explicitly specifying the types of the interface in the Proxy class leads to an error in such a situation. For example:

```
Spiral\Core\ScopeInterface SCOPED PROXY::runScope(): Argument #1 ($bindings) must be of type array, Spiral\Core\Scope given
```

The types have been changed to mixed.

