### PR TITLE
[psalm fix level 4] Spiral\Queue\HandlerInterface::handle can accept …

### DIFF
--- a/src/Queue/src/HandlerInterface.php
+++ b/src/Queue/src/HandlerInterface.php
@@ -12,7 +12,7 @@ interface HandlerInterface
     /**
      * Handle incoming job.
      *
-     * @param class-string<HandlerInterface> $name
+     * @param class-string<HandlerInterface>|non-empty-string $name
      * @param non-empty-string $id
      */
     public function handle(string $name, string $id, array $payload): void;


### PR DESCRIPTION
…string

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

HandlerInterface can accept string as job name

Here in example
https://spiral.dev/docs/queue-jobs/current/en#job-handler-registry


