### PR TITLE
CacheManager ability to set custom cache storage.

### DIFF
--- a/src/Cache/src/Bootloader/CacheBootloader.php
+++ b/src/Cache/src/Bootloader/CacheBootloader.php
@@ -10,6 +10,7 @@ use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Cache\CacheManager;
 use Spiral\Cache\CacheStorageProviderInterface;
+use Spiral\Cache\CacheStorageRegistryInterface;
 use Spiral\Cache\Config\CacheConfig;
 use Spiral\Cache\Core\CacheInjector;
 use Spiral\Cache\Storage\ArrayStorage;
@@ -22,6 +23,7 @@ use Spiral\Core\FactoryInterface;
 final class CacheBootloader extends Bootloader
 {
     protected const SINGLETONS = [
+        CacheStorageRegistryInterface::class => CacheManager::class,
         CacheStorageProviderInterface::class => CacheManager::class,
         CacheManager::class => [self::class, 'initCacheManager'],
     ];

--- a/src/Cache/src/CacheManager.php
+++ b/src/Cache/src/CacheManager.php
@@ -11,7 +11,7 @@ use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\FactoryInterface;
 
 #[Singleton]
-class CacheManager implements CacheStorageProviderInterface
+class CacheManager implements CacheStorageProviderInterface, CacheStorageRegistryInterface
 {
     /** @var CacheInterface[] */
     private array $storages = [];
@@ -48,5 +48,15 @@ class CacheManager implements CacheStorageProviderInterface
         $config = $this->config->getStorageConfig($name);
 
         return $this->factory->make($config['type'], $config);
+    }
+
+    public function set(string $name, CacheInterface $cache): void
+    {
+        $this->storages[$name] = $cache;
+    }
+
+    public function has(string $name): bool
+    {
+        return \array_key_exists($name, $this->storages);
     }
 }

--- a/src/Cache/src/CacheStorageRegistryInterface.php
+++ b/src/Cache/src/CacheStorageRegistryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+interface CacheStorageRegistryInterface
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function set(string $name, CacheInterface $cache): void;
+}

--- a/src/Cache/tests/CacheManagerTest.php
+++ b/src/Cache/tests/CacheManagerTest.php
@@ -12,6 +12,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\SimpleCache\CacheInterface;
 use Spiral\Cache\CacheManager;
 use Spiral\Cache\Config\CacheConfig;
+use Spiral\Cache\Storage\ArrayStorage;
 use Spiral\Core\FactoryInterface;
 
 final class CacheManagerTest extends TestCase
@@ -217,5 +218,18 @@ final class CacheManagerTest extends TestCase
         yield ['store-data', null];
         yield ['order-data', null];
         yield ['delivery-data', null];
+    }
+
+    public function testSet(): void
+    {
+        $uniq = \uniqid();
+        $cache = new ArrayStorage();
+        $cache->set('uniq', $uniq);
+        $name = 'brandNewCache';
+        $this->assertFalse($this->manager->has($name));
+        $this->manager->set($name, $cache);
+        $this->assertTrue($this->manager->has($name));
+        $repo = $this->manager->storage($name);
+        $this->assertSame($uniq, $repo->get('uniq'));
     }
 }

--- a/tests/Framework/Bootloader/Cache/CacheBootloaderTest.php
+++ b/tests/Framework/Bootloader/Cache/CacheBootloaderTest.php
@@ -9,6 +9,7 @@ use Spiral\Cache\Bootloader\CacheBootloader;
 use Spiral\Cache\CacheManager;
 use Spiral\Cache\CacheRepository;
 use Spiral\Cache\CacheStorageProviderInterface;
+use Spiral\Cache\CacheStorageRegistryInterface;
 use Spiral\Cache\Config\CacheConfig;
 use Spiral\Cache\Storage\ArrayStorage;
 use Spiral\Cache\Storage\FileStorage;
@@ -18,17 +19,22 @@ use Spiral\Tests\Framework\BaseTestCase;
 
 final class CacheBootloaderTest extends BaseTestCase
 {
-    public function testBindings()
+    public function testBindings(): void
     {
         $this->assertContainerInstantiable(CacheInterface::class, CacheRepository::class);
         $this->assertContainerBoundAsSingleton(CacheStorageProviderInterface::class, CacheManager::class);
+        $this->assertContainerBoundAsSingleton(CacheStorageRegistryInterface::class, CacheManager::class);
 
         $repository = $this->getContainer()->get(CacheInterface::class);
-
         $this->assertInstanceOf(ArrayStorage::class, $repository->getStorage());
+
+        $provider = $this->getContainer()->get(CacheStorageProviderInterface::class);
+        $this->assertInstanceOf(CacheManager::class, $provider);
+        $registry = $this->getContainer()->get(CacheStorageRegistryInterface::class);
+        $this->assertInstanceOf(CacheManager::class, $registry);
     }
 
-    public function testGetsStorageByAlias()
+    public function testGetsStorageByAlias(): void
     {
         $manager = $this->getContainer()->get(CacheStorageProviderInterface::class);
         $repository = $manager->storage('user-data');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

User can set custom cache in bootloader.

Example for redis
```php
use Spiral\Boot\Bootloader\Bootloader;
use Spiral\Boot\EnvironmentInterface;
use Spiral\Cache\CacheStorageRegistryInterface;
use Symfony\Component\Cache\Adapter\RedisAdapter;
use Symfony\Component\Cache\Psr16Cache;

final class RedisCacheBootloader extends Bootloader
{
    public function boot(CacheStorageRegistryInterface $cacheRegistry, EnvironmentInterface $env): void
    {
        $cacheRegistry->set(
            name: 'redis',
            cache: new Psr16Cache(
                pool: new RedisAdapter(
                    redis: RedisAdapter::createConnection($env->get('REDIS_DSN'))
                ),
            )
        );
    }
}
``` 
