### PR TITLE
feat(Cache): pre-operation events

### DIFF
--- a/src/Cache/src/CacheRepository.php
+++ b/src/Cache/src/CacheRepository.php
@@ -8,7 +8,12 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\SimpleCache\CacheInterface;
 use Spiral\Cache\Event\CacheHit;
 use Spiral\Cache\Event\CacheMissed;
+use Spiral\Cache\Event\CacheRetrieving;
 use Spiral\Cache\Event\KeyDeleted;
+use Spiral\Cache\Event\KeyDeleteFailed;
+use Spiral\Cache\Event\KeyDeleting;
+use Spiral\Cache\Event\KeyWriteFailed;
+use Spiral\Cache\Event\KeyWriting;
 use Spiral\Cache\Event\KeyWritten;
 
 /**
@@ -25,37 +30,51 @@ class CacheRepository implements CacheInterface
 
     public function get(string $key, mixed $default = null): mixed
     {
-        $value = $this->storage->get($this->resolveKey($key));
+        $key = $this->resolveKey($key);
+
+        $this->dispatcher?->dispatch(new CacheRetrieving($key));
+
+        $value = $this->storage->get($key);
 
         if ($value === null) {
-            $this->dispatcher?->dispatch(new CacheMissed($this->resolveKey($key)));
+            $this->dispatcher?->dispatch(new CacheMissed($key));
 
             return $default;
         }
 
-        $this->dispatcher?->dispatch(new CacheHit($this->resolveKey($key), $value));
+        $this->dispatcher?->dispatch(new CacheHit($key, $value));
 
         return $value;
     }
 
     public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
     {
-        $result = $this->storage->set($this->resolveKey($key), $value, $ttl);
+        $key = $this->resolveKey($key);
 
-        if ($result) {
-            $this->dispatcher?->dispatch(new KeyWritten($this->resolveKey($key), $value));
-        }
+        $this->dispatcher?->dispatch(new KeyWriting($key, $value));
+
+        $result = $this->storage->set($key, $value, $ttl);
+
+        $this->dispatcher?->dispatch(match ($result) {
+            true => new KeyWritten($key, $value),
+            default => new KeyWriteFailed($key, $value),
+        });
 
         return $result;
     }
 
     public function delete(string $key): bool
     {
-        $result = $this->storage->delete($this->resolveKey($key));
+        $key = $this->resolveKey($key);
 
-        if ($result) {
-            $this->dispatcher?->dispatch(new KeyDeleted($this->resolveKey($key)));
-        }
+        $this->dispatcher?->dispatch(new KeyDeleting($key));
+
+        $result = $this->storage->delete($key);
+
+        $this->dispatcher?->dispatch(match ($result) {
+            true => new KeyDeleted($key),
+            default => new KeyDeleteFailed($key),
+        });
 
         return $result;
     }

--- a/src/Cache/src/CacheRepository.php
+++ b/src/Cache/src/CacheRepository.php
@@ -55,10 +55,11 @@ class CacheRepository implements CacheInterface
 
         $result = $this->storage->set($key, $value, $ttl);
 
-        $this->dispatcher?->dispatch(match ($result) {
-            true => new KeyWritten($key, $value),
-            default => new KeyWriteFailed($key, $value),
-        });
+        $this->dispatcher?->dispatch(
+            $result
+                ? new KeyWritten($key, $value)
+                : new KeyWriteFailed($key, $value),
+        );
 
         return $result;
     }
@@ -71,10 +72,11 @@ class CacheRepository implements CacheInterface
 
         $result = $this->storage->delete($key);
 
-        $this->dispatcher?->dispatch(match ($result) {
-            true => new KeyDeleted($key),
-            default => new KeyDeleteFailed($key),
-        });
+        $this->dispatcher?->dispatch(
+            $result
+                ? new KeyDeleted($key)
+                : new KeyDeleteFailed($key),
+        );
 
         return $result;
     }
@@ -130,10 +132,6 @@ class CacheRepository implements CacheInterface
 
     private function resolveKey(string $key): string
     {
-        if (!empty($this->prefix)) {
-            return $this->prefix . $key;
-        }
-
-        return $key;
+        return $this->prefix . $key;
     }
 }

--- a/src/Cache/src/Event/AbstractCacheEvent.php
+++ b/src/Cache/src/Event/AbstractCacheEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spiral\Cache\Event;
+
+abstract class AbstractCacheEvent
+{
+    public function __construct(
+        public readonly string $key,
+    ) {
+    }
+}

--- a/src/Cache/src/Event/CacheEvent.php
+++ b/src/Cache/src/Event/CacheEvent.php
@@ -1,8 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spiral\Cache\Event;
 
-abstract class AbstractCacheEvent
+/**
+ * Base class for all cache events.
+ */
+abstract class CacheEvent
 {
     public function __construct(
         public readonly string $key,

--- a/src/Cache/src/Event/CacheHit.php
+++ b/src/Cache/src/Event/CacheHit.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class CacheHit extends AbstractCacheEvent
+/**
+ * Triggered when cache item is successfully retrieved.
+ */
+final class CacheHit extends CacheEvent
 {
     public function __construct(
         string $key,

--- a/src/Cache/src/Event/CacheMissed.php
+++ b/src/Cache/src/Event/CacheMissed.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class CacheMissed
+final class CacheMissed extends AbstractCacheEvent
 {
-    public function __construct(
-        public readonly string $key,
-    ) {
-    }
 }

--- a/src/Cache/src/Event/CacheMissed.php
+++ b/src/Cache/src/Event/CacheMissed.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class CacheMissed extends AbstractCacheEvent
+/**
+ * Triggered when cache item is not found.
+ */
+final class CacheMissed extends CacheEvent
 {
 }

--- a/src/Cache/src/Event/CacheRetrieving.php
+++ b/src/Cache/src/Event/CacheRetrieving.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spiral\Cache\Event;
+
+final class CacheRetrieving extends AbstractCacheEvent
+{
+}

--- a/src/Cache/src/Event/CacheRetrieving.php
+++ b/src/Cache/src/Event/CacheRetrieving.php
@@ -1,7 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spiral\Cache\Event;
 
-final class CacheRetrieving extends AbstractCacheEvent
+/**
+ * Triggered before cache item is retrieved.
+ */
+final class CacheRetrieving extends CacheEvent
 {
 }

--- a/src/Cache/src/Event/KeyDeleteFailed.php
+++ b/src/Cache/src/Event/KeyDeleteFailed.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class KeyDeleted extends AbstractCacheEvent
+final class KeyDeleteFailed extends AbstractCacheEvent
 {
 }

--- a/src/Cache/src/Event/KeyDeleteFailed.php
+++ b/src/Cache/src/Event/KeyDeleteFailed.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class KeyDeleteFailed extends AbstractCacheEvent
+/**
+ * Triggered when cache delete operation failed.
+ */
+final class KeyDeleteFailed extends CacheEvent
 {
 }

--- a/src/Cache/src/Event/KeyDeleted.php
+++ b/src/Cache/src/Event/KeyDeleted.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class KeyDeleted extends AbstractCacheEvent
+/**
+ * Triggered when cache item is deleted.
+ */
+final class KeyDeleted extends CacheEvent
 {
 }

--- a/src/Cache/src/Event/KeyDeleting.php
+++ b/src/Cache/src/Event/KeyDeleting.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spiral\Cache\Event;
+
+final class KeyDeleting extends AbstractCacheEvent
+{
+}

--- a/src/Cache/src/Event/KeyDeleting.php
+++ b/src/Cache/src/Event/KeyDeleting.php
@@ -1,7 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spiral\Cache\Event;
 
-final class KeyDeleting extends AbstractCacheEvent
+/**
+ * Triggered before cache item is deleted.
+ */
+final class KeyDeleting extends CacheEvent
 {
 }

--- a/src/Cache/src/Event/KeyWriteFailed.php
+++ b/src/Cache/src/Event/KeyWriteFailed.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class CacheHit extends AbstractCacheEvent
+final class KeyWriteFailed extends AbstractCacheEvent
 {
     public function __construct(
         string $key,
-        public readonly mixed $value
+        public readonly mixed $value,
     ) {
         parent::__construct($key);
     }

--- a/src/Cache/src/Event/KeyWriteFailed.php
+++ b/src/Cache/src/Event/KeyWriteFailed.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class KeyWriteFailed extends AbstractCacheEvent
+/**
+ * Triggered when cache write operation failed.
+ */
+final class KeyWriteFailed extends CacheEvent
 {
     public function __construct(
         string $key,

--- a/src/Cache/src/Event/KeyWriting.php
+++ b/src/Cache/src/Event/KeyWriting.php
@@ -1,14 +1,12 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Spiral\Cache\Event;
 
-final class CacheHit extends AbstractCacheEvent
+final class KeyWriting extends AbstractCacheEvent
 {
     public function __construct(
         string $key,
-        public readonly mixed $value
+        public readonly mixed $value,
     ) {
         parent::__construct($key);
     }

--- a/src/Cache/src/Event/KeyWriting.php
+++ b/src/Cache/src/Event/KeyWriting.php
@@ -1,8 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spiral\Cache\Event;
 
-final class KeyWriting extends AbstractCacheEvent
+/**
+ * Triggered before cache item is written.
+ */
+final class KeyWriting extends CacheEvent
 {
     public function __construct(
         string $key,

--- a/src/Cache/src/Event/KeyWritten.php
+++ b/src/Cache/src/Event/KeyWritten.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class KeyWritten
+final class KeyWritten extends AbstractCacheEvent
 {
     public function __construct(
-        public readonly string $key,
+        string $key,
         public readonly mixed $value,
     ) {
+        parent::__construct($key);
     }
 }

--- a/src/Cache/src/Event/KeyWritten.php
+++ b/src/Cache/src/Event/KeyWritten.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Event;
 
-final class KeyWritten extends AbstractCacheEvent
+/**
+ * Triggered after cache item is written.
+ */
+final class KeyWritten extends CacheEvent
 {
     public function __construct(
         string $key,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | N/A <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | N/A <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->

Adds events, that are dispatched before cache operations: `KeyWriting`, `CacheRetreiving`, etc...
