### PR TITLE
Fixed bug in directive parser

### DIFF
--- a/src/Stempler/src/Parser/Syntax/DynamicSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/DynamicSyntax.php
@@ -80,10 +80,9 @@ final class DynamicSyntax implements SyntaxInterface
         $src = new StringStream($body);
 
         while ($n = $src->peak()) {
-            if (\in_array($n, ['"', '"'])) {
+            if (\in_array($n, ['"', "'"], true)) {
                 $values[\count($values) - 1] .= $n;
                 while (($nn = $src->peak()) !== null) {
-
                     $values[\count($values) - 1] .= $nn;
                     if ($nn === $n) {
                         break;

--- a/src/Stempler/src/Parser/Syntax/DynamicSyntax.php
+++ b/src/Stempler/src/Parser/Syntax/DynamicSyntax.php
@@ -82,7 +82,8 @@ final class DynamicSyntax implements SyntaxInterface
         while ($n = $src->peak()) {
             if (\in_array($n, ['"', '"'])) {
                 $values[\count($values) - 1] .= $n;
-                while ($nn = $src->peak()) {
+                while (($nn = $src->peak()) !== null) {
+
                     $values[\count($values) - 1] .= $nn;
                     if ($nn === $n) {
                         break;

--- a/src/Stempler/tests/Directive/DirectiveTest.php
+++ b/src/Stempler/tests/Directive/DirectiveTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Directive;
+
+use Spiral\Tests\Stempler\fixtures\ImageDirective;
+use Spiral\Tests\Stempler\Directive\BaseTestCase;
+
+final class DirectiveTest extends BaseTestCase
+{
+    protected const DIRECTIVES = [
+        ImageDirective::class,
+    ];
+
+    public function testStringWithZeroChars(): void
+    {
+        $doc = $this->parse('@image("blog", "test.png", "150|250", "webp")');
+
+        $this->assertSame(
+            '<img title="blog" src="test.png" size="150|250" type="webp">',
+            $this->compile($doc),
+        );
+    }
+}

--- a/src/Stempler/tests/Directive/DirectiveTest.php
+++ b/src/Stempler/tests/Directive/DirectiveTest.php
@@ -22,4 +22,24 @@ final class DirectiveTest extends BaseTestCase
             $this->compile($doc),
         );
     }
+
+    public function testStringWithSingleQuotes(): void
+    {
+        $doc = $this->parse("@image('blog', 'test.png', '150|250', 'webp')");
+
+        $this->assertSame(
+            "<img title='blog' src='test.png' size='150|250' type='webp'>",
+            $this->compile($doc),
+        );
+    }
+
+    public function testVariableInjection(): void
+    {
+        $doc = $this->parse('@image("blog", $src, "150|250", "webp")');
+
+        $this->assertSame(
+            '<img title="blog" src="<?php echo $src; ?>" size="150|250" type="webp">',
+            $this->compile($doc),
+        );
+    }
 }

--- a/src/Stempler/tests/fixtures/ImageDirective.php
+++ b/src/Stempler/tests/fixtures/ImageDirective.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Stempler\fixtures;
+
+use Spiral\Stempler\Directive\AbstractDirective;
+use Spiral\Stempler\Node\Dynamic\Directive;
+
+final class ImageDirective extends AbstractDirective
+{
+    public function renderImage(Directive $directive): string
+    {
+        return \sprintf(
+            '<img title=%s src=%s size=%s type=%s>',
+            $directive->values[0],
+            $directive->values[1],
+            $directive->values[2],
+            $directive->values[3],
+        );
+    }
+}

--- a/src/Stempler/tests/fixtures/ImageDirective.php
+++ b/src/Stempler/tests/fixtures/ImageDirective.php
@@ -14,7 +14,7 @@ final class ImageDirective extends AbstractDirective
         return \sprintf(
             '<img title=%s src=%s size=%s type=%s>',
             $directive->values[0],
-            $directive->values[1],
+            \str_starts_with($directive->values[1], '$') ? \sprintf('"<?php echo %s; ?>"', $directive->values[1]) :  $directive->values[1],
             $directive->values[2],
             $directive->values[3],
         );


### PR DESCRIPTION
Fixed bug in directive parser where values containing zero character, such as '150' in '@image("blog", "test.png", "150|250", "webp")', were not processed correctly.

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
