### PR TITLE
[Interceptors] Add PipelineBuilder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,6 +124,9 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.270",
+        "buggregator/trap": "^1.10",
+        "doctrine/annotations": "^2.0",
+        "google/protobuf": "^3.25",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "jetbrains/phpstorm-attributes": "^1.0",
         "league/flysystem-async-aws-s3": "^2.0 || ^3.0",
@@ -138,10 +141,8 @@
         "spiral/nyholm-bridge": "^1.2",
         "spiral/testing": "^2.8",
         "spiral/validator": "^1.3",
-        "google/protobuf": "^3.25",
         "symplify/monorepo-builder": "^10.2.7",
-        "vimeo/psalm": "^5.9",
-        "doctrine/annotations": "^2.0"
+        "vimeo/psalm": "^5.9"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Console/src/Attribute/Option.php
+++ b/src/Console/src/Attribute/Option.php
@@ -11,10 +11,10 @@ use Symfony\Component\Console\Input\InputOption;
 final class Option
 {
     /**
-     * @param ?non-empty-string $name Option name. Property name by default
+     * @param non-empty-string|null $name Option name. Property name by default
      * @param non-empty-string|array|null $shortcut Option shortcut
-     * @param ?non-empty-string $description Option description
-     * @param ?positive-int $mode Option mode, {@see InputOption} constants
+     * @param non-empty-string|null $description Option description
+     * @param int<0, 31>|null $mode Option mode, {@see InputOption} constants
      * @param \Closure|array $suggestedValues Option suggested values
      */
     public function __construct(

--- a/src/Console/src/Command.php
+++ b/src/Console/src/Command.php
@@ -15,13 +15,12 @@ use Spiral\Console\Configurator\SignatureBasedConfigurator;
 use Spiral\Console\Event\CommandFinished;
 use Spiral\Console\Event\CommandStarting;
 use Spiral\Console\Traits\HelpersTrait;
-use Spiral\Core\ContainerScope;
 use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\CoreInterface;
 use Spiral\Core\Exception\ScopeException;
+use Spiral\Core\InvokerInterface;
 use Spiral\Core\Scope;
 use Spiral\Core\ScopeInterface;
-use Spiral\Core\InterceptorPipeline;
 use Spiral\Events\EventDispatcherAwareInterface;
 use Spiral\Interceptors\Context\CallContext;
 use Spiral\Interceptors\Context\Target;
@@ -133,9 +132,9 @@ abstract class Command extends SymfonyCommand implements EventDispatcherAwareInt
      */
     protected function buildCore(): CoreInterface|HandlerInterface
     {
-        return ContainerScope::getContainer()
-            ->get(CommandCoreFactory::class)
-            ->make($this->interceptors, $this->eventDispatcher);
+        /** @var InvokerInterface $invoker */
+        $invoker = $this->container->get(InvokerInterface::class);
+        return $invoker->invoke([CommandCoreFactory::class, 'make'], [$this->interceptors, $this->eventDispatcher]);
     }
 
     protected function prepareInput(InputInterface $input): InputInterface

--- a/src/Console/src/CommandCore.php
+++ b/src/Console/src/CommandCore.php
@@ -7,11 +7,13 @@ namespace Spiral\Console;
 use Spiral\Core\Attribute\Scope as ScopeAttribute;
 use Spiral\Core\CoreInterface;
 use Spiral\Core\InvokerInterface;
+use Spiral\Interceptors\Context\CallContext;
+use Spiral\Interceptors\HandlerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[ScopeAttribute('console.command')]
-final class CommandCore implements CoreInterface
+final class CommandCore implements CoreInterface, HandlerInterface
 {
     public function __construct(
         private readonly InvokerInterface $invoker,
@@ -26,5 +28,11 @@ final class CommandCore implements CoreInterface
         $command = $parameters['command'];
 
         return (int)$this->invoker->invoke([$command, $action]);
+    }
+
+    public function handle(CallContext $context): int
+    {
+        $callable = $context->getTarget()->getCallable() ?? throw new \RuntimeException('Command action not found');
+        return (int)$this->invoker->invoke($callable, $context->getArguments());
     }
 }

--- a/src/Console/src/Configurator/Attribute/Parser.php
+++ b/src/Console/src/Configurator/Attribute/Parser.php
@@ -237,7 +237,7 @@ final class Parser
     }
 
     /**
-     * @return positive-int
+     * @return int<0, 31>
      */
     private function guessOptionMode(\ReflectionNamedType $type, \ReflectionProperty $property): int
     {

--- a/src/Events/src/EventDispatcher.php
+++ b/src/Events/src/EventDispatcher.php
@@ -14,7 +14,7 @@ final class EventDispatcher implements EventDispatcherInterface
 {
     private readonly bool $isLegacy;
     public function __construct(
-        private readonly HandlerInterface|CoreInterface $core
+        private readonly HandlerInterface|CoreInterface $core,
     ) {
         $this->isLegacy = !$core instanceof HandlerInterface;
     }
@@ -22,9 +22,9 @@ final class EventDispatcher implements EventDispatcherInterface
     public function dispatch(object $event): object
     {
         return $this->isLegacy
-            ? $this->core->callAction($event::class, 'dispatch', ['event' => $event])
+            ? $this->core->callAction(EventDispatcherInterface::class, 'dispatch', ['event' => $event])
             : $this->core->handle(new CallContext(
-                Target::fromPair($event, 'dispatch'),
+                Target::fromPair(EventDispatcherInterface::class, 'dispatch'),
                 ['event' => $event],
             ));
     }

--- a/src/Events/src/Interceptor/Core.php
+++ b/src/Events/src/Interceptor/Core.php
@@ -6,11 +6,13 @@ namespace Spiral\Events\Interceptor;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Core\CoreInterface;
+use Spiral\Interceptors\Context\CallContext;
+use Spiral\Interceptors\HandlerInterface;
 
 /**
  * @psalm-type TParameters = array{event: object}
  */
-final class Core implements CoreInterface
+final class Core implements CoreInterface, HandlerInterface
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher
@@ -26,5 +28,10 @@ final class Core implements CoreInterface
         \assert(\is_object($parameters['event']));
 
         return $this->dispatcher->dispatch($parameters['event']);
+    }
+
+    public function handle(CallContext $context): mixed
+    {
+        return $this->dispatcher->dispatch($context->getArguments()['event']);
     }
 }

--- a/src/Events/tests/EventDispatcherTest.php
+++ b/src/Events/tests/EventDispatcherTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Events\Interceptor;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Core\CoreInterface;
 use Spiral\Events\EventDispatcher;
 
@@ -19,7 +20,7 @@ final class EventDispatcherTest extends TestCase
         $core
             ->shouldReceive('callAction')
             ->once()
-            ->with($event::class, 'dispatch', ['event' => $event])
+            ->with(EventDispatcherInterface::class, 'dispatch', ['event' => $event])
             ->andReturn($event);
 
         $dispatcher = new EventDispatcher($core);

--- a/src/Framework/Framework/Spiral.php
+++ b/src/Framework/Framework/Spiral.php
@@ -20,7 +20,7 @@ enum Spiral: string
     case Centrifugo = 'centrifugo';
     case CentrifugoRequest = 'centrifugo.request';
     case Tcp = 'tcp';
-    case TcpPacket = 'tcp.packet';
+    case TcpRequest = 'tcp.request';
     case Console = 'console';
     case ConsoleCommand = 'console.command';
 }

