### PR TITLE
Define Auth* middleware in `http` scope

### DIFF
--- a/src/AuthHttp/src/Middleware/AuthMiddleware.php
+++ b/src/AuthHttp/src/Middleware/AuthMiddleware.php
@@ -14,11 +14,13 @@ use Spiral\Auth\AuthContext;
 use Spiral\Auth\AuthContextInterface;
 use Spiral\Auth\TokenStorageInterface;
 use Spiral\Auth\TransportRegistry;
+use Spiral\Core\Attribute\Scope;
 use Spiral\Core\ScopeInterface;
 
 /**
  * Manages auth context scope.
  */
+#[Scope('http')]
 final class AuthMiddleware implements MiddlewareInterface
 {
     public const ATTRIBUTE = 'authContext';

--- a/src/AuthHttp/src/Middleware/AuthTransportMiddleware.php
+++ b/src/AuthHttp/src/Middleware/AuthTransportMiddleware.php
@@ -12,11 +12,13 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Auth\ActorProviderInterface;
 use Spiral\Auth\TokenStorageInterface;
 use Spiral\Auth\TransportRegistry;
+use Spiral\Core\Attribute\Scope;
 use Spiral\Core\ScopeInterface;
 
 /**
  * Auth by specific transport.
  */
+#[Scope('http')]
 final class AuthTransportMiddleware implements MiddlewareInterface
 {
     private readonly AuthMiddleware $authMiddleware;

--- a/src/AuthHttp/src/Middleware/AuthTransportWithStorageMiddleware.php
+++ b/src/AuthHttp/src/Middleware/AuthTransportWithStorageMiddleware.php
@@ -12,14 +12,16 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Auth\ActorProviderInterface;
 use Spiral\Auth\TokenStorageProviderInterface;
 use Spiral\Auth\TransportRegistry;
+use Spiral\Core\Attribute\Scope;
 use Spiral\Core\ScopeInterface;
 
 /**
  * Auth by specific transport.
  */
+#[Scope('http')]
 final class AuthTransportWithStorageMiddleware implements MiddlewareInterface
 {
-    private readonly MiddlewareInterface $authMiddleware;
+    private readonly AuthTransportMiddleware $authMiddleware;
 
     /**
      * @param ScopeInterface $scope Deprecated, will be removed in v4.0.

--- a/tests/Framework/Bootloader/Http/HttpAuthBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/HttpAuthBootloaderTest.php
@@ -19,6 +19,7 @@ use Spiral\Boot\EnvironmentInterface;
 use Spiral\Bootloader\Auth\HttpAuthBootloader;
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;
+use Spiral\Core\BinderInterface;
 use Spiral\Framework\Spiral;
 use Spiral\Http\CurrentRequest;
 use Spiral\Testing\Attribute\TestScope;
@@ -79,8 +80,11 @@ final class HttpAuthBootloaderTest extends BaseTestCase
     {
         $configs = new ConfigManager($this->createMock(LoaderInterface::class));
 
-        $bootloader = new HttpAuthBootloader($configs, $this->getContainer());
-        $bootloader->init($this->getContainer()->get(EnvironmentInterface::class));
+        $bootloader = new HttpAuthBootloader($configs);
+        $bootloader->init(
+            $this->getContainer()->get(EnvironmentInterface::class),
+            $this->getContainer()->get(BinderInterface::class),
+        );
 
         /** @var HeaderTransport $headerTransport */
         $headerTransport = $configs->getConfig(AuthConfig::CONFIG)['transports']['header'];
@@ -118,8 +122,10 @@ final class HttpAuthBootloaderTest extends BaseTestCase
         };
         $configs = new ConfigManager($loader);
 
-        $bootloader = new HttpAuthBootloader($configs, $this->getContainer());
-        $bootloader->init($this->getContainer()->get(EnvironmentInterface::class));
+        $bootloader = new HttpAuthBootloader($configs);
+        $bootloader->init($this->getContainer()->get(EnvironmentInterface::class),
+            $this->getContainer()->get(BinderInterface::class),
+        );
 
         /** @var HeaderTransport $headerTransport */
         $headerTransport = $configs->getConfig(AuthConfig::CONFIG)['transports']['header'];


### PR DESCRIPTION
Overriding services like `TokenStorage` in the HTTP scope should be considered in HTTP middleware.