### PR TITLE
Inject optional EventDispatcher into CacheManager

### DIFF
--- a/src/Cache/src/Bootloader/CacheBootloader.php
+++ b/src/Cache/src/Bootloader/CacheBootloader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Cache\Bootloader;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\SimpleCache\CacheInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\DirectoriesInterface;
@@ -49,9 +50,10 @@ final class CacheBootloader extends Bootloader
     private function initCacheManager(
         BinderInterface $binder,
         FactoryInterface $factory,
-        CacheConfig $config
+        CacheConfig $config,
+        ?EventDispatcherInterface $dispatcher = null
     ): CacheManager {
-        $manager = new CacheManager($config, $factory);
+        $manager = new CacheManager($config, $factory, $dispatcher);
 
         foreach ($config->getAliases() as $alias => $storageName) {
             $binder->bind(


### PR DESCRIPTION
I'm creating a clockwork bridge, but I can't listen to cache events because the event dispatcher is always null.

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->