--- a/src/Hmvc/src/Core/CompatiblePipelineBuilder.php
+++ b/src/Hmvc/src/Core/CompatiblePipelineBuilder.php
@@ -20,6 +20,11 @@ class CompatiblePipelineBuilder implements PipelineBuilderInterface
         $this->pipeline = new InterceptorPipeline();
     }
 
+    public function __clone()
+    {
+        $this->pipeline = clone $this->pipeline;
+    }
+
     public function withInterceptors(CoreInterceptorInterface|InterceptorInterface ...$interceptors): static
     {
         $clone = clone $this;
@@ -36,10 +41,5 @@ class CompatiblePipelineBuilder implements PipelineBuilderInterface
         return $last instanceof HandlerInterface
             ? $this->pipeline->withHandler($last)
             : $this->pipeline->withCore($last);
-    }
-
-    public function __clone()
-    {
-        $this->pipeline = clone $this->pipeline;
     }
 }

--- a/src/Hmvc/src/Core/CompatiblePipelineBuilder.php
+++ b/src/Hmvc/src/Core/CompatiblePipelineBuilder.php
@@ -4,20 +4,23 @@ declare(strict_types=1);
 
 namespace Spiral\Core;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Interceptors\HandlerInterface;
 use Spiral\Interceptors\InterceptorInterface;
 use Spiral\Interceptors\PipelineBuilderInterface;
 
 /**
  * Accepts {@see InterceptorInterface} and {@see CoreInterface} instances to build a pipeline.
+ *
+ * @deprecated Use {@see PipelineBuilder} instead.
  */
 class CompatiblePipelineBuilder implements PipelineBuilderInterface
 {
     private InterceptorPipeline $pipeline;
 
-    public function __construct()
+    public function __construct(?EventDispatcherInterface $dispatcher = null)
     {
-        $this->pipeline = new InterceptorPipeline();
+        $this->pipeline = new InterceptorPipeline($dispatcher);
     }
 
     public function __clone()
@@ -35,7 +38,7 @@ class CompatiblePipelineBuilder implements PipelineBuilderInterface
         return $clone;
     }
 
