### PR TITLE
refactor: add closure void return type via rector type declaration set level 0

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -115,4 +115,5 @@ return RectorConfig::configure()
     ->withComposerBased(phpunit: true)
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
-    ]);
+    ])
+    ->withTypeCoverageLevel(0);

--- a/src/AuthHttp/tests/AuthTransportWithStorageMiddlewareTest.php
+++ b/src/AuthHttp/tests/AuthTransportWithStorageMiddlewareTest.php
@@ -33,7 +33,7 @@ final class AuthTransportWithStorageMiddlewareTest extends BaseTestCase
         $request
             ->expects($this->exactly(2))
             ->method('withAttribute')
-            ->willReturnCallback(function (string $key, string $value) use ($matcher, $tokenStorage) {
+            ->willReturnCallback(function (string $key, string $value) use ($matcher, $tokenStorage): void {
                 match ($matcher->numberOfInvocations()) {
                     1 =>  $this->assertInstanceOf(AuthContextInterface::class, $value),
                     2 =>  $this->assertSame($tokenStorage, $value),

--- a/src/Boot/tests/BootloadManager/BootloadManagerTest.php
+++ b/src/Boot/tests/BootloadManager/BootloadManagerTest.php
@@ -33,11 +33,11 @@ final class BootloadManagerTest extends TestCase
             SampleBootWithMethodBoot::class,
             SampleBoot::class,
         ], [
-            static function(Container $container, SampleBoot $boot) {
+            static function(Container $container, SampleBoot $boot): void {
                 $container->bind('efg', $boot);
             }
         ], [
-            static function(Container $container, SampleBoot $boot) {
+            static function(Container $container, SampleBoot $boot): void {
                 $container->bind('ghi', $boot);
             }
         ]);

--- a/src/Boot/tests/BootloadManager/BootloadersTest.php
+++ b/src/Boot/tests/BootloadManager/BootloadersTest.php
@@ -26,11 +26,11 @@ final class BootloadersTest extends TestCase
             SampleBootWithMethodBoot::class,
             SampleBoot::class,
         ], [
-            static function(Container $container, SampleBoot $boot) {
+            static function(Container $container, SampleBoot $boot): void {
                 $container->bind('efg', $boot);
             }
         ], [
-            static function(Container $container, SampleBoot $boot) {
+            static function(Container $container, SampleBoot $boot): void {
                 $container->bind('ghi', $boot);
             }
         ]);

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -124,19 +124,19 @@ class KernelTest extends TestCase
     {
         $kernel = TestCore::create(['root' => __DIR__]);
 
-        $kernel->booting(static function (TestCore $core) {
+        $kernel->booting(static function (TestCore $core): void {
             $core->getContainer()->bind('abc', 'foo');
         });
 
-        $kernel->booting(static function (TestCore $core) {
+        $kernel->booting(static function (TestCore $core): void {
             $core->getContainer()->bind('bcd', 'foo');
         });
 
-        $kernel->booted( static function (TestCore $core) {
+        $kernel->booted( static function (TestCore $core): void {
             $core->getContainer()->bind('cde', 'foo');
         });
 
-        $kernel->booted( static function (TestCore $core) {
+        $kernel->booted( static function (TestCore $core): void {
             $core->getContainer()->bind('def', 'foo');
         });
 

--- a/src/Core/tests/Scope/ExceptionsTest.php
+++ b/src/Core/tests/Scope/ExceptionsTest.php
@@ -20,7 +20,7 @@ final class ExceptionsTest extends BaseTestCase
 
         $container = new Container();
 
-        $container->runScoped(static function (Container $c1) {
+        $container->runScoped(static function (Container $c1): void {
             try {
                 $c1->get(ExceptionConstructor::class);
                 self::fail('Exception should be thrown');
@@ -38,7 +38,7 @@ final class ExceptionsTest extends BaseTestCase
 
         $container = new Container();
 
-        $container->runScoped(static function (Container $c1) {
+        $container->runScoped(static function (Container $c1): void {
             try {
                 $c1->get(ExceptionConstructor::class);
                 self::fail('Exception should be thrown');
@@ -56,7 +56,7 @@ final class ExceptionsTest extends BaseTestCase
 
         $container = new Container();
 
-        $container->runScoped(static function (Container $c1) {
+        $container->runScoped(static function (Container $c1): void {
             try {
                 $c1->get(DatetimeCarrier::class);
                 self::fail('Exception should be thrown');

--- a/src/Core/tests/Scope/FibersTest.php
+++ b/src/Core/tests/Scope/FibersTest.php
@@ -30,7 +30,7 @@ final class FibersTest extends BaseTestCase
 
         FiberHelper::runInFiber(
             self::functionScopedTestDataIterator(),
-            static function (mixed $suspendValue) {
+            static function (mixed $suspendValue): void {
                 self::assertNull(ContainerScope::getContainer());
                 self::assertTrue(\in_array($suspendValue, self::TEST_DATA, true));
             },

--- a/src/Core/tests/Scope/FinalizeAttributeTest.php
+++ b/src/Core/tests/Scope/FinalizeAttributeTest.php
@@ -125,7 +125,7 @@ final class FinalizeAttributeTest extends BaseTestCase
         self::expectExceptionMessage('An exception has been thrown during finalization of the scope `foo`');
 
         try {
-            $root->runScoped(static function (Container $c1) {
+            $root->runScoped(static function (Container $c1): void {
                 $obj = $c1->get(AttrScopeFooFinalize::class);
                 $obj->throwException = true;
             }, name: 'foo');
@@ -154,7 +154,7 @@ final class FinalizeAttributeTest extends BaseTestCase
         self::expectExceptionMessage('3 exceptions have been thrown during finalization of the scope `foo`');
 
         try {
-            $root->runScoped(static function (Container $c1) {
+            $root->runScoped(static function (Container $c1): void {
                 $c1->get(AttrScopeFooFinalize::class)->throwException = true;
                 $c1->get(AttrScopeFooFinalize::class)->throwException = true;
                 $c1->get(AttrScopeFooFinalize::class)->throwException = true;

--- a/src/Core/tests/Scope/ProxyTest.php
+++ b/src/Core/tests/Scope/ProxyTest.php
@@ -45,7 +45,7 @@ final class ProxyTest extends BaseTestCase
                         LoggerInterface::class => KVLogger::class,
                     ],
                 ),
-                static function (ScopedProxyLoggerCarrier $carrier, LoggerInterface $logger) use ($lc) {
+                static function (ScopedProxyLoggerCarrier $carrier, LoggerInterface $logger) use ($lc): void {
                     // from the current `foo` scope
                     self::assertInstanceOf(KVLogger::class, $logger);
 
@@ -65,7 +65,7 @@ final class ProxyTest extends BaseTestCase
                         LoggerInterface::class => FileLogger::class,
                     ],
                 ),
-                static function (ScopedProxyLoggerCarrier $carrier, LoggerInterface $logger) use ($lc) {
+                static function (ScopedProxyLoggerCarrier $carrier, LoggerInterface $logger) use ($lc): void {
                     // from the current `foo` scope
                     self::assertInstanceOf(FileLogger::class, $logger);
 
@@ -86,14 +86,14 @@ final class ProxyTest extends BaseTestCase
         $root = new Container();
         $root->getBinder('http')->bindSingleton(LoggerInterface::class, KVLogger::class);
 
-        $root->runScope(new Scope(), static function (Container $c1) {
+        $root->runScope(new Scope(), static function (Container $c1): void {
             $c1->runScope(
                 new Scope(name: 'http'),
                 static function (
                     ScopedProxyLoggerCarrier $carrier,
                     ScopedProxyLoggerCarrier $carrier2,
                     LoggerInterface $logger,
-                ) {
+                ): void {
                     // from the current `foo` scope
                     self::assertInstanceOf(KVLogger::class, $logger);
 
@@ -113,10 +113,10 @@ final class ProxyTest extends BaseTestCase
         $root = new Container();
         $root->getBinder('foo')->bind(LoggerInterface::class, KVLogger::class);
 
-        $root->runScope(new Scope(), static function (Container $c1) {
+        $root->runScope(new Scope(), static function (Container $c1): void {
             $c1->runScope(
                 new Scope(name: 'foo'),
-                static function (ScopedProxyLoggerCarrier $carrier, LoggerInterface $logger) {
+                static function (ScopedProxyLoggerCarrier $carrier, LoggerInterface $logger): void {
                     // from the current `foo` scope
                     self::assertInstanceOf(KVLogger::class, $logger);
 
@@ -146,8 +146,8 @@ final class ProxyTest extends BaseTestCase
                 ),
             );
 
-        $root->runScope(new Scope(), static function (Container $c1) {
-            $c1->runScope(new Scope(name: 'foo'), static function (Container $c, ContextInterface $param) {
+        $root->runScope(new Scope(), static function (Container $c1): void {
+            $c1->runScope(new Scope(name: 'foo'), static function (Container $c, ContextInterface $param): void {
                 self::assertInstanceOf(ReflectionParameter::class, $param->value);
                 self::assertSame('param', $param->value->getName());
 
@@ -188,14 +188,14 @@ final class ProxyTest extends BaseTestCase
             );
 
         FiberHelper::runFiberSequence(
-            static fn() => $root->runScope(new Scope(name: 'foo'), static function (ContextInterface $ctx) {
+            static fn() => $root->runScope(new Scope(name: 'foo'), static function (ContextInterface $ctx): void {
                 for ($i = 0; $i < 10; $i++) {
                     self::assertInstanceOf(ReflectionParameter::class, $ctx->getValue(), 'Context injected');
                     self::assertSame('ctx', $ctx->getValue()->getName());
                     \Fiber::suspend();
                 }
             }),
-            static fn() => $root->runScope(new Scope(name: 'foo'), static function (ContextInterface $context) {
+            static fn() => $root->runScope(new Scope(name: 'foo'), static function (ContextInterface $context): void {
                 for ($i = 0; $i < 10; $i++) {
                     self::assertInstanceOf(ReflectionParameter::class, $context->getValue(), 'Context injected');
                     self::assertSame('context', $context->getValue()->getName());
@@ -212,8 +212,8 @@ final class ProxyTest extends BaseTestCase
 
         $root->runScope(
             new Scope(),
-            static function (#[Proxy] ContainerInterface $cp) use ($root) {
-                $root->runScope(new Scope(name: 'http'), static function (ContainerInterface $c) use ($cp) {
+            static function (#[Proxy] ContainerInterface $cp) use ($root): void {
+                $root->runScope(new Scope(name: 'http'), static function (ContainerInterface $c) use ($cp): void {
                     self::assertNotSame($c, $cp);
                     self::assertSame($c, $cp->get(ContainerInterface::class));
                     self::assertInstanceOf(KVLogger::class, $cp->get(LoggerInterface::class));
@@ -286,7 +286,7 @@ final class ProxyTest extends BaseTestCase
 
         $root->runScope(
             new Scope('http'),
-            static function () use ($root, $proxy) {
+            static function () use ($root, $proxy): void {
                 self::assertSame('Foo', $proxy->getName());
                 $proxy->setName(new class implements \Stringable {
                     public function __toString(): string
@@ -353,9 +353,9 @@ final class ProxyTest extends BaseTestCase
 
         $root->runScope(
             new Scope(),
-            static function (#[Proxy] ContainerInterface $proxy, ContainerInterface $scoped) {
+            static function (#[Proxy] ContainerInterface $proxy, ContainerInterface $scoped): void {
                 self::assertNotSame($scoped, $proxy);
-                ContainerScope::runScope($proxy, static function (ContainerInterface $passed) use ($proxy, $scoped) {
+                ContainerScope::runScope($proxy, static function (ContainerInterface $passed) use ($proxy, $scoped): void {
                     self::assertNotSame($passed, $proxy);
                     self::assertSame($scoped, ContainerScope::getContainer());
                 });

--- a/src/Core/tests/Scope/ScopeAttributeTest.php
+++ b/src/Core/tests/Scope/ScopeAttributeTest.php
@@ -39,8 +39,8 @@ final class ScopeAttributeTest extends BaseTestCase
     {
         $root = self::makeContainer();
 
-        $root->runScoped(static function (Container $c1) {
-            $c1->runScoped(static function (Container $c2) use ($c1) {
+        $root->runScoped(static function (Container $c1): void {
+            $c1->runScoped(static function (Container $c2) use ($c1): void {
                 $obj1 = $c1->get(AttrScopeFooSingleton::class);
                 $obj2 = $c2->get(AttrScopeFooSingleton::class);
 
@@ -54,8 +54,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer();
         $root->getBinder('bar')->bindSingleton('binding', static fn () => new AttrScopeFoo());
 
-        $root->runScoped(static function (Container $fooScope) {
-            $fooScope->runScoped(static function (Container $container) {
+        $root->runScoped(static function (Container $fooScope): void {
+            $fooScope->runScoped(static function (Container $container): void {
                 self::assertInstanceOf(AttrScopeFoo::class, $container->get('binding'));
             }, name: 'bar');
         }, name: 'foo');
@@ -69,8 +69,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer();
         $root->getBinder('bar')->bindSingleton('binding', static fn () => new AttrScopeFoo());
 
-        $root->runScoped(static function (Container $fooScope) {
-            $fooScope->runScoped(static function (Container $container) {
+        $root->runScoped(static function (Container $fooScope): void {
+            $fooScope->runScoped(static function (Container $container): void {
                 $container->get('binding');
             }, name: 'bar');
         }, name: 'baz');
@@ -81,8 +81,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer(checkScope: false);
         $root->getBinder('bar')->bindSingleton('binding', static fn () => new AttrScopeFoo());
 
-        $root->runScoped(static function (Container $fooScope) {
-            $fooScope->runScoped(static function (Container $container) {
+        $root->runScoped(static function (Container $fooScope): void {
+            $fooScope->runScoped(static function (Container $container): void {
                 self::assertInstanceOf(AttrScopeFoo::class, $container->get('binding'));
             }, name: 'bar');
         }, name: 'baz');
@@ -101,8 +101,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer();
         $root->bind('foo', self::makeFooScopeObject(...));
 
-        $root->runScoped(static function (Container $c1) {
-            $c1->runScoped(static function (Container $c2) {
+        $root->runScoped(static function (Container $c1): void {
+            $c1->runScoped(static function (Container $c2): void {
                 $c2->get('foo');
             }, name: 'foo');
         });
@@ -114,8 +114,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer(checkScope: false);
         $root->bind('foo', self::makeFooScopeObject(...));
 
-        $root->runScoped(static function (Container $c1) {
-            $c1->runScoped(static function (Container $c2) {
+        $root->runScoped(static function (Container $c1): void {
+            $c1->runScoped(static function (Container $c2): void {
                 self::assertInstanceOf(AttrScopeFoo::class, $c2->get('foo'));
             }, name: 'foo');
         });
@@ -133,8 +133,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer();
         $root->bind('foo', self::makeFooScopeObject(...));
 
-        $root->runScoped(static function (Container $c1) {
-            $c1->runScoped(static function (Container $c2) {
+        $root->runScoped(static function (Container $c1): void {
+            $c1->runScoped(static function (Container $c2): void {
                 $c2->get('foo');
             });
         });
@@ -146,8 +146,8 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer(checkScope: false);
         $root->bind('foo', self::makeFooScopeObject(...));
 
-        $root->runScoped(static function (Container $c1) {
-            $c1->runScoped(static function (Container $c2) {
+        $root->runScoped(static function (Container $c1): void {
+            $c1->runScoped(static function (Container $c2): void {
                 self::assertInstanceOf(AttrScopeFoo::class, $c2->get('foo'));
             });
         });
@@ -166,9 +166,9 @@ final class ScopeAttributeTest extends BaseTestCase
         $root = self::makeContainer();
 
         try {
-            $root->runScoped(static function (Container $c1) {
-                $c1->runScoped(static function (Container $c2) {
-                    $c2->runScoped(static function (Container $c3) {
+            $root->runScoped(static function (Container $c1): void {
+                $c1->runScoped(static function (Container $c2): void {
+                    $c2->runScoped(static function (Container $c3): void {
                         // do nothing
                     }, name: 'root');
                 });
@@ -190,8 +190,8 @@ final class ScopeAttributeTest extends BaseTestCase
 
         try {
             $root = self::makeContainer();
-            $root->runScoped(static function (Container $c1) {
-                $c1->runScoped(static function (Container $c2) {
+            $root->runScoped(static function (Container $c1): void {
+                $c1->runScoped(static function (Container $c2): void {
                     $c2->get(AttrScopeFoo::class);
                 });
             }, name: 'bar');

--- a/src/Core/tests/Scope/SideEffectTest.php
+++ b/src/Core/tests/Scope/SideEffectTest.php
@@ -25,10 +25,10 @@ final class SideEffectTest extends BaseTestCase
         $root = new Container();
         $root->bind(LoggerInterface::class, KVLogger::class);
 
-        $root->runScope(new Scope(), static function (Container $c1) {
+        $root->runScope(new Scope(), static function (Container $c1): void {
             $c1->bind(LoggerInterface::class, FileLogger::class);
 
-            $c1->runScope(new Scope(), static function (LoggerCarrier $carrier, LoggerInterface $logger) {
+            $c1->runScope(new Scope(), static function (LoggerCarrier $carrier, LoggerInterface $logger): void {
                 // from the $root container
                 self::assertInstanceOf(KVLogger::class, $carrier->logger);
                 // from the $c1 container
@@ -42,7 +42,7 @@ final class SideEffectTest extends BaseTestCase
         $root = new Container();
         $root->bind(LoggerInterface::class, KVLogger::class);
 
-        $root->runScope(new Scope(), static function (Container $c1) {
+        $root->runScope(new Scope(), static function (Container $c1): void {
             $c1->bind(LoggerInterface::class, FileLogger::class);
 
             self::assertInstanceOf(

--- a/src/Core/tests/Scope/UseCaseTest.php
+++ b/src/Core/tests/Scope/UseCaseTest.php
@@ -34,7 +34,7 @@ final class UseCaseTest extends BaseTestCase
         $root = new Container();
         $root->bind('foo', SampleClass::class);
 
-        $root->runScoped(function (ContainerInterface $c1) {
+        $root->runScoped(function (ContainerInterface $c1): void {
             $c1->get('foo');
         }, bindings: ['foo' => SampleClass::class]);
 
@@ -67,7 +67,7 @@ final class UseCaseTest extends BaseTestCase
     {
         $root = new Container();
 
-        $root->runScoped(function (ContainerInterface $c1) use ($theSame, $alias) {
+        $root->runScoped(function (ContainerInterface $c1) use ($theSame, $alias): void {
             $obj1 = $c1->get($alias);
             $obj2 = $c1->get($alias);
 
@@ -92,14 +92,14 @@ final class UseCaseTest extends BaseTestCase
     {
         $root = new Container();
 
-        $root->runScoped(function (ContainerInterface $c1) use ($root) {
+        $root->runScoped(function (ContainerInterface $c1) use ($root): void {
             $obj1 = $c1->get('foo');
             $this->weakMap->offsetSet($obj1, true);
 
             self::assertNotSame($root, $c1);
             self::assertInstanceOf(stdClass::class, $obj1);
 
-            $c1->runScoped(function (ContainerInterface $c2) use ($root, $c1, $obj1) {
+            $c1->runScoped(function (ContainerInterface $c2) use ($root, $c1, $obj1): void {
                 $obj2 = $c2->get('foo');
                 $this->weakMap->offsetSet($obj2, true);
 
@@ -128,14 +128,14 @@ final class UseCaseTest extends BaseTestCase
         $root->bindSingleton('bar', [Factory::class, 'makeStdClass']);
         $root->bind(stdClass::class, new stdClass());
 
-        $root->runScoped(function (ContainerInterface $c1) use ($root) {
+        $root->runScoped(function (ContainerInterface $c1) use ($root): void {
             $obj1 = $c1->get('foo');
             $this->weakMap->offsetSet($obj1, true);
 
             self::assertInstanceOf(stdClass::class, $obj1);
             // Singleton must be the same
             self::assertSame($c1->get('bar'), $root->get('bar'));
-            $c1->runScoped(function (ContainerInterface $c2) use ($root, $obj1) {
+            $c1->runScoped(function (ContainerInterface $c2) use ($root, $obj1): void {
                 $obj2 = $c2->get('foo');
 
                 self::assertInstanceOf(stdClass::class, $obj2);
@@ -268,7 +268,7 @@ final class UseCaseTest extends BaseTestCase
     {
         $root = new Container();
 
-        $root->invoke(static function () use ($root) {
+        $root->invoke(static function () use ($root): void {
             self::assertNotNull(\Spiral\Core\ContainerScope::getContainer());
             self::assertSame($root, \Spiral\Core\ContainerScope::getContainer());
         });
@@ -277,7 +277,7 @@ final class UseCaseTest extends BaseTestCase
     public function testRegisterContainerOnGet(): void
     {
         $root = new Container();
-        $root->bind('foo', function () use ($root) {
+        $root->bind('foo', function () use ($root): void {
             self::assertNotNull(\Spiral\Core\ContainerScope::getContainer());
             self::assertSame($root, \Spiral\Core\ContainerScope::getContainer());
         });
@@ -288,7 +288,7 @@ final class UseCaseTest extends BaseTestCase
     public function testRegisterContainerOnMake(): void
     {
         $root = new Container();
-        $root->bind('foo', function () use ($root) {
+        $root->bind('foo', function () use ($root): void {
             self::assertNotNull(\Spiral\Core\ContainerScope::getContainer());
             self::assertSame($root, \Spiral\Core\ContainerScope::getContainer());
         });
@@ -306,7 +306,7 @@ final class UseCaseTest extends BaseTestCase
         $root->bind('isFoo', new Scalar(false));
         $root->getBinder('foo')->bind('isFoo', new Scalar(true));
 
-        $root->bind('foo', function (#[Proxy] ContainerInterface $c, ContainerInterface $r) use ($root) {
+        $root->bind('foo', function (#[Proxy] ContainerInterface $c, ContainerInterface $r) use ($root): void {
             // Direct
             self::assertNotNull(\Spiral\Core\ContainerScope::getContainer());
             self::assertNotSame($root, \Spiral\Core\ContainerScope::getContainer());
@@ -321,7 +321,7 @@ final class UseCaseTest extends BaseTestCase
 
         $root->runScope(
             new Scope('foo'),
-            function (ContainerInterface $c) {
+            function (ContainerInterface $c): void {
                 self::assertTrue($c->get('isFoo'));
                 $c->get('foo');
             }
@@ -334,7 +334,7 @@ final class UseCaseTest extends BaseTestCase
         $root = new Container();
         $root->getBinder($scope)->bindSingleton('foo', SampleClass::class);
 
-        $root->runScope(new Scope($scope), function (Container $container) {
+        $root->runScope(new Scope($scope), function (Container $container): void {
             $this->assertTrue($container->has('foo'));
             $this->assertInstanceOf(SampleClass::class, $container->get('foo'));
         });
@@ -346,20 +346,20 @@ final class UseCaseTest extends BaseTestCase
         $root = new Container();
         $root->bindSingleton('sampleClass', SampleClass::class);
 
-        $root->runScope(new Scope('foo'), function (Container $container) {
+        $root->runScope(new Scope('foo'), function (Container $container): void {
             $this->assertTrue($container->has('sampleClass'));
         });
 
-        $root->runScope(new Scope('foo'), function (Container $container) {
-            $container->runScope(new Scope('bar'), function (Container $container) {
+        $root->runScope(new Scope('foo'), function (Container $container): void {
+            $container->runScope(new Scope('bar'), function (Container $container): void {
                 $this->assertTrue($container->has('sampleClass'));
             });
         });
 
-        $root->runScope(new Scope('foo'), function (Container $container) {
+        $root->runScope(new Scope('foo'), function (Container $container): void {
             $container->bindSingleton('otherClass', SampleClass::class);
 
-            $container->runScope(new Scope('bar'), function (Container $container) {
+            $container->runScope(new Scope('bar'), function (Container $container): void {
                 $this->assertTrue($container->has('sampleClass'));
                 $this->assertTrue($container->has('otherClass'));
             });
@@ -371,33 +371,33 @@ final class UseCaseTest extends BaseTestCase
         $root = new Container();
         $root->getBinder('foo')->bindSingleton('sampleClass', AttrScopeFoo::class);
 
-        $root->runScope(new Scope('foo'), function (Container $container) {
+        $root->runScope(new Scope('foo'), function (Container $container): void {
             $this->assertTrue($container->has('sampleClass'));
         });
 
-        $root->runScope(new Scope('bar'), function (Container $container) {
+        $root->runScope(new Scope('bar'), function (Container $container): void {
             $this->assertFalse($container->has('sampleClass'));
         });
 
-        $root->runScope(new Scope('foo'), function (Container $container) {
-            $container->runScope(new Scope('bar'), function (Container $container) {
+        $root->runScope(new Scope('foo'), function (Container $container): void {
+            $container->runScope(new Scope('bar'), function (Container $container): void {
                 $this->assertTrue($container->has('sampleClass'));
             });
         });
 
-        $root->runScope(new Scope('foo'), function (Container $container) {
+        $root->runScope(new Scope('foo'), function (Container $container): void {
             $container->bindSingleton('otherClass', AttrScopeFoo::class);
 
-            $container->runScope(new Scope('bar'), function (Container $container) {
+            $container->runScope(new Scope('bar'), function (Container $container): void {
                 $this->assertTrue($container->has('sampleClass'));
                 $this->assertTrue($container->has('otherClass'));
             });
         });
 
-        $root->runScope(new Scope('baz'), function (Container $container) {
+        $root->runScope(new Scope('baz'), function (Container $container): void {
             $container->getBinder('foo')->bindSingleton('otherClass', AttrScopeFoo::class);
 
-            $container->runScope(new Scope('bar'), function (Container $container) {
+            $container->runScope(new Scope('bar'), function (Container $container): void {
                 $this->assertFalse($container->has('sampleClass'));
                 $this->assertFalse($container->has('otherClass'));
             });

--- a/src/Core/tests/ScopesTest.php
+++ b/src/Core/tests/ScopesTest.php
@@ -141,7 +141,7 @@ class ScopesTest extends TestCase
         $container->bindSingleton('test', new #[Singleton] class {});
         $container->make('test');
 
-        $container->runScoped(function (Container $container) {
+        $container->runScoped(function (Container $container): void {
             $this->assertTrue($container->hasInstance('test'));
         });
     }
@@ -152,7 +152,7 @@ class ScopesTest extends TestCase
         $container->bindSingleton('test', SampleClass::class);
         $container->make('test');
 
-        $container->runScoped(function (Container $container) {
+        $container->runScoped(function (Container $container): void {
             $this->assertTrue($container->hasInstance('test'));
         });
     }
@@ -167,7 +167,7 @@ class ScopesTest extends TestCase
         $container->bindSingleton('bar', 'foo');
         $container->make('bar');
 
-        $container->runScoped(function (Container $container) {
+        $container->runScoped(function (Container $container): void {
             $this->assertTrue($container->hasInstance('bar'));
         });
     }

--- a/src/Events/tests/AutowireListenerFactoryTest.php
+++ b/src/Events/tests/AutowireListenerFactoryTest.php
@@ -44,7 +44,7 @@ final class AutowireListenerFactoryTest extends TestCase
 
         $this->listener->shouldReceive('onFooEvent')->once()->with($this->ev);
 
-        ContainerScope::runScope($this->container, function () {
+        ContainerScope::runScope($this->container, function (): void {
             $listener = $this->factory->create(ClassAndMethodAttribute::class, 'onFooEvent');
             $listener($this->ev);
         });
@@ -54,7 +54,7 @@ final class AutowireListenerFactoryTest extends TestCase
     {
         $this->listener->shouldReceive('onFooEvent')->once()->with($this->ev);
 
-        ContainerScope::runScope($this->container, function () {
+        ContainerScope::runScope($this->container, function (): void {
             $listener = $this->factory->create($this->listener, 'onFooEvent');
             $listener($this->ev);
         });
@@ -76,7 +76,7 @@ final class AutowireListenerFactoryTest extends TestCase
             ->once()
             ->with([$this->listener, 'onFooEventWithTwoArguments'], ['event' => $this->ev]);
 
-        ContainerScope::runScope($this->container, function () {
+        ContainerScope::runScope($this->container, function (): void {
             $listener = $this->factory->create(ClassAndMethodAttribute::class, 'onFooEventWithTwoArguments');
             $listener($this->ev);
         });
@@ -93,7 +93,7 @@ final class AutowireListenerFactoryTest extends TestCase
             ->once()
             ->with([$this->listener, 'onFooEventWithTwoArguments'], ['event' => $this->ev]);
 
-        ContainerScope::runScope($this->container, function () {
+        ContainerScope::runScope($this->container, function (): void {
             $listener = $this->factory->create($this->listener, 'onFooEventWithTwoArguments');
             $listener($this->ev);
         });
@@ -106,7 +106,7 @@ final class AutowireListenerFactoryTest extends TestCase
             'Listener `Spiral\Tests\Events\Fixtures\Listener\ClassAndMethodAttribute` does not contain `test` method.'
         );
 
-        ContainerScope::runScope($this->container, function () {
+        ContainerScope::runScope($this->container, function (): void {
             $this->factory->create(ClassAndMethodAttribute::class, 'test');
         });
     }

--- a/src/Http/tests/PipelineTest.php
+++ b/src/Http/tests/PipelineTest.php
@@ -107,7 +107,7 @@ final class PipelineTest extends TestCase
 
         $this->container->runScope(
             new \Spiral\Core\Scope(name: 'http'),
-            function (ScopeInterface $c) use ($middleware) {
+            function (ScopeInterface $c) use ($middleware): void {
                 $request = new ServerRequest('GET', '');
                 $handler = new CallableHandler(fn() => 'response', new ResponseFactory(new HttpConfig(['headers' => []])));
 

--- a/src/Logger/tests/FactoryTest.php
+++ b/src/Logger/tests/FactoryTest.php
@@ -93,7 +93,7 @@ class FactoryTest extends TestCase
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([LoggerBootloader::class]);
         $this->container->bindSingleton(LogsInterface::class, $factory);
 
-        $this->container->invoke(function (#[LoggerChannel('foo')] LoggerInterface $logger) {
+        $this->container->invoke(function (#[LoggerChannel('foo')] LoggerInterface $logger): void {
             $this->assertSame('foo', $logger->getName());
         });
     }

--- a/src/Queue/tests/Interceptor/Push/CoreTest.php
+++ b/src/Queue/tests/Interceptor/Push/CoreTest.php
@@ -84,7 +84,7 @@ final class CoreTest extends TestCase
                 && $payload === ['baz' => 'baf']
                 && $options->getHeader('foo') === ['bar']);
 
-        ContainerScope::runScope($container, function() use($core) {
+        ContainerScope::runScope($container, function() use($core): void {
             $core->callAction('foo', 'bar', [
                 'id' => 'job-id',
                 'payload' => ['baz' => 'baf'],

--- a/src/Telemetry/tests/NullTracerTest.php
+++ b/src/Telemetry/tests/NullTracerTest.php
@@ -78,7 +78,7 @@ final class NullTracerTest extends TestCase
             ->with(SpanInterface::class);
         $scope->shouldNotReceive('runScope');
 
-        ContainerScope::runScope($container, function () use ($tracer, $callable) {
+        ContainerScope::runScope($container, function () use ($tracer, $callable): void {
             $this->assertSame(
                 'hello',
                 $tracer->trace('foo', $callable, ['foo' => 'bar'])

--- a/src/Tokenizer/src/AbstractLocator.php
+++ b/src/Tokenizer/src/AbstractLocator.php
@@ -68,7 +68,7 @@ abstract class AbstractLocator implements InjectableInterface, LoggerAwareInterf
      */
     protected function classReflection(string $class): \ReflectionClass
     {
-        $loader = static function ($class) {
+        $loader = static function ($class): void {
             if ($class === LocatorException::class) {
                 return;
             }

--- a/tests/Framework/Bootloader/Prototype/PrototypeBootloaderTest.php
+++ b/tests/Framework/Bootloader/Prototype/PrototypeBootloaderTest.php
@@ -18,7 +18,7 @@ final class PrototypeBootloaderTest extends BaseTestCase
 {
     protected function setUp(): void
     {
-        $this->beforeBooting(function (PrototypeBootloader $bootloader) {
+        $this->beforeBooting(function (PrototypeBootloader $bootloader): void {
             $bootloader->bindProperty(
                 'service.client.http',
                 HttpClient::class

--- a/tests/Framework/Bootloader/Tokenizer/TokenizerListenerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Tokenizer/TokenizerListenerBootloaderTest.php
@@ -21,7 +21,7 @@ final class TokenizerListenerBootloaderTest extends BaseTestCase
 
     protected function setUp(): void
     {
-        $this->beforeBooting(function (TokenizerListenerBootloader $bootloader) {
+        $this->beforeBooting(function (TokenizerListenerBootloader $bootloader): void {
             $bootloader->addListener(
                 new class($this->classes, $this->finalized) implements TokenizationListenerInterface {
 

--- a/tests/Framework/Command/Tokenizer/ValidateCommandTest.php
+++ b/tests/Framework/Command/Tokenizer/ValidateCommandTest.php
@@ -16,7 +16,7 @@ final class ValidateCommandTest extends ConsoleTestCase
 {
     public function testValidate(): void
     {
-        $this->beforeBooting(function (TokenizerListenerBootloader $tokenizer) {
+        $this->beforeBooting(function (TokenizerListenerBootloader $tokenizer): void {
             $tokenizer->addListener(new InvalidListener());
         });
         $this->initApp();

--- a/tests/Framework/Framework/KernelTest.php
+++ b/tests/Framework/Framework/KernelTest.php
@@ -13,19 +13,19 @@ final class KernelTest extends BaseTestCase
     {
         $kernel = $this->createAppInstance();
 
-        $kernel->appBooting(static function (TestApp $core) {
+        $kernel->appBooting(static function (TestApp $core): void {
             $core->getContainer()->bind('abc', 'foo');
         });
 
-        $kernel->appBooting(static function (TestApp $core) {
+        $kernel->appBooting(static function (TestApp $core): void {
             $core->getContainer()->bind('bcd', 'foo');
         });
 
-        $kernel->appBooted(static function (TestApp $core) {
+        $kernel->appBooted(static function (TestApp $core): void {
             $core->getContainer()->bind('cde', 'foo');
         });
 
-        $kernel->appBooted(static function (TestApp $core) {
+        $kernel->appBooted(static function (TestApp $core): void {
             $core->getContainer()->bind('def', 'foo');
         });
 

--- a/tests/Framework/Http/CookiesTest.php
+++ b/tests/Framework/Http/CookiesTest.php
@@ -43,7 +43,7 @@ final class CookiesTest extends HttpTestCase
     #[TestScope([Spiral::Http, Spiral::HttpRequest])]
     public function testCookieQueueInScope(): void
     {
-        $this->setHttpHandler(static function (ServerRequestInterface $request) {
+        $this->setHttpHandler(static function (ServerRequestInterface $request): void {
             self::assertInstanceOf(
                 CookieQueue::class,
                 ContainerScope::getContainer()->get(ServerRequestInterface::class)->getAttribute(CookieQueue::ATTRIBUTE)

--- a/tests/app/routes/api.php
+++ b/tests/app/routes/api.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Spiral\Router\Loader\Configurator\RoutingConfigurator;
 
-return function (RoutingConfigurator $routes) {
+return function (RoutingConfigurator $routes): void {
     $routes->add('test-import-index', '/test-import')->callable(static fn () => null);
     $routes->add('test-import-posts', '/test-import/posts')->callable(static fn () => null);
     $routes->add('test-import-post', '/test-import/post/<id>')->callable(static fn () => null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

Apply `AddClosureVoidReturnTypeWhereNoReturnRector` to add closure return type void if there is no return