### PR TITLE
refactor: add property types on tests classes

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,6 +21,7 @@ use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -120,4 +121,5 @@ return RectorConfig::configure()
     ->withTypeCoverageLevel(5)
     ->withRules([
         ClosureReturnTypeRector::class,
+        TypedPropertyFromStrictSetUpRector::class,
     ]);

--- a/src/Cache/tests/CacheManagerTest.php
+++ b/src/Cache/tests/CacheManagerTest.php
@@ -22,8 +22,7 @@ final class CacheManagerTest extends TestCase
     /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|FactoryInterface */
     private $factory;
 
-    /** @var CacheManager */
-    private $manager;
+    private CacheManager $manager;
 
     protected function setUp(): void
     {

--- a/src/Cache/tests/Config/CacheConfigTest.php
+++ b/src/Cache/tests/Config/CacheConfigTest.php
@@ -10,8 +10,7 @@ use Spiral\Cache\Exception\InvalidArgumentException;
 
 final class CacheConfigTest extends TestCase
 {
-    /** @var CacheConfig */
-    private $config;
+    private CacheConfig $config;
 
     protected function setUp(): void
     {

--- a/src/Cache/tests/Storage/ArrayStorageTest.php
+++ b/src/Cache/tests/Storage/ArrayStorageTest.php
@@ -11,8 +11,7 @@ final class ArrayStorageTest extends TestCase
 {
     public const DEFAULT_TTL = 50;
 
-    /** @var ArrayStorage */
-    private $storage;
+    private ArrayStorage $storage;
 
     protected function setUp(): void
     {

--- a/src/Cache/tests/Storage/FileStorageTest.php
+++ b/src/Cache/tests/Storage/FileStorageTest.php
@@ -20,8 +20,7 @@ final class FileStorageTest extends TestCase
     /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|FilesInterface */
     private $files;
 
-    /** @var FileStorage */
-    private $storage;
+    private FileStorage $storage;
 
     protected function setUp(): void
     {

--- a/src/Core/tests/InvokerTest.php
+++ b/src/Core/tests/InvokerTest.php
@@ -14,8 +14,7 @@ use Spiral\Tests\Core\Fixtures\Storage;
 
 class InvokerTest extends TestCase
 {
-    /** @var Container */
-    private $container;
+    private Container $container;
 
     protected function setUp(): void
     {

--- a/src/Distribution/tests/ManagerTestCase.php
+++ b/src/Distribution/tests/ManagerTestCase.php
@@ -10,15 +10,9 @@ use Spiral\Distribution\Resolver\StaticResolver;
 #[\PHPUnit\Framework\Attributes\Group('unit')]
 class ManagerTestCase extends TestCase
 {
-    /**
-     * @var StaticResolver
-     */
-    private $resolver;
+    private StaticResolver $resolver;
 
-    /**
-     * @var Manager
-     */
-    private $manager;
+    private Manager $manager;
 
     public function setUp(): void
     {

--- a/src/Http/tests/FilesTest.php
+++ b/src/Http/tests/FilesTest.php
@@ -14,15 +14,9 @@ use Nyholm\Psr7\UploadedFile;
 
 class FilesTest extends TestCase
 {
-    /**
-     * @var Container
-     */
-    private $container;
+    private Container $container;
 
-    /**
-     * @var InputManager
-     */
-    private $input;
+    private InputManager $input;
 
     public function setUp(): void
     {

--- a/src/Http/tests/HeadersTest.php
+++ b/src/Http/tests/HeadersTest.php
@@ -12,15 +12,9 @@ use Nyholm\Psr7\ServerRequest;
 
 class HeadersTest extends TestCase
 {
-    /**
-     * @var Container
-     */
-    private $container;
+    private Container $container;
 
-    /**
-     * @var InputManager
-     */
-    private $input;
+    private InputManager $input;
 
     public function setUp(): void
     {

--- a/src/Http/tests/ServerTest.php
+++ b/src/Http/tests/ServerTest.php
@@ -13,15 +13,9 @@ use Nyholm\Psr7\ServerRequest;
 
 class ServerTest extends TestCase
 {
-    /**
-     * @var Container
-     */
-    private $container;
+    private Container $container;
 
-    /**
-     * @var InputManager
-     */
-    private $input;
+    private InputManager $input;
 
     public function setUp(): void
     {

--- a/src/Http/tests/SlicesTest.php
+++ b/src/Http/tests/SlicesTest.php
@@ -12,15 +12,9 @@ use Nyholm\Psr7\ServerRequest;
 
 class SlicesTest extends TestCase
 {
-    /**
-     * @var Container
-     */
-    private $container;
+    private Container $container;
 
-    /**
-     * @var InputManager
-     */
-    private $input;
+    private InputManager $input;
 
     public function setUp(): void
     {

--- a/src/Queue/tests/Job/ObjectJobTest.php
+++ b/src/Queue/tests/Job/ObjectJobTest.php
@@ -12,8 +12,7 @@ use Spiral\Tests\Queue\TestCase;
 
 final class ObjectJobTest extends TestCase
 {
-    /** @var Container */
-    private $container;
+    private Container $container;
 
     protected function setUp(): void
     {

--- a/src/Queue/tests/QueueRegistryTest.php
+++ b/src/Queue/tests/QueueRegistryTest.php
@@ -24,8 +24,7 @@ final class QueueRegistryTest extends TestCase
     private Container $mockContainer;
     /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|HandlerRegistryInterface */
     private $fallbackHandlers;
-    /** @var QueueRegistry */
-    private $registry;
+    private QueueRegistry $registry;
 
     protected function setUp(): void
     {

--- a/src/SendIt/tests/QueueTest.php
+++ b/src/SendIt/tests/QueueTest.php
@@ -17,8 +17,7 @@ class QueueTest extends TestCase
 {
     /** @var m\LegacyMockInterface|m\MockInterface|QueueInterface */
     private $queue;
-    /** @var MailQueue */
-    private $mailer;
+    private MailQueue $mailer;
 
     protected function setUp(): void
     {

--- a/src/Storage/tests/ManagerTestCase.php
+++ b/src/Storage/tests/ManagerTestCase.php
@@ -13,10 +13,7 @@ use Spiral\Storage\Visibility;
 #[\PHPUnit\Framework\Attributes\Group('unit')]
 class ManagerTestCase extends TestCase
 {
-    /**
-     * @var Storage
-     */
-    private $manager;
+    private Storage $manager;
 
     public function setUp(): void
     {

--- a/src/Translator/tests/TraitTest.php
+++ b/src/Translator/tests/TraitTest.php
@@ -26,10 +26,7 @@ class TraitTest extends TestCase
 {
     use TranslatorTrait;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface
-     */
-    private $container;
+    private Container $container;
 
     public function setUp(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

Apply `TypedPropertyFromStrictSetUpRector` to add property types on tests based on `setUp()` method.