-    public function build(HandlerInterface|CoreInterface $last): HandlerInterface
+    public function build(HandlerInterface|CoreInterface $last): InterceptorPipeline
     {
         /** @psalm-suppress InvalidArgument */
         return $last instanceof HandlerInterface

--- a/src/Hmvc/src/Core/CompatiblePipelineBuilder.php
+++ b/src/Hmvc/src/Core/CompatiblePipelineBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Core;
+
+use Spiral\Interceptors\HandlerInterface;
+use Spiral\Interceptors\InterceptorInterface;
+use Spiral\Interceptors\PipelineBuilderInterface;
+
+/**
+ * Accepts {@see InterceptorInterface} and {@see CoreInterface} instances to build a pipeline.
+ */
+class CompatiblePipelineBuilder implements PipelineBuilderInterface
+{
+    private InterceptorPipeline $pipeline;
+
+    public function __construct()
+    {
+        $this->pipeline = new InterceptorPipeline();
+    }
+
+    public function withInterceptors(CoreInterceptorInterface|InterceptorInterface ...$interceptors): static
+    {
+        $clone = clone $this;
+        foreach ($interceptors as $interceptor) {
+            $clone->pipeline->addInterceptor($interceptor);
+        }
+
+        return $clone;
+    }
+
+    public function build(HandlerInterface|CoreInterface $last): HandlerInterface
+    {
+        /** @psalm-suppress InvalidArgument */
+        return $last instanceof HandlerInterface
+            ? $this->pipeline->withHandler($last)
+            : $this->pipeline->withCore($last);
+    }
+
+    public function __clone()
+    {
+        $this->pipeline = clone $this->pipeline;
+    }
+}

--- a/src/Hmvc/src/Core/InterceptorPipeline.php
+++ b/src/Hmvc/src/Core/InterceptorPipeline.php
@@ -38,6 +38,9 @@ final class InterceptorPipeline implements CoreInterface, HandlerInterface
         $this->interceptors[] = $interceptor;
     }
 
+    /**
+     * @psalm-immutable
+     */
     public function withCore(CoreInterface $core): self
     {
         $pipeline = clone $this;
@@ -46,6 +49,9 @@ final class InterceptorPipeline implements CoreInterface, HandlerInterface
         return $pipeline;
     }
 
+    /**
+     * @psalm-immutable
+     */
     public function withHandler(HandlerInterface $handler): self
     {
         $pipeline = clone $this;

--- a/src/Hmvc/src/Interceptors/Context/TargetInterface.php
+++ b/src/Hmvc/src/Interceptors/Context/TargetInterface.php
@@ -51,4 +51,12 @@ interface TargetInterface extends Stringable
      * @return TController|null
      */
     public function getObject(): ?object;
+
+    /**
+     * Returns the callable associated with the target.
+     * It may be a classic PHP callable or an array with a class name and a method name.
+     *
+     * @return callable|array{class-string, non-empty-string}|null
+     */
+    public function getCallable(): callable|array|null;
 }

--- a/src/Hmvc/src/Interceptors/Handler/InterceptorPipeline.php
+++ b/src/Hmvc/src/Interceptors/Handler/InterceptorPipeline.php
@@ -30,9 +30,17 @@ final class InterceptorPipeline implements HandlerInterface
     ) {
     }
 
-    public function addInterceptor(InterceptorInterface $interceptor): void
+    /**
+     * @psalm-immutable
+     */
+    public function withInterceptors(InterceptorInterface ...$interceptors): self
     {
-        $this->interceptors[] = $interceptor;
+        $clone = clone $this;
+        foreach ($interceptors as $interceptor) {
+            $clone->interceptors[] = $interceptor;
+        }
+
+        return $clone;
     }
 
     public function withHandler(HandlerInterface $handler): self

