### PR TITLE
Fix concurrent writing and reading on workers boot

### DIFF
--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -35,7 +35,14 @@ final class Memory implements MemoryInterface
         }
 
         try {
-            return include($filename);
+            $fp = fopen($filename, 'r');
+            if (!flock($fp, LOCK_SH | LOCK_NB)) {
+                return null;
+            }
+            $data = include($filename);
+            flock($fp, LOCK_UN);
+            fclose($fp);
+            return $data;
         } catch (\Throwable) {
             return null;
         }

--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -1,4 +1,4 @@
-<?php
+e<?php
 
 declare(strict_types=1);
 
@@ -36,7 +36,7 @@ final class Memory implements MemoryInterface
 
         try {
             $fp = fopen($filename, 'r');
-            if (!flock($fp, LOCK_SH | LOCK_NB)) {
+            if (!flock($fp, LOCK_SH)) {
                 return null;
             }
             $data = include($filename);

--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -36,7 +36,7 @@ final class Memory implements MemoryInterface
 
         try {
             $fp = fopen($filename, 'r');
-            if (!flock($fp, LOCK_SH)) {
+            if (!flock($fp, LOCK_SH | LOCK_NB)) {
                 return null;
             }
             $data = include($filename);

--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -1,4 +1,4 @@
-e<?php
+<?php
 
 declare(strict_types=1);
 
@@ -35,13 +35,13 @@ final class Memory implements MemoryInterface
         }
 
         try {
-            $fp = fopen($filename, 'r');
-            if (!flock($fp, LOCK_SH | LOCK_NB)) {
+            $fp = \fopen($filename, 'r');
+            if (!\flock($fp, \LOCK_SH | \LOCK_NB)) {
                 return null;
             }
             $data = include($filename);
-            flock($fp, LOCK_UN);
-            fclose($fp);
+            \flock($fp, \LOCK_UN);
+            \fclose($fp);
             return $data;
         } catch (\Throwable) {
             return null;


### PR DESCRIPTION
Set a shared lock on a file in Memoty::loadData() to prevent reading an empty file while writing it in concurrent worker/process

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | Can get an empty file when `file_put_contents` in `\Spiral\Boot\Memory::saveData=>\Spiral\Files\Files::write` created, but not completed write to file
| Docs PR       | spiral/docs

Got this problem when 2 jobs consumers concurrently started writing/reading runtime/cache/cycle.php file. First consumer writing schema to the file, second consumers find out that files exists and read it, but it still was empty = so read empty schema.