### PR TITLE
fix: add strict mode for UriHandler

### DIFF
--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -45,7 +45,10 @@ final class UriHandler
     private string $basePath = '/';
     private ?string $compiled = null;
     private ?string $template = null;
+
     private array $options = [];
+    private array $requiredOptions = [];
+    private bool $strict = false;
 
     private \Closure $pathSegmentEncoder;
 
@@ -61,7 +64,12 @@ final class UriHandler
         $this->patternRegistry = $patternRegistry ?? new DefaultPatternRegistry();
 
         $slugify ??= new Slugify();
-        $this->pathSegmentEncoder = static fn (string $segment): string => $slugify->slugify($segment);
+        $this->pathSegmentEncoder = static fn(string $segment): string => $slugify->slugify($segment);
+    }
+
+    public function setStrict(bool $strict): void
+    {
+        $this->strict = $strict;
     }
 
     /**
@@ -182,8 +190,8 @@ final class UriHandler
         }
 
         $matches = \array_intersect_key(
-            \array_filter($matches, static fn (string $value): bool => $value !== ''),
-            $this->options
+            \array_filter($matches, static fn(string $value): bool => $value !== ''),
+            $this->options,
         );
 
         return \array_merge($this->options, $defaults, $matches);
@@ -201,13 +209,26 @@ final class UriHandler
         $parameters = \array_merge(
             $this->options,
             $defaults,
-            $this->fetchOptions($parameters, $query)
+            $this->fetchOptions($parameters, $query),
         );
 
-        foreach ($this->constrains as $key => $_) {
-            if (empty($parameters[$key])) {
-                throw new UriHandlerException(\sprintf('Unable to generate Uri, parameter `%s` is missing', $key));
-            }
+        $required = \array_keys($this->constrains);
+        $parametersToCheck = $parameters;
+        if ($this->strict) {
+            $required = \array_unique([...$this->requiredOptions, ...$required]);
+            $parametersToCheck = \array_filter($parametersToCheck);
+        }
+
+        $missingParameters = \array_diff($required, \array_keys($parametersToCheck));
+        if ($missingParameters !== []) {
+            throw new UriHandlerException(
+                \sprintf(
+                    \count($missingParameters) === 1
+                        ? 'Unable to generate Uri, parameter `%s` is missing'
+                        : 'Unable to generate Uri, parameters `%s` are missing',
+                    \implode('`, `', $missingParameters),
+                ),
+            );
         }
 
         //Uri without empty blocks (pretty stupid implementation)
@@ -245,7 +266,7 @@ final class UriHandler
                 continue;
             }
 
-            $result[$key] = (string)$parameter;
+            $result[$key] = (string) $parameter;
         }
 
         return $result;
@@ -265,10 +286,7 @@ final class UriHandler
         if ($this->matchHost) {
             $uriString = $uri->getHost() . $path;
         } else {
-            $uriString = \substr($path, \strlen($this->basePath));
-            if ($uriString === false) {
-                $uriString = '';
-            }
+            $uriString = \substr($path, \strlen($this->basePath)) ?: '';
         }
 
         return \trim($uriString, '/');
@@ -289,6 +307,7 @@ final class UriHandler
         $options = [];
         $replaces = [];
 
+        // 1) Build full pattern
         $prefix = \rtrim($this->getPrefix(), '/ ');
         $pattern = \ltrim($this->pattern, '/ ');
         $pattern = $prefix . '/' . $pattern;
@@ -299,6 +318,7 @@ final class UriHandler
             $pattern = '[' . \substr($pattern, 2);
         }
 
+        // 2) Extract variables from the pattern
         if (\preg_match_all('/<(\w+):?(.*?)?>/', $pattern, $matches)) {
             $variables = \array_combine($matches[1], $matches[2]);
 
@@ -309,29 +329,98 @@ final class UriHandler
             }
         }
 
+        // Simplify template
         $template = \preg_replace('/<(\w+):?.*?>/', '<\1>', $pattern);
         $options = \array_fill_keys($options, null);
 
+        // 3) Validate constraints
         foreach ($this->constrains as $key => $value) {
             if ($value instanceof Autofill) {
                 // only forces value replacement, not required to be presented as parameter
                 continue;
             }
 
+            // If a constraint references a param that doesn't appear in the pattern or defaults
             if (!\array_key_exists($key, $options) && !isset($this->defaults[$key])) {
                 throw new ConstrainException(
                     \sprintf(
                         'Route `%s` does not define routing parameter `<%s>`.',
                         $this->pattern,
-                        $key
-                    )
+                        $key,
+                    ),
                 );
             }
         }
 
+        // 4) Compile your final regex pattern
         $this->compiled = '/^' . \strtr($template, $replaces + self::PATTERN_REPLACES) . '$/iu';
         $this->template = \stripslashes(\str_replace('?', '', $template));
         $this->options = $options;
+
+        // 5) Mark which parameters are required vs. optional
+        if ($this->strict) {
+            $this->requiredOptions = $this->findRequiredOptions($pattern, \array_keys($options));
+        }
+    }
+
+    /**
+     * Find which parameters are required based on bracket notation and defaults.
+     *
+     * @param string $pattern The full pattern (with optional segments in [ ])
+     * @param array $paramNames All the parameter names found (e.g. ['id','controller','action'])
+     * @return array List of required parameter names
+     */
+    private function findRequiredOptions(string $pattern, array $paramNames): array
+    {
+        // This array will collect optional vars, either because they're in [ ] or have defaults
+        $optionalVars = [];
+
+        // 1) Identify any variables that appear in optional bracket segments
+        $stack = [];
+        $pos = 0;
+        $length = \strlen($pattern);
+
+        while ($pos < $length) {
+            $char = $pattern[$pos];
+
+            // We enter an optional segment
+            if ($char === '[') {
+                \array_push($stack, '[');
+            } // We exit an optional segment
+            elseif ($char === ']') {
+                \array_pop($stack);
+            } // We see a parameter like <id> or <action:\d+>
+            elseif ($char === '<') {
+                // Find the closing '>'
+                $endPos = \strpos($pattern, '>', $pos);
+                if ($endPos === false) {
+                    break;
+                }
+
+                // The inside is something like 'id:\d+' or just 'id'
+                $varPart = \substr($pattern, $pos + 1, $endPos - $pos - 1);
+
+                // The first chunk is the variable name (before any :)
+                $varName = \explode(':', $varPart)[0];
+
+                // If we are inside a bracket, that var is optional
+                if ($stack !== []) {
+                    $optionalVars[] = $varName;
+                }
+
+                // Move past this variable
+                $pos = $endPos;
+            }
+
+            $pos++;
+        }
+
+        // 2) Also mark anything that has a default value as optional
+        // so we merge them into $optionalVars
+        $optionalVars = \array_unique($optionalVars);
+
+        // 3) Required = everything in $paramNames that is not in optionalVars
+        return \array_diff($paramNames, $optionalVars);
     }
 
     /**
@@ -342,7 +431,7 @@ final class UriHandler
         $replaces = [];
         foreach ($values as $key => $value) {
             $replaces[\sprintf('<%s>', $key)] = match (true) {
-                $value instanceof \Stringable || \is_scalar($value) => (string)$value,
+                $value instanceof \Stringable || \is_scalar($value) => (string) $value,
                 default => '',
             };
         }
@@ -360,9 +449,9 @@ final class UriHandler
             !isset($this->constrains[$name]) => self::DEFAULT_SEGMENT,
             \is_array($this->constrains[$name]) => \implode(
                 '|',
-                \array_map(fn (string $segment): string => $this->filterSegment($segment), $this->constrains[$name])
+                \array_map(fn(string $segment): string => $this->filterSegment($segment), $this->constrains[$name]),
             ),
-            default => $this->filterSegment((string)$this->constrains[$name])
+            default => $this->filterSegment((string) $this->constrains[$name])
         };
     }
 

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -29,8 +29,9 @@ final class UriHandler
         '[/]' => '',
         '[' => '',
         ']' => '',
-        '://' => '://',
         '//' => '/',
+        // todo: probably should be removed. There are no examples of usage or cases where it is needed.
+        '://' => '://',
     ];
 
     private ?string $pattern = null;
@@ -441,7 +442,11 @@ final class UriHandler
             };
         }
 
-        return \strtr($string, $replaces + self::URI_FIXERS);
+        // Replace all variables
+        $path = \strtr($string, [...$replaces, ...self::URI_FIXERS]);
+
+        // Remove all empty segments
+        return \preg_replace('/\/{2,}/', '/', $path);
     }
 
     /**

--- a/src/Router/src/UriHandler.php
+++ b/src/Router/src/UriHandler.php
@@ -213,13 +213,18 @@ final class UriHandler
         );
 
         $required = \array_keys($this->constrains);
-        $parametersToCheck = $parameters;
         if ($this->strict) {
             $required = \array_unique([...$this->requiredOptions, ...$required]);
-            $parametersToCheck = \array_filter($parametersToCheck);
         }
 
-        $missingParameters = \array_diff($required, \array_keys($parametersToCheck));
+        $missingParameters = [];
+
+        foreach ($required as $key) {
+            if (empty($parameters[$key])) {
+                $missingParameters[] = $key;
+            }
+        }
+
         if ($missingParameters !== []) {
             throw new UriHandlerException(
                 \sprintf(

--- a/src/Router/tests/UriTest.php
+++ b/src/Router/tests/UriTest.php
@@ -119,10 +119,12 @@ class UriTest extends BaseTestCase
 
     public static function providePatternsWithRequiredSegments(): iterable
     {
+        yield ['<controller>[/<section>[/<ext>]]/test/<id>', ['controller' => 'test', 'id' => 1], '/test/test/1'];
         yield ['/articles/<id>[/<section>]', ['id' => 1], '/articles/1'];
         yield ['/articles/<id>', ['id' => 1], '/articles/1'];
         yield ['/articles/<id>/edit', ['id' => 1], '/articles/1/edit'];
         yield ['/articles/<id>/edit/<section>', ['id' => 1, 'section' => 'test'], '/articles/1/edit/test'];
+        yield ['/articles/<id>/edit/[<section>/]<path>', ['id' => 1, 'path' => 'test'], '/articles/1/edit/test'];
         yield ['/articles/<id:int>', ['id' => 1], '/articles/1'];
         yield ['/articles/<id:\d+>', ['id' => 1], '/articles/1'];
         yield ['/<path:.*>', ['path' => 'test'], '/test'];

--- a/src/Router/tests/UriTest.php
+++ b/src/Router/tests/UriTest.php
@@ -148,7 +148,9 @@ class UriTest extends BaseTestCase
 
         $route = $router->getRoute('article');
 
-        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(fn(string $segment) => \rawurlencode($segment));
+        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(
+            fn(string $segment): string => \rawurlencode($segment),
+        );
         $route = $route->withUriHandler($uriHandler);
 
         self::assertNotNull($route->uri());
@@ -173,7 +175,9 @@ class UriTest extends BaseTestCase
 
         $route = $router->getRoute('article');
 
-        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(fn(string $segment) => \rawurlencode($segment));
+        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(
+            fn(string $segment): string => \rawurlencode($segment),
+        );
         $uriHandler->setStrict(true);
         $route = $route->withUriHandler($uriHandler);
 
@@ -197,7 +201,9 @@ class UriTest extends BaseTestCase
 
         $route = $router->getRoute('article');
 
-        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(fn(string $segment) => \rawurlencode($segment));
+        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(
+            fn(string $segment): string => \rawurlencode($segment),
+        );
         $uriHandler->setStrict(true);
         $route = $route->withUriHandler($uriHandler);
 

--- a/src/Router/tests/UriTest.php
+++ b/src/Router/tests/UriTest.php
@@ -6,12 +6,15 @@ namespace Spiral\Tests\Router;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Spiral\Router\Exception\UndefinedRouteException;
+use Spiral\Router\Exception\UriHandlerException;
 use Spiral\Router\Route;
+use Spiral\Router\Target\Action;
 use Spiral\Router\Target\Group;
 use Spiral\Tests\Router\Fixtures\TestController;
 
 class UriTest extends BaseTestCase
 {
+
     public function testCastRoute(): void
     {
         $router = $this->makeRouter();
@@ -114,6 +117,93 @@ class UriTest extends BaseTestCase
         self::assertSame('/test/id/100-hello-world', $uri->getPath());
     }
 
+    public static function providePatternsWithRequiredSegments(): iterable
+    {
+        yield ['/articles/<id>[/<section>]', ['id' => 1], '/articles/1'];
+        yield ['/articles/<id>', ['id' => 1], '/articles/1'];
+        yield ['/articles/<id>/edit', ['id' => 1], '/articles/1/edit'];
+        yield ['/articles/<id>/edit/<section>', ['id' => 1, 'section' => 'test'], '/articles/1/edit/test'];
+        yield ['/articles/<id:int>', ['id' => 1], '/articles/1'];
+        yield ['/articles/<id:\d+>', ['id' => 1], '/articles/1'];
+        yield ['/<path:.*>', ['path' => 'test'], '/test'];
+        yield ['/do/<method:login|logout>', ['method' => 'login'], '/do/login'];
+        yield ['//<sub>.domain.com/[<section>]', ['sub' => 'test'], 'test.domain.com'];
+        yield ['//<sub>.domain.com/', ['sub' => 'test'], 'test.domain.com'];
+    }
+
+    #[DataProvider('providePatternsWithRequiredSegments')]
+    public function testRouteRequiredSegmentsNoStrict(string $pattern): void
+    {
+        $router = $this->makeRouter();
+        $router->setRoute(
+            'article',
+            new Route(
+                pattern: $pattern,
+                target: new Action(
+                    controller: TestController::class,
+                    action: 'id',
+                ),
+            ),
+        );
+
+        $route = $router->getRoute('article');
+
+        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(fn(string $segment) => \rawurlencode($segment));
+        $route = $route->withUriHandler($uriHandler);
+
+        self::assertNotNull($route->uri());
+    }
+
+    #[DataProvider('providePatternsWithRequiredSegments')]
+    public function testRouteRequiredSegments(string $pattern): void
+    {
+        $this->expectException(UriHandlerException::class);
+
+        $router = $this->makeRouter();
+        $router->setRoute(
+            'article',
+            new Route(
+                pattern: $pattern,
+                target: new Action(
+                    controller: TestController::class,
+                    action: 'id',
+                ),
+            ),
+        );
+
+        $route = $router->getRoute('article');
+
+        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(fn(string $segment) => \rawurlencode($segment));
+        $uriHandler->setStrict(true);
+        $route = $route->withUriHandler($uriHandler);
+
+        $route->uri();
+    }
+
+    #[DataProvider('providePatternsWithRequiredSegments')]
+    public function testRouteOptionalSegments(string $pattern, array $params, string $expected): void
+    {
+        $router = $this->makeRouter();
+        $router->setRoute(
+            'article',
+            new Route(
+                pattern: $pattern,
+                target: new Action(
+                    controller: TestController::class,
+                    action: 'id',
+                ),
+            ),
+        );
+
+        $route = $router->getRoute('article');
+
+        $uriHandler = $route->getUriHandler()->withPathSegmentEncoder(fn(string $segment) => \rawurlencode($segment));
+        $uriHandler->setStrict(true);
+        $route = $route->withUriHandler($uriHandler);
+
+        self::assertSame($expected, (string) $route->uri($params));
+    }
+
     #[DataProvider('provideSegmentInDifferentLanguages')]
     public function testCustomPathSegmentEncoder(string $segment, string $expected): void
     {
@@ -126,7 +216,8 @@ class UriTest extends BaseTestCase
         );
 
         $route = $router->getRoute('group');
-        $uriHandler = $route->getUriHandler()
+        $uriHandler = $route
+            ->getUriHandler()
             ->withPathSegmentEncoder(static fn(string $segment): string => \rawurlencode($segment));
         $route = $route->withUriHandler($uriHandler);
 


### PR DESCRIPTION
Strict mode ensures all required URI segments are validated. If any are missing, an exception is thrown. 

To enable strict mode, request `Spiral\Router\UriHandler` from the container in `RoutersBootloader` and set strict mode:

```php
$handler = $container->get(\Spiral\Router\UriHandler::class);
$handler->setStrict(true);
```

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #1162 
