### PR TITLE
[psalm fix level 4] TracerFactoryInterface - not internal

### DIFF
--- a/src/Telemetry/src/LogTracerFactory.php
+++ b/src/Telemetry/src/LogTracerFactory.php
@@ -11,8 +11,6 @@ use Spiral\Core\ScopeInterface;
 use Spiral\Logger\LogsInterface;
 
 /**
- * The component is under development.
- *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/LogTracerFactory.php
+++ b/src/Telemetry/src/LogTracerFactory.php
@@ -11,7 +11,8 @@ use Spiral\Core\ScopeInterface;
 use Spiral\Logger\LogsInterface;
 
 /**
- * @internal The component is under development.
+ * The component is under development.
+ *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/NullTracerFactory.php
+++ b/src/Telemetry/src/NullTracerFactory.php
@@ -9,7 +9,8 @@ use Spiral\Core\Container;
 use Spiral\Core\ScopeInterface;
 
 /**
- * @internal The component is under development.
+ * The component is under development.
+ *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/NullTracerFactory.php
+++ b/src/Telemetry/src/NullTracerFactory.php
@@ -9,8 +9,6 @@ use Spiral\Core\Container;
 use Spiral\Core\ScopeInterface;
 
 /**
- * The component is under development.
- *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/TracerFactoryInterface.php
+++ b/src/Telemetry/src/TracerFactoryInterface.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Spiral\Telemetry;
 
 /**
- * @internal The component is under development.
+ * The component is under development.
+ *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/TracerFactoryInterface.php
+++ b/src/Telemetry/src/TracerFactoryInterface.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Telemetry;
 
 /**
- * The component is under development.
- *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/TracerInterface.php
+++ b/src/Telemetry/src/TracerInterface.php
@@ -7,8 +7,6 @@ namespace Spiral\Telemetry;
 use Spiral\Core\ScopeInterface;
 
 /**
- * The component is under development.
- *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */

--- a/src/Telemetry/src/TracerInterface.php
+++ b/src/Telemetry/src/TracerInterface.php
@@ -7,7 +7,8 @@ namespace Spiral\Telemetry;
 use Spiral\Core\ScopeInterface;
 
 /**
- * @internal The component is under development.
+ * The component is under development.
+ *
  * Something may be changed in the future. We will stable it soon.
  * Feedback is welcome {@link https://github.com/spiral/framework/discussions/822}.
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

Remove internal annotation from:
- TracerFactoryInterface
- TracerInterface

Psalm level 4 triggers error
```php

use Spiral\Telemetry\TracerFactoryInterface;

final class TelemetryDecorator implements ResponseDataHandlerInterface
{
    public function __construct(
        private readonly TracerFactoryInterface       $tracerFactory,
        private readonly ResponseDataHandlerInterface $inner,
    ) {
    }

    public function handle(array $responseData, array $options = []): array
    {     
        return $this->tracerFactory
            ->make()
            ->trace(
                name: sprintf('ResponseDataHandler [%s]', get_class($this->inner)),
                callback: fn () => $this->inner->handle($responseData, $options),
                attributes: [
                    'itemsCount' => count($responseData),
                    'options' => $options,
                ]
            );
    }
}
```

```
ERROR: InternalMethod
at /home/gam6itko/TelemetryDecorator.php:23:15
The method Spiral\Telemetry\TracerFactoryInterface::make is internal to Spiral but called from TelemetryDecorator::handle (see https://psalm.dev/175)
            ->make()


ERROR: InternalMethod
at /home/gam6itko/TelemetryDecorator.php:24:15
The method Spiral\Telemetry\TracerInterface::trace is internal to Spiral but called from TelemetryDecorator::handle (see https://psalm.dev/175)
            ->trace(

```

The usage example.
https://spiral.dev/docs/advanced-telemetry/current/en#create-trace-from-context