--- a/src/Hmvc/src/Interceptors/PipelineBuilder.php
+++ b/src/Hmvc/src/Interceptors/PipelineBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Interceptors;
+
+use Spiral\Interceptors\Handler\InterceptorPipeline;
+
+/**
+ * Uses only {@see InterceptorInterface} instances to build a pipeline.
+ */
+class PipelineBuilder implements PipelineBuilderInterface
+{
+    private InterceptorPipeline $pipeline;
+
+    public function __construct()
+    {
+        $this->pipeline = new InterceptorPipeline();
+    }
+
+    public function withInterceptors(InterceptorInterface ...$interceptors): static
+    {
+        $clone = clone $this;
+        $clone->pipeline = $this->pipeline->withInterceptors(...$interceptors);
+        return $clone;
+    }
+
+    public function build(): HandlerInterface
+    {
+        return $this->pipeline;
+    }
+}

--- a/src/Hmvc/src/Interceptors/PipelineBuilder.php
+++ b/src/Hmvc/src/Interceptors/PipelineBuilder.php
@@ -25,8 +25,8 @@ class PipelineBuilder implements PipelineBuilderInterface
         return $clone;
     }
 
-    public function build(): HandlerInterface
+    public function build(HandlerInterface $last): HandlerInterface
     {
-        return $this->pipeline;
+        return $this->pipeline->withHandler($last);
     }
 }

--- a/src/Hmvc/src/Interceptors/PipelineBuilder.php
+++ b/src/Hmvc/src/Interceptors/PipelineBuilder.php
@@ -7,7 +7,7 @@ namespace Spiral\Interceptors;
 use Spiral\Interceptors\Handler\InterceptorPipeline;
 
 /**
- * Uses only {@see InterceptorInterface} instances to build a pipeline.
+ * Accepts only {@see InterceptorInterface} instances to build a pipeline.
  */
 class PipelineBuilder implements PipelineBuilderInterface
 {

--- a/src/Hmvc/src/Interceptors/PipelineBuilderInterface.php
+++ b/src/Hmvc/src/Interceptors/PipelineBuilderInterface.php
@@ -15,5 +15,8 @@ interface PipelineBuilderInterface
      */
     public function withInterceptors(InterceptorInterface ...$interceptors): static;
 
+    /**
+     * @param HandlerInterface $last The last handler in the pipeline.
+     */
     public function build(HandlerInterface $last): HandlerInterface;
 }

--- a/src/Hmvc/src/Interceptors/PipelineBuilderInterface.php
+++ b/src/Hmvc/src/Interceptors/PipelineBuilderInterface.php
@@ -15,5 +15,5 @@ interface PipelineBuilderInterface
      */
     public function withInterceptors(InterceptorInterface ...$interceptors): static;
 
-    public function build(): HandlerInterface;
+    public function build(HandlerInterface $last): HandlerInterface;
 }

--- a/src/Hmvc/src/Interceptors/PipelineBuilderInterface.php
+++ b/src/Hmvc/src/Interceptors/PipelineBuilderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Interceptors;
+
+/**
+ * Helps to build a pipeline of interceptors.
+ */
+interface PipelineBuilderInterface
+{
+    /**
+     * @param InterceptorInterface ...$interceptors List of interceptors to append to the pipeline.
+     * @psalm-immutable
+     */
+    public function withInterceptors(InterceptorInterface ...$interceptors): static;
+
+    public function build(): HandlerInterface;
+}

