### PR TITLE
fix: Fixes the problem when stempler tries to parse @ char inside a string that is not a directive.

### DIFF
--- a/src/Stempler/src/Lexer/Buffer.php
+++ b/src/Stempler/src/Lexer/Buffer.php
@@ -20,7 +20,7 @@ final class Buffer implements \IteratorAggregate
     public function __construct(
         /** @internal */
         private readonly \Generator $generator,
-        private int $offset = 0
+        private int $offset = 0,
     ) {
     }
 
@@ -135,5 +135,10 @@ final class Buffer implements \IteratorAggregate
                 $this->replay[] = $n;
             }
         }
+    }
+
+    public function flushReplay(): void
+    {
+        $this->replay = [];
     }
 }

--- a/src/Stempler/src/Lexer/Buffer.php
+++ b/src/Stempler/src/Lexer/Buffer.php
@@ -137,7 +137,7 @@ final class Buffer implements \IteratorAggregate
         }
     }
 
-    public function flushReplay(): void
+    public function cleanReplay(): void
     {
         $this->replay = [];
     }

--- a/src/Stempler/src/Lexer/Grammar/Dynamic/DirectiveGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/Dynamic/DirectiveGrammar.php
@@ -229,6 +229,12 @@ final class DirectiveGrammar implements \IteratorAggregate
     {
         $tokens = $this->tokens;
 
+        // A directive must have at least one keyword
+        // Without it, it's just a char
+        if (\count($tokens) === 1 && $tokens[0]->content === self::DIRECTIVE_CHAR) {
+            return false;
+        }
+
         foreach (\array_reverse($tokens, true) as $i => $t) {
             if ($t->type !== DynamicGrammar::TYPE_WHITESPACE) {
                 break;

--- a/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
@@ -45,20 +45,20 @@ final class DynamicGrammar implements GrammarInterface
     private readonly BracesGrammar $raw;
 
     public function __construct(
-        private readonly ?DirectiveRendererInterface $directiveRenderer = null
+        private readonly ?DirectiveRendererInterface $directiveRenderer = null,
     ) {
         $this->echo = new BracesGrammar(
             '{{',
             '}}',
             self::TYPE_OPEN_TAG,
-            self::TYPE_CLOSE_TAG
+            self::TYPE_CLOSE_TAG,
         );
 
         $this->raw = new BracesGrammar(
             '{!!',
             '!!}',
             self::TYPE_OPEN_RAW_TAG,
-            self::TYPE_CLOSE_RAW_TAG
+            self::TYPE_CLOSE_RAW_TAG,
         );
     }
 
@@ -107,6 +107,10 @@ final class DynamicGrammar implements GrammarInterface
 
                     $src->replay($directive->getLastOffset());
                     continue;
+                } else {
+                    // When we found directive char but it's not a directive, we need to flush the replay buffer
+                    // because it may contain extra tokens that we don't need to return back to the stream
+                    $src->flushReplay();
                 }
 
                 $src->replay($n->offset);

--- a/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
+++ b/src/Stempler/src/Lexer/Grammar/DynamicGrammar.php
@@ -108,9 +108,9 @@ final class DynamicGrammar implements GrammarInterface
                     $src->replay($directive->getLastOffset());
                     continue;
                 } else {
-                    // When we found directive char but it's not a directive, we need to flush the replay buffer
+                    // When we found directive char but it's not a directive, we need to clean the replay buffer
                     // because it may contain extra tokens that we don't need to return back to the stream
-                    $src->flushReplay();
+                    $src->cleanReplay();
                 }
 
                 $src->replay($n->offset);

--- a/src/Stempler/tests/Directive/DirectiveTest.php
+++ b/src/Stempler/tests/Directive/DirectiveTest.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Directive;
+namespace Spiral\Tests\Stempler\Directive;
 
 use Spiral\Tests\Stempler\fixtures\ImageDirective;
-use Spiral\Tests\Stempler\Directive\BaseTestCase;
 
 final class DirectiveTest extends BaseTestCase
 {

--- a/src/Stempler/tests/Transform/DynamicToPHPTest.php
+++ b/src/Stempler/tests/Transform/DynamicToPHPTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Stempler\Transform;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Spiral\Stempler\Directive\LoopDirective;
 use Spiral\Stempler\Node\PHP;
+use Spiral\Stempler\Node\Raw;
 use Spiral\Stempler\Transform\Finalizer\DynamicToPHP;
 
 class DynamicToPHPTest extends BaseTestCase
@@ -15,6 +17,20 @@ class DynamicToPHPTest extends BaseTestCase
         $doc = $this->parse('{{ $name }}');
 
         self::assertInstanceOf(PHP::class, $doc->nodes[0]);
+    }
+
+    public static function provideStringWithoutDirective(): iterable
+    {
+        yield ['https://unpkg.com/tailwindcss@^1.6/dist/tailwind.min.css'];
+    }
+
+    #[DataProvider('provideStringWithoutDirective')]
+    public function testLinkWithReservedSymbol(string $string): void
+    {
+        $doc = $this->parse($string);
+
+        self::assertInstanceOf(Raw::class, $doc->nodes[0]);
+        self::assertSame($string, $doc->nodes[0]->content);
     }
 
     public function testDirective(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| Issues        | #331
