### PR TITLE
Fix error when a file from the stacktrace doesn't exist

### DIFF
--- a/src/Exceptions/src/Renderer/ConsoleRenderer.php
+++ b/src/Exceptions/src/Renderer/ConsoleRenderer.php
@@ -202,11 +202,13 @@ class ConsoleRenderer extends AbstractRenderer
             $result .= $line . "\n";
 
             if ($h !== null && !empty($trace['file'])) {
+                $str = @\file_get_contents($trace['file']);
                 $result .= $h->highlightLines(
-                    \file_get_contents($trace['file']),
+                    $str,
                     $trace['line'],
                     static::SHOW_LINES
                 ) . "\n";
+                unset($str);
             }
         }
 

--- a/src/Exceptions/src/Renderer/PlainRenderer.php
+++ b/src/Exceptions/src/Renderer/PlainRenderer.php
@@ -102,12 +102,14 @@ final class PlainRenderer extends AbstractRenderer
 
             $result .= $line . "\n";
 
-            if ($h !== null && !empty($trace['file'])) {
+            if ($h !== null && !empty($trace['file']) && \is_file($trace['file'])) {
+                $str = @\file_get_contents($trace['file']);
                 $result .= $h->highlightLines(
-                    \file_get_contents($trace['file']),
+                    $str,
                     $trace['line'],
                     self::SHOW_LINES
                 ) . "\n";
+                unset($str);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️

Sometimes the `file` element doesn't contain valid file name

![image](https://github.com/spiral/framework/assets/4152481/f3343874-3efa-4b1e-8100-3b18ad6a45df)
