### PR TITLE
[spiral/queue] Adding TaskInterface and Task for the Queue component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+- **Other Features**
+  - [spiral/queue] Added `Spiral\Queue\TaskInterface` and `Spiral\Queue\Task` which will contain all the necessary data
+    for job processing.
+
 ## 3.12.0 - 2024-02-29
 
 - **Medium Impact Changes**

--- a/src/Queue/src/Task.php
+++ b/src/Queue/src/Task.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+final class Task implements TaskInterface
+{
+    /**
+     * @param non-empty-string $id Unique identifier of the task in the queue.
+     * @param non-empty-string $queue broker queue name.
+     * @param non-empty-string $name name of the task/job.
+     * @param mixed $payload payload of the task/job.
+     * @param array<non-empty-string, array<string>> $headers headers of the task/job.
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly string $queue,
+        private readonly string $name,
+        private readonly mixed $payload,
+        private readonly array $headers,
+    ) {
+    }
+
+    public function getPayload(): mixed
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<non-empty-string, array<string>>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getQueue(): string
+    {
+        return $this->queue;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Queue/src/TaskInterface.php
+++ b/src/Queue/src/TaskInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Queue;
+
+interface TaskInterface
+{
+    /**
+     * Returns payload of the task/job.
+     */
+    public function getPayload(): mixed;
+
+    /**
+     * Returns the name of the task/job.
+     *
+     * @return non-empty-string
+     */
+    public function getName(): string;
+
+    /**
+     * Returns headers of the task/job.
+     *
+     * @return array<non-empty-string, array<string>>
+     */
+    public function getHeaders(): array;
+
+    /**
+     * Returns the name of the queue.
+     *
+     * @return non-empty-string
+     */
+    public function getQueue(): string;
+
+    /**
+     * Returns the unique identifier of the task in the queue.
+     *
+     * @return non-empty-string
+     */
+    public function getId(): string;
+}

--- a/src/Queue/tests/TaskTest.php
+++ b/src/Queue/tests/TaskTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use Spiral\Queue\Task;
+
+final class TaskTest extends TestCase
+{
+    public function testGetPayload(): void
+    {
+        $task = new Task('some-id', 'some-queue', 'some-name', ['key' => 'value'], ['header' => ['value']]);
+        $this->assertSame(['key' => 'value'], $task->getPayload());
+
+        $task = new Task('some-id', 'some-queue', 'some-name', 'string-payload', ['header' => ['value']]);
+        $this->assertSame('string-payload', $task->getPayload());
+    }
+
+    public function testGetName(): void
+    {
+        $task = new Task('some-id', 'some-queue', 'some-name', ['key' => 'value'], ['header' => ['value']]);
+        $this->assertSame('some-name', $task->getName());
+    }
+
+    public function testGetHeaders(): void
+    {
+        $task = new Task('some-id', 'some-queue', 'some-name', ['key' => 'value'], ['header' => ['value']]);
+        $this->assertSame(['header' => ['value']], $task->getHeaders());
+    }
+
+    public function testGetQueue(): void
+    {
+        $task = new Task('some-id', 'some-queue', 'some-name', ['key' => 'value'], ['header' => ['value']]);
+        $this->assertSame('some-queue', $task->getQueue());
+    }
+
+    public function testGetId(): void
+    {
+        $task = new Task('some-id', 'some-queue', 'some-name', ['key' => 'value'], ['header' => ['value']]);
+        $this->assertSame('some-id', $task->getId());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

This change will allow creating a task object from the queue, which will contain all the necessary data for its processing. After introducing scopes, it will be possible to request this object in the task handler and extract the necessary data from it.

```php
use Spiral\Queue\JobHandler;
use Spiral\Queue\TaskInterface;

final class SomeJob extends JobHandler
{
    public function invoke(TaskInterface $task): void
    {
        $payload = $task->getPayload();
        $headers = $task->getHeaders();
        $name = $task->getName();
        $queue = $task->getQueue();
        $id = $task->getId();
    }
}
```