### PR TITLE
refactor: add typed MockObject in tests

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -116,4 +116,4 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(2);
+    ->withTypeCoverageLevel(4);

--- a/src/Pagination/tests/LimitsTraitTest.php
+++ b/src/Pagination/tests/LimitsTraitTest.php
@@ -8,8 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Spiral\Pagination\Traits\LimitsTrait;
 
 /**
- * Class LimitTraitTest
- *
  * @package Spiral\Tests\Pagination\Traits
  */
 class LimitsTraitTest extends TestCase
@@ -19,14 +17,13 @@ class LimitsTraitTest extends TestCase
     public const LIMIT = 10;
     public const OFFSET = 15;
 
-    /**
-     * @var LimitsTrait
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $trait;
+    private object $trait;
 
     public function setUp(): void
     {
-        $this->trait = $this->getMockForTrait(LimitsTrait::class);
+        $this->trait = new class {
+            use LimitsTrait;
+        };
     }
 
     public function testLimit(): void

--- a/src/Pagination/tests/LimitsTraitTest.php
+++ b/src/Pagination/tests/LimitsTraitTest.php
@@ -22,7 +22,7 @@ class LimitsTraitTest extends TestCase
     /**
      * @var LimitsTrait
      */
-    private $trait;
+    private \PHPUnit\Framework\MockObject\MockObject $trait;
 
     public function setUp(): void
     {

--- a/src/Security/tests/GuardTest.php
+++ b/src/Security/tests/GuardTest.php
@@ -19,12 +19,12 @@ class GuardTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|PermissionsInterface
      */
-    private $permission;
+    private \PHPUnit\Framework\MockObject\MockObject $permission;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ActorInterface
      */
-    private $actor;
+    private \PHPUnit\Framework\MockObject\MockObject $actor;
 
     /**
      * @var array

--- a/src/Security/tests/GuardTest.php
+++ b/src/Security/tests/GuardTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Security;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Spiral\Security\ActorInterface;
 use Spiral\Security\Exception\GuardException;
@@ -16,20 +17,11 @@ class GuardTest extends TestCase
     public const OPERATION = 'test';
     public const CONTEXT = [];
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|PermissionsInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $permission;
+    private MockObject&PermissionsInterface $permission;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ActorInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $actor;
+    private MockObject&ActorInterface $actor;
 
-    /**
-     * @var array
-     */
-    private $roles = ['user', 'admin'];
+    private array $roles = ['user', 'admin'];
 
     public function setUp(): void
     {

--- a/src/Security/tests/PermissionManagerTest.php
+++ b/src/Security/tests/PermissionManagerTest.php
@@ -26,7 +26,7 @@ class PermissionManagerTest extends TestCase
     /**
      * @var RulesInterface
      */
-    private $rules;
+    private \PHPUnit\Framework\MockObject\MockObject $rules;
 
     public function setUp(): void
     {

--- a/src/Security/tests/PermissionManagerTest.php
+++ b/src/Security/tests/PermissionManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Security;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Spiral\Security\Exception\PermissionException;
 use Spiral\Security\Exception\RoleException;
@@ -23,10 +24,7 @@ class PermissionManagerTest extends TestCase
     public const ROLE = 'test';
     public const PERMISSION = 'permission';
 
-    /**
-     * @var RulesInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $rules;
+    private MockObject&RulesInterface $rules;
 
     public function setUp(): void
     {

--- a/src/Security/tests/RuleTest.php
+++ b/src/Security/tests/RuleTest.php
@@ -24,17 +24,17 @@ class RuleTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ActorInterface
      */
-    private $actor;
+    private \PHPUnit\Framework\MockObject\MockObject $actor;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ResolverInterface
      */
-    private $resolver;
+    private \PHPUnit\Framework\MockObject\MockObject $resolver;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|Rule
      */
-    private $rule;
+    private \PHPUnit\Framework\MockObject\MockObject $rule;
 
     protected function setUp(): void
     {

--- a/src/Security/tests/RuleTest.php
+++ b/src/Security/tests/RuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Security;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Spiral\Core\ResolverInterface;
 use Spiral\Security\ActorInterface;
@@ -21,20 +22,11 @@ class RuleTest extends TestCase
     public const OPERATION = 'test';
     public const CONTEXT = [];
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ActorInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $actor;
+    private MockObject&ActorInterface $actor;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ResolverInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $resolver;
+    private MockObject&ResolverInterface $resolver;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|Rule
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $rule;
+    private MockObject&Rule $rule;
 
     protected function setUp(): void
     {

--- a/src/Security/tests/Rules/CompositeRuleTest.php
+++ b/src/Security/tests/Rules/CompositeRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Security\Rules;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls;
 use PHPUnit\Framework\TestCase;
 use Spiral\Security\ActorInterface;
@@ -18,10 +19,7 @@ class CompositeRuleTest extends TestCase
     public const OPERATION = 'test';
     public const CONTEXT = [];
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ActorInterface $callable
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $actor;
+    private MockObject&ActorInterface $actor;
 
     public function setUp(): void
     {
@@ -53,10 +51,10 @@ class CompositeRuleTest extends TestCase
         yield [false, OneCompositeRule::class, [$forbidRule, $forbidRule, $forbidRule]];
     }
 
-    
+
     private function createRepository(array $rules): RulesInterface
     {
-        /** @var \PHPUnit\Framework\MockObject\MockObject|RulesInterface $repository */
+        /** @var MockObject|RulesInterface $repository */
         $repository = $this->createMock(RulesInterface::class);
 
         $repository->method('get')

--- a/src/Security/tests/Rules/CompositeRuleTest.php
+++ b/src/Security/tests/Rules/CompositeRuleTest.php
@@ -21,7 +21,7 @@ class CompositeRuleTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ActorInterface $callable
      */
-    private $actor;
+    private \PHPUnit\Framework\MockObject\MockObject $actor;
 
     public function setUp(): void
     {

--- a/src/Security/tests/Traits/GuardedTraitTest.php
+++ b/src/Security/tests/Traits/GuardedTraitTest.php
@@ -22,17 +22,17 @@ class GuardedTraitTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|GuardedTrait
      */
-    private $trait;
+    private \PHPUnit\Framework\MockObject\MockObject $trait;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|GuardInterface
      */
-    private $guard;
+    private \PHPUnit\Framework\MockObject\MockObject $guard;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface
      */
-    private $container;
+    private \PHPUnit\Framework\MockObject\MockObject $container;
 
     public function setUp(): void
     {

--- a/src/Security/tests/Traits/GuardedTraitTest.php
+++ b/src/Security/tests/Traits/GuardedTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Security\Traits;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Spiral\Core\Container;
@@ -19,24 +20,17 @@ class GuardedTraitTest extends TestCase
     public const OPERATION = 'test';
     public const CONTEXT   = [];
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|GuardedTrait
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $trait;
+    private object $trait;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|GuardInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $guard;
+    private MockObject&GuardInterface $guard;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $container;
+    private MockObject&ContainerInterface $container;
 
     public function setUp(): void
     {
-        $this->trait = $this->getMockForTrait(GuardedTrait::class);
+        $this->trait = new class {
+            use GuardedTrait;
+        };
         $this->guard = $this->createMock(GuardInterface::class);
         $this->container = $this->createMock(ContainerInterface::class);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

Apply `ReturnTypeFromMockObjectRector` and `TypedPropertyFromCreateMockAssignRector` to add `MockObject` typed in tests.