### PR TITLE
Fix psalm issue: remove internal annotation from LoggerTrait::$logger

### DIFF
--- a/src/Logger/src/Traits/LoggerTrait.php
+++ b/src/Logger/src/Traits/LoggerTrait.php
@@ -14,7 +14,6 @@ use Spiral\Logger\LogsInterface;
  */
 trait LoggerTrait
 {
-    /** @internal */
     private ?LoggerInterface $logger = null;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->


This class triggers psalm level 4 error
```php
use Spiral\Logger\Traits\LoggerTrait;

class Foo
{
    use LoggerTrait;

    public function __construct() {
        $this->logger = $this->allocateLogger('bar');
    }
```

```
ERROR: InternalProperty
at /home/gam6itko/Foo.php:24:9
Foo::$logger is internal to Spiral but called from Foo (see https://psalm.dev/176)
        $this->logger = $this->allocateLogger('bar');

```