### PR TITLE
refactor: add closure void return type in tests

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -116,4 +116,4 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(0);
+    ->withTypeCoverageLevel(2);

--- a/src/Auth/tests/TokenStorageProviderTest.php
+++ b/src/Auth/tests/TokenStorageProviderTest.php
@@ -137,7 +137,7 @@ class TokenStorageProviderTest extends TestCase
         $this->assertSame($sameStorage, $provider->getStorage('database'));
     }
 
-    public function testGetDifferentStorage()
+    public function testGetDifferentStorage(): void
     {
         $provider = new TokenStorageProvider(
             new AuthConfig([

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -120,7 +120,7 @@ class KernelTest extends TestCase
         );
     }
 
-    public function testBootingCallbacks()
+    public function testBootingCallbacks(): void
     {
         $kernel = TestCore::create(['root' => __DIR__]);
 

--- a/src/Core/tests/Scope/FinalizeAttributeTest.php
+++ b/src/Core/tests/Scope/FinalizeAttributeTest.php
@@ -117,7 +117,7 @@ final class FinalizeAttributeTest extends BaseTestCase
     }
 
     #[Group('scrutinizer-ignore')]
-    public function testExceptionOnDestroy()
+    public function testExceptionOnDestroy(): void
     {
         $root = self::makeContainer();
 
@@ -146,7 +146,7 @@ final class FinalizeAttributeTest extends BaseTestCase
     }
 
     #[Group('scrutinizer-ignore')]
-    public function testManyExceptionsOnDestroy()
+    public function testManyExceptionsOnDestroy(): void
     {
         $root = self::makeContainer();
 

--- a/src/Core/tests/Scope/ProxyTest.php
+++ b/src/Core/tests/Scope/ProxyTest.php
@@ -363,7 +363,7 @@ final class ProxyTest extends BaseTestCase
         );
     }
 
-    public function testProxyFallbackFactory()
+    public function testProxyFallbackFactory(): void
     {
         $root = new Container();
         $root->bind(UserInterface::class, new ProxyConfig(

--- a/src/Mailer/tests/MessageTest.php
+++ b/src/Mailer/tests/MessageTest.php
@@ -113,7 +113,7 @@ class MessageTest extends TestCase
         $this->assertNull($m->getReplyTo());
     }
 
-    public function testSetDelayInSeconds()
+    public function testSetDelayInSeconds(): void
     {
         $m = new Message('test', 'email@domain.com');
         $m->setDelay(100);
@@ -123,7 +123,7 @@ class MessageTest extends TestCase
         ], $m->getOptions());
     }
 
-    public function testSetDelayInDateInterval()
+    public function testSetDelayInDateInterval(): void
     {
         $m = new Message('test', 'email@domain.com');
         $m->setDelay(new \DateInterval('PT56S'));
@@ -133,7 +133,7 @@ class MessageTest extends TestCase
         ], $m->getOptions());
     }
 
-    public function testSetDelayInDateTime()
+    public function testSetDelayInDateTime(): void
     {
         $m = new Message('test', 'email@domain.com');
         $m->setDelay(new \DateTimeImmutable('+ 123 second'));
@@ -143,7 +143,7 @@ class MessageTest extends TestCase
         ], $m->getOptions());
     }
 
-    public function testSetDelayInDateTimeWithPastTime()
+    public function testSetDelayInDateTimeWithPastTime(): void
     {
         $m = new Message('test', 'email@domain.com');
         $m->setDelay(new \DateTimeImmutable('- 123 second'));

--- a/src/Pagination/tests/LimitsTraitTest.php
+++ b/src/Pagination/tests/LimitsTraitTest.php
@@ -29,14 +29,14 @@ class LimitsTraitTest extends TestCase
         $this->trait = $this->getMockForTrait(LimitsTrait::class);
     }
 
-    public function testLimit()
+    public function testLimit(): void
     {
         $this->assertEquals(static::DEFAULT_LIMIT, $this->trait->getLimit());
         $this->assertEquals($this->trait, $this->trait->limit(static::LIMIT));
         $this->assertEquals(static::LIMIT, $this->trait->getLimit());
     }
 
-    public function testOffset()
+    public function testOffset(): void
     {
         $this->assertEquals(static::DEFAULT_OFFSET, $this->trait->getOffset());
         $this->assertEquals($this->trait, $this->trait->offset(static::OFFSET));

--- a/src/Snapshots/tests/SnapshotTest.php
+++ b/src/Snapshots/tests/SnapshotTest.php
@@ -9,7 +9,7 @@ use Spiral\Snapshots\Snapshot;
 
 class SnapshotTest extends TestCase
 {
-    public function testSnapshot()
+    public function testSnapshot(): void
     {
         $e = new \Error("message");
         $s = new Snapshot("id", $e);

--- a/src/Streams/tests/StreamsTest.php
+++ b/src/Streams/tests/StreamsTest.php
@@ -24,7 +24,7 @@ class StreamsTest extends TestCase
         $files->deleteDirectory(self::FIXTURE_DIRECTORY, true);
     }
 
-    public function testGetUri()
+    public function testGetUri(): void
     {
         $stream = Stream::create();
         $stream->write('sample text');
@@ -51,7 +51,7 @@ class StreamsTest extends TestCase
         $this->assertFalse(StreamWrapper::has($newFilename));
     }
 
-    public function testGetResource()
+    public function testGetResource(): void
     {
         $stream = Stream::create();
         $stream->write('sample text');
@@ -74,7 +74,7 @@ class StreamsTest extends TestCase
     /**
      * @requires PHP < 8.0
      */
-    public function testException()
+    public function testException(): void
     {
         try {
             fopen('spiral://non-exists', 'rb');
@@ -92,7 +92,7 @@ class StreamsTest extends TestCase
     /**
      * @requires PHP >= 8.0
      */
-    public function testExceptionPHP8()
+    public function testExceptionPHP8(): void
     {
         try {
             fopen('spiral://non-exists', 'rb');
@@ -107,7 +107,7 @@ class StreamsTest extends TestCase
         }
     }
 
-    public function testWriteIntoStream()
+    public function testWriteIntoStream(): void
     {
         $stream = Stream::create(fopen('php://temp', 'wrb+'));
         $file = StreamWrapper::getFilename($stream);

--- a/src/Tokenizer/tests/ReflectionFileTest.php
+++ b/src/Tokenizer/tests/ReflectionFileTest.php
@@ -113,7 +113,7 @@ class ReflectionFileTest extends TestCase
     }
 }
 
-function hello()
+function hello(): void
 {
 }
 

--- a/tests/Framework/Framework/KernelTest.php
+++ b/tests/Framework/Framework/KernelTest.php
@@ -9,7 +9,7 @@ use Spiral\Tests\Framework\BaseTestCase;
 
 final class KernelTest extends BaseTestCase
 {
-    public function testAppBootingCallbacks()
+    public function testAppBootingCallbacks(): void
     {
         $kernel = $this->createAppInstance();
 

--- a/tests/Framework/SnapshotTest.php
+++ b/tests/Framework/SnapshotTest.php
@@ -9,7 +9,7 @@ use Spiral\Snapshots\SnapshotterInterface;
 
 final class SnapshotTest extends BaseTestCase
 {
-    public function testStringConfigParams()
+    public function testStringConfigParams(): void
     {
         // string important. Emulating string from .env
         $app = $this->makeApp([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

Apply `AddFunctionVoidReturnTypeWhereNoReturnRector` and `AddTestsVoidReturnTypeWhereNoReturnRector` to add void to:

- function
- method in tests