### PR TITLE
Fix `GuardScope` to operate within container scopes

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -34,7 +34,9 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/container": "^1.1|^2.0"
+        "psr/container": "^1.1|^2.0",
+        "spiral/core": "^3.14",
+        "spiral/security": "^3.14"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/src/Framework/Security/GuardScope.php
+++ b/src/Framework/Security/GuardScope.php
@@ -6,11 +6,13 @@ namespace Spiral\Security;
 
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Spiral\Core\Attribute\Proxy;
 use Spiral\Core\Exception\ScopeException;
 use Spiral\Security\Exception\GuardException;
 
 /**
  * Resolves Actor dynamically, using current active IoC scope.
+ * @deprecated Use {@see ActorInterface} instead. Will be removed in v4.0.
  */
 final class GuardScope implements GuardInterface
 {
@@ -18,7 +20,7 @@ final class GuardScope implements GuardInterface
 
     public function __construct(
         private readonly PermissionsInterface $permissions,
-        private readonly ContainerInterface $container,
+        #[Proxy] private readonly ContainerInterface $container,
         private array $roles = []
     ) {
     }


### PR DESCRIPTION
The container is passed through a proxy now