### PR TITLE
Fix server request for root services

### DIFF
--- a/src/Core/src/Exception/Container/RecursiveProxyException.php
+++ b/src/Core/src/Exception/Container/RecursiveProxyException.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Container;
 
+use Psr\Container\NotFoundExceptionInterface;
+
 /**
  * Recursion can occur due to improper container configuration or
  * an unplanned exit from the scope by the execution thread.
  */
-class RecursiveProxyException extends ContainerException
+class RecursiveProxyException extends ContainerException implements NotFoundExceptionInterface
 {
     public function __construct(
         public readonly string $alias,

--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -18,6 +18,7 @@ use Spiral\Core\Attribute\Singleton;
 use Spiral\Core\BinderInterface;
 use Spiral\Core\Container;
 use Spiral\Core\Container\Autowire;
+use Spiral\Core\Exception\ScopeException;
 use Spiral\Core\InvokerInterface;
 use Spiral\Framework\Spiral;
 use Spiral\Http\Config\HttpConfig;
@@ -52,7 +53,10 @@ final class HttpBootloader extends Bootloader
             RequestInterface::class,
             new \Spiral\Core\Config\Proxy(
                 interface: RequestInterface::class,
-                singleton: true,
+                fallbackFactory: static fn (ContainerInterface $c) => throw new ScopeException(
+                    'Unable to receive current Server Request. '
+                    . 'Try to define the service in the `http` scope or use the Poxy attribute.',
+                ),
             ),
         );
 

--- a/src/Framework/Bootloader/Http/HttpBootloader.php
+++ b/src/Framework/Bootloader/Http/HttpBootloader.php
@@ -48,6 +48,14 @@ final class HttpBootloader extends Bootloader
 
     public function defineSingletons(): array
     {
+        $this->binder->bind(
+            RequestInterface::class,
+            new \Spiral\Core\Config\Proxy(
+                interface: RequestInterface::class,
+                singleton: true,
+            ),
+        );
+
         $httpBinder = $this->binder->getBinder(Spiral::Http);
 
         $httpBinder->bindSingleton(Http::class, [self::class, 'httpCore']);

--- a/src/Framework/Bootloader/Http/SessionBootloader.php
+++ b/src/Framework/Bootloader/Http/SessionBootloader.php
@@ -37,7 +37,7 @@ final class SessionBootloader extends Bootloader
                 SessionInterface::class,
                 new Proxy(SessionInterface::class, false, $this->resolveSession(...)),
             );
-        $this->binder->bind(SessionInterface::class, new Proxy(SessionInterface::class, true), );
+        $this->binder->bind(SessionInterface::class, new Proxy(SessionInterface::class, true));
 
         return [];
     }

--- a/src/Router/tests/Fixtures/UserContext.php
+++ b/src/Router/tests/Fixtures/UserContext.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\Fixtures;
+
+final class UserContext
+{
+    private function __construct() {}
+
+    public static function create(): self
+    {
+        return new self();
+    }
+}

--- a/src/Router/tests/Fixtures/UserContextBootloader.php
+++ b/src/Router/tests/Fixtures/UserContextBootloader.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\Fixtures;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+
+final class UserContextBootloader extends Bootloader
+{
+    public function defineBindings(): array
+    {
+        return [
+            UserContext::class => [self::class, 'userContext'],
+        ];
+    }
+
+    private function userContext(ServerRequestInterface $request): UserContext
+    {
+        return isset($request->getQueryParams()['context'])
+            ? UserContext::create()
+            : throw new \Exception(
+                'Unable to resolve UserContext, invalid request.',
+            );
+    }
+}

--- a/src/Router/tests/Fixtures/UserContextController.php
+++ b/src/Router/tests/Fixtures/UserContextController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Router\Fixtures;
+
+class UserContextController
+{
+    public function __construct(
+        private readonly UserContext $scope,
+    ) {}
+
+    public function scope(): string
+    {
+        return $this->scope ? 'OK' : 'FAIL';
+    }
+}


### PR DESCRIPTION
- Bind Proxy to ServerRequestInterface in `root` scope

Fix #1158