--- a/src/Hmvc/tests/Core/Unit/CompatiblePipelineBuilderTest.php
+++ b/src/Hmvc/tests/Core/Unit/CompatiblePipelineBuilderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Core\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\CompatiblePipelineBuilder;
+use Spiral\Core\CoreInterface;
+use Spiral\Interceptors\Context\CallContext;
+use Spiral\Interceptors\Context\Target;
+use Spiral\Interceptors\HandlerInterface;
+use Spiral\Tests\Core\Unit\Stub\Legacy\LegacyExceptionInterceptor;
+use Spiral\Tests\Interceptors\Unit\Stub\ExceptionInterceptor;
+
+final class CompatiblePipelineBuilderTest extends TestCase
+{
+    public function testCreateEmpty(): void
+    {
+        $handler = self::createMock(HandlerInterface::class);
+        $handler->expects(self::once())->method('handle')->willReturn('foo');
+
+        $builder = (new CompatiblePipelineBuilder())->build($handler);
+        $result = $builder->handle($this->createPathContext());
+
+        self::assertSame('foo', $result);
+    }
+
+    public function testCreateWithInterceptor(): void
+    {
+        $handler = self::createMock(HandlerInterface::class);
+        $handler->expects(self::never())->method('handle')->willReturn('foo');
+
+        $builder = (new CompatiblePipelineBuilder())->withInterceptors(
+            new ExceptionInterceptor(),
+        )->build($handler);
+
+        $this->expectException(\RuntimeException::class);
+        $builder->handle($this->createPathContext());
+    }
+
+    public function testCreateWithLegacyHandler(): void
+    {
+        $handler = self::createMock(CoreInterface::class);
+        $handler->expects(self::never())->method('callAction')->willReturn('foo');
+
+        $builder = (new CompatiblePipelineBuilder())->withInterceptors(
+            new ExceptionInterceptor(),
+        )->build($handler);
+
+        $this->expectException(\RuntimeException::class);
+        $builder->handle($this->createPathContext());
+    }
+
+    public function testCreateWithLegacyInterceptor(): void
+    {
+        $handler = self::createMock(CoreInterface::class);
+        $handler->expects(self::never())->method('callAction')->willReturn('foo');
+
+        $builder = (new CompatiblePipelineBuilder())->withInterceptors(
+            new LegacyExceptionInterceptor(),
+        )->build($handler);
+
+        $this->expectException(\RuntimeException::class);
+        $builder->handle($this->createPathContext());
+    }
+
+    public function testWithMiddleware(): void
+    {
+        $handler = self::createMock(HandlerInterface::class);
+        $handler->expects(self::never())->method('handle')->willReturn('foo');
+
+        $builder = (new CompatiblePipelineBuilder());
+        $second = $builder->withInterceptors(new ExceptionInterceptor());
+
+        self::assertNotSame($builder, $second);
+    }
+
+    private function createPathContext(array $path = []): CallContext
+    {
+        return new CallContext(Target::fromPathArray($path));
+    }
+}

--- a/src/Hmvc/tests/Core/Unit/Stub/Legacy/LegacyExceptionInterceptor.php
+++ b/src/Hmvc/tests/Core/Unit/Stub/Legacy/LegacyExceptionInterceptor.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Core\Unit\Stub\Legacy;
+
+use Spiral\Core\CoreInterceptorInterface;
+use Spiral\Core\CoreInterface;
+
+final class LegacyExceptionInterceptor implements CoreInterceptorInterface
+{
+    public function process(string $controller, string $action, array $parameters, CoreInterface $core): mixed
+    {
+        throw new \RuntimeException('test');
+    }
+}

--- a/src/Hmvc/tests/Interceptors/Unit/PipelineBuilderTest.php
+++ b/src/Hmvc/tests/Interceptors/Unit/PipelineBuilderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Interceptors\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Interceptors\Context\CallContext;
+use Spiral\Interceptors\Context\Target;
+use Spiral\Interceptors\HandlerInterface;
+use Spiral\Interceptors\PipelineBuilder;
+use Spiral\Tests\Interceptors\Unit\Stub\ExceptionInterceptor;
+
+final class PipelineBuilderTest extends TestCase
+{
+    public function testCreateEmpty(): void
+    {
+        $handler = self::createMock(HandlerInterface::class);
+        $handler->expects(self::once())->method('handle')->willReturn('foo');
+
+        $builder = (new PipelineBuilder())->build($handler);
+        $result = $builder->handle($this->createPathContext());
+
+        self::assertSame('foo', $result);
+    }
+
+    public function testCreateWithMiddleware(): void
+    {
+        $handler = self::createMock(HandlerInterface::class);
+        $handler->expects(self::never())->method('handle')->willReturn('foo');
+
+        $builder = (new PipelineBuilder())->withInterceptors(
+            new ExceptionInterceptor(),
+        )->build($handler);
+
+        $this->expectException(\RuntimeException::class);
+        $builder->handle($this->createPathContext());
+    }
+
+    public function testWithMiddleware(): void
+    {
+        $handler = self::createMock(HandlerInterface::class);
+        $handler->expects(self::never())->method('handle')->willReturn('foo');
+
+        $builder = (new PipelineBuilder());
+        $second = $builder->withInterceptors(new ExceptionInterceptor());
+
+        self::assertNotSame($builder, $second);
+    }
+
+    private function createPathContext(array $path = []): CallContext
+    {
+        return new CallContext(Target::fromPathArray($path));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

Added an interface for interceptors pipeline builder.
It should be used instead of building `InterceptorPipeline` by hands.

\Spiral\Interceptors\Context\TargetInterface:
- added method `getCallable()`