### PR TITLE
[spiral/queue] Added passing headers to the job handler in SyncDriver

### DIFF
--- a/src/Queue/src/Driver/SyncDriver.php
+++ b/src/Queue/src/Driver/SyncDriver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Queue\Driver;
 
 use Ramsey\Uuid\Uuid;
+use Spiral\Queue\ExtendedOptionsInterface;
 use Spiral\Queue\Interceptor\Consume\Handler;
 use Spiral\Queue\OptionsInterface;
 use Spiral\Queue\QueueInterface;
@@ -36,7 +37,8 @@ final class SyncDriver implements QueueInterface
             driver: 'sync',
             queue: 'default',
             id: $id,
-            payload: $payload
+            payload: $payload,
+            headers: $options instanceof ExtendedOptionsInterface ? $options->getHeaders() : [],
         );
 
         return $id;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌

In the Queue component, there is an `Spiral\Queue\ExtendedOptionsInterface` interface that allows the use headers. The base implementation `Spiral\Queue\Options` implements this interface. It would be good to pass headers to the job handler.