### PR TITLE
Added HEAD and OPTIONS http method verbs to route list command

### DIFF
--- a/src/Framework/Command/Router/ListCommand.php
+++ b/src/Framework/Command/Router/ListCommand.php
@@ -72,6 +72,8 @@ final class ListCommand extends Command
         foreach ($route->getVerbs() as $verb) {
             $result[] = match (\strtolower($verb)) {
                 'get' => '<fg=green>GET</>',
+                'head' => '<fg=bright-green>HEAD</>',
+                'options' => '<fg=magenta>OPTIONS</>',
                 'post' => '<fg=blue>POST</>',
                 'patch' => '<fg=cyan>PATCH</>',
                 'put' => '<fg=yellow>PUT</>',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌
| Issues        | #1096 

Fixed the `route:list` command. The command crashes with an error when using `HEAD`/`OPTIONS` http methods in routes.
