### PR TITLE
Fix @template-covariant usage on Target and TargetInterface

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,8 +11,6 @@ use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Expression\RemoveDeadStmtRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
@@ -110,16 +108,6 @@ return RectorConfig::configure()
         \Rector\PHPUnit\PHPUnit100\Rector\MethodCall\AssertIssetToAssertObjectHasPropertyRector::class => [
             // ArrayAccess usage
             __DIR__ . '/src/Session/tests/SessionTest.php',
-        ],
-
-        // nullable @template usage, see https://github.com/rectorphp/rector-src/pull/6409
-        // can be re-enabled on next rector release
-        RemoveUselessParamTagRector::class => [
-            __DIR__ . '/src/Interceptors/src/Context/Target.php',
-        ],
-
-        RemoveUselessReturnTagRector::class => [
-            __DIR__ . '/src/Interceptors/src/Context/TargetInterface.php',
         ],
     ])
     ->withPhpSets(php81: true)

--- a/src/Interceptors/src/Context/Target.php
+++ b/src/Interceptors/src/Context/Target.php
@@ -12,7 +12,7 @@ final class Target implements TargetInterface
 {
     /**
      * @param list<string> $path
-     * @param TController|null $object
+     * @param TController $object
      * @param \Closure|array{class-string|object, non-empty-string}|null $callable
      */
     private function __construct(

--- a/src/Interceptors/src/Context/TargetInterface.php
+++ b/src/Interceptors/src/Context/TargetInterface.php
@@ -48,7 +48,7 @@ interface TargetInterface extends Stringable
      *
      * If the object is present, it always corresponds to the method reflection from {@see getReflection()}.
      *
-     * @return TController|null
+     * @return TController
      */
     public function getObject(): ?object;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

The definition is already nullable

```
@template-covariant TController of object|null
```

so add `TController|null` on `@param` and `@return` should be updated to `TController` only. 

Then `RemoveUselessParamTagRector` and `RemoveUselessReturnTagRector` skip can be cleaned up.