### PR TITLE
Fix configuration replacement for auth in HttpAuthBootloader

### DIFF
--- a/src/Framework/Bootloader/Auth/HttpAuthBootloader.php
+++ b/src/Framework/Bootloader/Auth/HttpAuthBootloader.php
@@ -90,23 +90,22 @@ final class HttpAuthBootloader extends Bootloader
         ];
     }
 
-    public function init(AbstractKernel $kernel, EnvironmentInterface $env): void
+    public function init(EnvironmentInterface $env): void
     {
         $this->config->setDefaults(
             AuthConfig::CONFIG,
             [
                 'defaultTransport' => $env->get('AUTH_TOKEN_TRANSPORT', 'cookie'),
                 'defaultStorage' => $env->get('AUTH_TOKEN_STORAGE', 'session'),
-                'transports' => [],
-                'storages' => [],
+                'transports' => [
+                    'cookie' => $this->createDefaultCookieTransport(),
+                    'header' => new HeaderTransport(header: 'X-Auth-Token'),
+                ],
+                'storages' => [
+                    'session' => SessionTokenStorage::class,
+                ],
             ]
         );
-
-        $kernel->booting(function () {
-            $this->addTransport('cookie', $this->createDefaultCookieTransport());
-            $this->addTransport('header', new HeaderTransport('X-Auth-Token'));
-            $this->addTokenStorage('session', SessionTokenStorage::class);
-        });
     }
 
     /**


### PR DESCRIPTION
This pull request addresses an issue in the `HttpAuthBootloader` where configuration settings for authentication transports and storages defined in the `auth.php` config file are overridden by hardcoded defaults during the `booting` process.

According to the [documentation](https://spiral.dev/docs/security-authentication/current#token-transport), it should be possible to configure where the authentication token is stored (e.g., in a cookie or header) and customize related parameters, such as the token's name, through the configuration file, as shown:

```php
return [
    'defaultStorage'   => 'session',
    'defaultTransport' => 'cookie',

    'transports' => [
        'header' => new HeaderTransport(header: 'X-Auth-Token-Custom'),
        'cookie' => new CookieTransport(cookie: 'token-custom', basePath: '/'),
    ],
];
```

However, these configuration settings are ignored, and the token is always stored in the default `token` cookie. Currently, the only way to change the cookie name is by overriding it in the `AppBootloader`.

### Issue:
In the `Spiral\Bootloader\Auth\HttpAuthBootloader::init()` method, the configuration values are replaced by hardcoded defaults:

```php
$kernel->booting(function () {
    $this->addTransport('cookie', $this->createDefaultCookieTransport());
    $this->addTransport('header', new HeaderTransport('X-Auth-Token'));
    $this->addTokenStorage('session', SessionTokenStorage::class);
});
```

### Benefits:
- Ensures that configuration settings in `auth.php` are respected.
- Works correctly with or without configuration.
- PR does not break backward compatibility


| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
