### PR TITLE
fix: boot resource leakage

### DIFF
--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -24,9 +24,9 @@ final class Memory implements MemoryInterface
     }
 
     /**
-     * @param string $filename Cache filename.
+     * @param non-empty-string|null $filename Cache filename.
      */
-    public function loadData(string $section, string &$filename = null): mixed
+    public function loadData(string $section, ?string &$filename = null): mixed
     {
         $filename = $this->getFilename($section);
 

--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -36,16 +36,27 @@ final class Memory implements MemoryInterface
 
         try {
             $fp = \fopen($filename, 'r');
-            if (!\flock($fp, \LOCK_SH | \LOCK_NB)) {
+            if ($fp === false) {
                 return null;
             }
+
+            if (!\flock($fp, \LOCK_SH | \LOCK_NB)) {
+                \fclose($fp);
+                return null;
+            }
+
             $data = include($filename);
+
             \flock($fp, \LOCK_UN);
-            \fclose($fp);
-            return $data;
         } catch (\Throwable) {
             return null;
+        } finally {
+            if (isset($fp)) {
+                \fclose($fp);
+            }
         }
+
+        return $data;
     }
 
     public function saveData(string $section, mixed $data): void

--- a/src/Boot/src/Memory.php
+++ b/src/Boot/src/Memory.php
@@ -34,29 +34,28 @@ final class Memory implements MemoryInterface
             return null;
         }
 
+        $fp = false;
+        $lock = false;
+
         try {
             $fp = \fopen($filename, 'r');
             if ($fp === false) {
                 return null;
             }
 
-            if (!\flock($fp, \LOCK_SH | \LOCK_NB)) {
-                \fclose($fp);
+            $lock = \flock($fp, \LOCK_SH | \LOCK_NB);
+
+            if ($lock === false) {
                 return null;
             }
 
-            $data = include($filename);
-
-            \flock($fp, \LOCK_UN);
+            return include($filename);
         } catch (\Throwable) {
             return null;
         } finally {
-            if (isset($fp)) {
-                \fclose($fp);
-            }
+            $lock === false or \flock($fp, \LOCK_UN);
+            $fp === false or \fclose($fp);
         }
-
-        return $data;
     }
 
     public function saveData(string $section, mixed $data): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | N/A <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | N/A <!-- prefix each issue number with "spiral/docs#", required only for new features -->

#1137 introduced resource leakage by not freeing handles in some cases. This led to endless loop while trying to loadData or saveData

This PR should fix this bug by always attempting to close the resource
