### PR TITLE
[Rector] Enable RemoveUselessParamTagRector and RemoveUselessReturnTagRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -9,8 +9,6 @@ use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
@@ -62,8 +60,6 @@ return RectorConfig::configure()
         RemoveUnusedPublicMethodParameterRector::class,
         RemoveEmptyClassMethodRector::class,
         RemoveUnusedPromotedPropertyRector::class,
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
     ])
     ->withPhpSets(php72: true)
     ->withPreparedSets(deadCode: true);

--- a/rector.php
+++ b/rector.php
@@ -46,6 +46,7 @@ return RectorConfig::configure()
             __DIR__ . '/src/Prototype/src/NodeVisitors/LocateProperties.php',
             __DIR__ . '/src/Prototype/src/NodeVisitors/RemoveTrait.php',
             __DIR__ . '/src/Logger/src/ListenerRegistry.php',
+            __DIR__ . '/src/Stempler/src/Transform/Merge/ExtendsParent.php',
         ],
         RemoveExtraParametersRector::class => [
             __DIR__ . '/src/Boot/src/BootloadManager/AbstractBootloadManager.php',
@@ -56,7 +57,6 @@ return RectorConfig::configure()
 
         // to be enabled later after upgrade to 1.2.4 merged
         // to easier to review
-        RemoveAlwaysTrueIfConditionRector::class,
         RemoveUnusedPublicMethodParameterRector::class,
         RemoveEmptyClassMethodRector::class,
         RemoveUnusedPromotedPropertyRector::class,

--- a/src/Boot/src/Directories.php
+++ b/src/Boot/src/Directories.php
@@ -11,6 +11,9 @@ use Spiral\Boot\Exception\DirectoryException;
  */
 final class Directories implements DirectoriesInterface
 {
+    /**
+     * @param array<non-empty-string, string> $directories
+     */
     public function __construct(
         private array $directories = []
     ) {

--- a/src/Boot/src/DirectoriesInterface.php
+++ b/src/Boot/src/DirectoriesInterface.php
@@ -14,7 +14,7 @@ interface DirectoriesInterface
     public function has(string $name): bool;
 
     /**
-     * @param string $name Directory alias, ie. "framework".
+     * @param non-empty-string $name Directory alias, ie. "framework".
      * @param string $path Directory path without ending slash.
      *
      * @throws DirectoryException
@@ -24,7 +24,7 @@ interface DirectoriesInterface
     /**
      * Get directory value.
      *
-     *
+     * @param non-empty-string $name Directory alias, ie. "framework".
      * @throws DirectoryException When no directory found.
      */
     public function get(string $name): string;

--- a/src/Boot/src/helpers.php
+++ b/src/Boot/src/helpers.php
@@ -39,7 +39,6 @@ if (!function_exists('directory')) {
      * Get directory alias value. Uses application core from the current global scope.
      *
      * @param string $alias Directory alias, ie. "framework".
-     * @return string
      *
      * @throws ScopeException
      * @throws DirectoryException
@@ -54,7 +53,6 @@ if (!function_exists('env')) {
     /**
      * Gets the value of an environment variable. Uses application core from the current global scope.
      *
-     * @param string $key
      * @param mixed  $default
      * @return mixed
      */

--- a/src/Boot/src/helpers.php
+++ b/src/Boot/src/helpers.php
@@ -38,7 +38,7 @@ if (!function_exists('directory')) {
     /**
      * Get directory alias value. Uses application core from the current global scope.
      *
-     * @param string $alias Directory alias, ie. "framework".
+     * @param non-empty-string $alias Directory alias, ie. "framework".
      *
      * @throws ScopeException
      * @throws DirectoryException
@@ -53,6 +53,7 @@ if (!function_exists('env')) {
     /**
      * Gets the value of an environment variable. Uses application core from the current global scope.
      *
+     * @param non-empty-string $key
      * @param mixed  $default
      * @return mixed
      */

--- a/src/Interceptors/src/Context/Target.php
+++ b/src/Interceptors/src/Context/Target.php
@@ -12,7 +12,6 @@ final class Target implements TargetInterface
 {
     /**
      * @param list<string> $path
-     * @param \ReflectionFunctionAbstract|null $reflection
      * @param TController|null $object
      * @param \Closure|array{class-string|object, non-empty-string}|null $callable
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

This is part of dead code set list, remove useless `@param` and `@return` when there is native type already.