### PR TITLE
refactor: set setUp()/tearDown() method modifier protected on tests

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
 use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
@@ -120,6 +121,10 @@ return RectorConfig::configure()
         ],
 
         PreferPHPUnitThisCallRector::class,
+
+        MakeInheritedMethodVisibilitySameAsParentRector::class => [
+            __DIR__ . '/src/Models/tests/PublicEntity.php',
+        ],
     ])
     ->withPhpSets(php81: true)
     ->withPreparedSets(deadCode: true, phpunitCodeQuality: true)
@@ -134,4 +139,5 @@ return RectorConfig::configure()
         PreferPHPUnitSelfCallRector::class,
         TypedPropertyFromAssignsRector::class,
         AddClosureNeverReturnTypeRector::class,
+        MakeInheritedMethodVisibilitySameAsParentRector::class,
     ]);

--- a/src/Bridge/Monolog/tests/HandlersTest.php
+++ b/src/Bridge/Monolog/tests/HandlersTest.php
@@ -23,7 +23,7 @@ use Spiral\Monolog\Exception\ConfigException;
 
 class HandlersTest extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Bridge/Monolog/tests/ProcessorsTest.php
+++ b/src/Bridge/Monolog/tests/ProcessorsTest.php
@@ -19,7 +19,7 @@ use Spiral\Monolog\Exception\ConfigException;
 
 class ProcessorsTest extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Bridge/Monolog/tests/TraitTest.php
+++ b/src/Bridge/Monolog/tests/TraitTest.php
@@ -25,7 +25,7 @@ final class TraitTest extends BaseTestCase
 {
     use LoggerTrait;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Bridge/Stempler/tests/BaseTestCase.php
+++ b/src/Bridge/Stempler/tests/BaseTestCase.php
@@ -32,7 +32,7 @@ abstract class BaseTestCase extends TestCase
         ] + parent::defineDirectories($root);
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Bridge/Stempler/tests/CacheTest.php
+++ b/src/Bridge/Stempler/tests/CacheTest.php
@@ -16,7 +16,7 @@ class CacheTest extends BaseTestCase
     /** @var FilesInterface */
     protected $files;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Config/tests/BaseTestCase.php
+++ b/src/Config/tests/BaseTestCase.php
@@ -18,7 +18,7 @@ abstract class BaseTestCase extends TestCase
      */
     protected $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
     }

--- a/src/Console/tests/AttributeTest.php
+++ b/src/Console/tests/AttributeTest.php
@@ -13,7 +13,7 @@ use Spiral\Tests\Console\Fixtures\Attribute\WithSymfonyAttributeCommand;
 
 final class AttributeTest extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Console/tests/BaseTestCase.php
+++ b/src/Console/tests/BaseTestCase.php
@@ -32,7 +32,7 @@ abstract class BaseTestCase extends TestCase
 
     protected Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
 

--- a/src/Console/tests/HelpersTest.php
+++ b/src/Console/tests/HelpersTest.php
@@ -12,7 +12,7 @@ class HelpersTest extends BaseTestCase
 {
     private \Spiral\Console\Console $core;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Cookies/tests/CookiesTest.php
+++ b/src/Cookies/tests/CookiesTest.php
@@ -27,7 +27,7 @@ final class CookiesTest extends TestCase
 {
     private Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = new Options();
         $options->checkScope = false;

--- a/src/Csrf/tests/CsrfTest.php
+++ b/src/Csrf/tests/CsrfTest.php
@@ -24,7 +24,7 @@ final class CsrfTest extends TestCase
 {
     private Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = new Options();
         $options->checkScope = false;

--- a/src/Distribution/tests/ManagerTestCase.php
+++ b/src/Distribution/tests/ManagerTestCase.php
@@ -14,7 +14,7 @@ class ManagerTestCase extends TestCase
 
     private Manager $manager;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->resolver = new StaticResolver($this->uri('localhost'));
 

--- a/src/Files/tests/DirectoriesTest.php
+++ b/src/Files/tests/DirectoriesTest.php
@@ -10,13 +10,13 @@ use Spiral\Files\FilesInterface;
 
 class DirectoriesTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $files = new Files();
         $files->ensureDirectory(self::FIXTURE_DIRECTORY, FilesInterface::RUNTIME);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $files = new Files();
         $files->deleteDirectory(self::FIXTURE_DIRECTORY, true);

--- a/src/Files/tests/IOTest.php
+++ b/src/Files/tests/IOTest.php
@@ -11,13 +11,13 @@ use Spiral\Files\FilesInterface;
 
 class IOTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $files = new Files();
         $files->ensureDirectory(self::FIXTURE_DIRECTORY, FilesInterface::RUNTIME);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $files = new Files();
         $files->deleteDirectory(self::FIXTURE_DIRECTORY, true);

--- a/src/Files/tests/InformationTest.php
+++ b/src/Files/tests/InformationTest.php
@@ -10,13 +10,13 @@ use Spiral\Files\FilesInterface;
 
 class InformationTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $files = new Files();
         $files->ensureDirectory(self::FIXTURE_DIRECTORY, FilesInterface::RUNTIME);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $files = new Files();
         $files->deleteDirectory(self::FIXTURE_DIRECTORY, true);

--- a/src/Files/tests/TempFilesTest.php
+++ b/src/Files/tests/TempFilesTest.php
@@ -9,13 +9,13 @@ use Spiral\Files\FilesInterface;
 
 class TempFilesTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $files = new Files();
         $files->ensureDirectory(self::FIXTURE_DIRECTORY, FilesInterface::RUNTIME);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $files = new Files();
         $files->deleteDirectory(self::FIXTURE_DIRECTORY, true);

--- a/src/Filters/tests/BaseTestCase.php
+++ b/src/Filters/tests/BaseTestCase.php
@@ -15,7 +15,7 @@ abstract class BaseTestCase extends TestCase
 {
     protected ContainerInterface $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = new Options();
         $options->checkScope = false;

--- a/src/Filters/tests/InputScopeTest.php
+++ b/src/Filters/tests/InputScopeTest.php
@@ -12,7 +12,7 @@ use Spiral\Http\Request\InputManager;
 
 final class InputScopeTest extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Filters/tests/Model/FilterProviderTest.php
+++ b/src/Filters/tests/Model/FilterProviderTest.php
@@ -26,7 +26,7 @@ use Spiral\Tests\Filters\Fixtures\UserFilter;
 
 final class FilterProviderTest extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Filters/tests/Model/Interceptor/PopulateDataFromEntityInterceptorTest.php
+++ b/src/Filters/tests/Model/Interceptor/PopulateDataFromEntityInterceptorTest.php
@@ -17,7 +17,7 @@ final class PopulateDataFromEntityInterceptorTest extends BaseTestCase
 {
     private PopulateDataFromEntityInterceptor $interceptor;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Filters/tests/Model/Interceptor/ValidateFilterInterceptorTest.php
+++ b/src/Filters/tests/Model/Interceptor/ValidateFilterInterceptorTest.php
@@ -25,7 +25,7 @@ final class ValidateFilterInterceptorTest extends BaseTestCase
     private ValidateFilterInterceptor $interceptor;
     private m\MockInterface $validationProvider;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Filters/tests/Model/Schema/AttributeMapperTest.php
+++ b/src/Filters/tests/Model/Schema/AttributeMapperTest.php
@@ -29,7 +29,7 @@ final class AttributeMapperTest extends BaseTestCase
     private m\LegacyMockInterface|m\MockInterface|FilterProviderInterface $provider;
     private AttributeMapper $mapper;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Filters/tests/Model/Schema/BuilderTest.php
+++ b/src/Filters/tests/Model/Schema/BuilderTest.php
@@ -13,7 +13,7 @@ final class BuilderTest extends BaseTestCase
 {
     private Builder $builder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->builder = new Builder();

--- a/src/Filters/tests/Model/Schema/InputMapperTest.php
+++ b/src/Filters/tests/Model/Schema/InputMapperTest.php
@@ -19,7 +19,7 @@ final class InputMapperTest extends BaseTestCase
     private m\LegacyMockInterface|m\MockInterface|FilterProviderInterface $provider;
     private InputMapper $mapper;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Http/tests/FilesTest.php
+++ b/src/Http/tests/FilesTest.php
@@ -18,7 +18,7 @@ class FilesTest extends TestCase
 
     private InputManager $input;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->input = new InputManager($this->container);

--- a/src/Http/tests/HeadersTest.php
+++ b/src/Http/tests/HeadersTest.php
@@ -16,7 +16,7 @@ class HeadersTest extends TestCase
 
     private InputManager $input;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->input = new InputManager($this->container);

--- a/src/Http/tests/HttpTest.php
+++ b/src/Http/tests/HttpTest.php
@@ -29,7 +29,7 @@ final class HttpTest extends TestCase
 
     private Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = new Options();
         $options->checkScope = false;

--- a/src/Http/tests/InputManagerTest.php
+++ b/src/Http/tests/InputManagerTest.php
@@ -23,7 +23,7 @@ class InputManagerTest extends TestCase
     private Container $container;
     private InputManager $input;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->input = new InputManager($this->container);

--- a/src/Http/tests/ServerTest.php
+++ b/src/Http/tests/ServerTest.php
@@ -17,7 +17,7 @@ class ServerTest extends TestCase
 
     private InputManager $input;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->input = new InputManager($this->container);

--- a/src/Http/tests/SlicesTest.php
+++ b/src/Http/tests/SlicesTest.php
@@ -16,7 +16,7 @@ class SlicesTest extends TestCase
 
     private InputManager $input;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->input = new InputManager($this->container);

--- a/src/Http/tests/TestCase.php
+++ b/src/Http/tests/TestCase.php
@@ -13,7 +13,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = new Options();
         $options->checkScope = false;

--- a/src/Logger/tests/TraitTest.php
+++ b/src/Logger/tests/TraitTest.php
@@ -17,7 +17,7 @@ class TraitTest extends TestCase
 {
     use LoggerTrait;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->logger = null;
     }

--- a/src/Pagination/tests/LimitsTraitTest.php
+++ b/src/Pagination/tests/LimitsTraitTest.php
@@ -19,7 +19,7 @@ class LimitsTraitTest extends TestCase
 
     private object $trait;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->trait = new class {
             use LimitsTrait;

--- a/src/Prototype/tests/Commands/AbstractCommandsTestCase.php
+++ b/src/Prototype/tests/Commands/AbstractCommandsTestCase.php
@@ -27,7 +27,7 @@ abstract class AbstractCommandsTestCase extends TestCase
     protected array $buf = [];
     private readonly Storage $storage;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!\class_exists(Kernel::class)) {
             $this->markTestSkipped('A "spiral/framework" dependency is required to run these tests');
@@ -47,7 +47,7 @@ abstract class AbstractCommandsTestCase extends TestCase
         }
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         foreach (static::STORE as $name) {
             $this->storage->restore($name);

--- a/src/Prototype/tests/InjectorTest.php
+++ b/src/Prototype/tests/InjectorTest.php
@@ -17,7 +17,7 @@ use Spiral\Tests\Prototype\Fixtures\TestClass;
 
 class InjectorTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if ((string)ini_get('zend.assertions') === 1) {
             ini_set('zend.assertions', 0);

--- a/src/Scaffolder/tests/BaseTestCase.php
+++ b/src/Scaffolder/tests/BaseTestCase.php
@@ -18,7 +18,7 @@ abstract class BaseTestCase extends TestCase
     /**
      * @throws Throwable
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->app = TestApp::create([
             'root' => __DIR__ . '/App',

--- a/src/Security/tests/GuardTest.php
+++ b/src/Security/tests/GuardTest.php
@@ -23,7 +23,7 @@ class GuardTest extends TestCase
 
     private array $roles = ['user', 'admin'];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->permission = $this->createMock(PermissionsInterface::class);
         $this->actor = $this->createMock(ActorInterface::class);

--- a/src/Security/tests/PermissionManagerTest.php
+++ b/src/Security/tests/PermissionManagerTest.php
@@ -26,7 +26,7 @@ class PermissionManagerTest extends TestCase
 
     private MockObject&RulesInterface $rules;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->rules = $this->createMock(RulesInterface::class);
     }

--- a/src/Security/tests/RuleManagerTest.php
+++ b/src/Security/tests/RuleManagerTest.php
@@ -27,7 +27,7 @@ class RuleManagerTest extends TestCase
     /** @var RuleInterface */
     private $rule;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = m::mock(ContainerInterface::class);
         $this->rule = m::mock(RuleInterface::class);

--- a/src/Security/tests/Rules/CompositeRuleTest.php
+++ b/src/Security/tests/Rules/CompositeRuleTest.php
@@ -21,7 +21,7 @@ class CompositeRuleTest extends TestCase
 
     private MockObject&ActorInterface $actor;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->actor = $this->createMock(ActorInterface::class);
     }

--- a/src/Security/tests/Traits/GuardedTraitTest.php
+++ b/src/Security/tests/Traits/GuardedTraitTest.php
@@ -26,7 +26,7 @@ class GuardedTraitTest extends TestCase
 
     private MockObject&ContainerInterface $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->trait = new class {
             use GuardedTrait;

--- a/src/SendIt/tests/JobTest.php
+++ b/src/SendIt/tests/JobTest.php
@@ -26,7 +26,7 @@ class JobTest extends TestCase
     /** @var RendererInterface */
     protected $renderer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/SendIt/tests/RenderTest.php
+++ b/src/SendIt/tests/RenderTest.php
@@ -36,7 +36,7 @@ class RenderTest extends TestCase
             ] + parent::defineDirectories($root);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/src/Session/tests/FactoryTest.php
+++ b/src/Session/tests/FactoryTest.php
@@ -13,7 +13,7 @@ use Spiral\Session\SessionInterface;
 
 final class FactoryTest extends TestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if ((int)session_status() === PHP_SESSION_ACTIVE) {
             session_abort();

--- a/src/Session/tests/SessionTest.php
+++ b/src/Session/tests/SessionTest.php
@@ -19,7 +19,7 @@ final class SessionTest extends TestCase
 {
     private SessionFactory $factory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ final class SessionTest extends TestCase
         ]), $this->container);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if ((int)session_status() === PHP_SESSION_ACTIVE) {
             session_abort();

--- a/src/Session/tests/TestCase.php
+++ b/src/Session/tests/TestCase.php
@@ -11,7 +11,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $options = new Options();
         $options->checkScope = false;

--- a/src/Storage/tests/ManagerTestCase.php
+++ b/src/Storage/tests/ManagerTestCase.php
@@ -15,7 +15,7 @@ class ManagerTestCase extends TestCase
 {
     private Storage $manager;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/src/Storage/tests/TestCase.php
+++ b/src/Storage/tests/TestCase.php
@@ -26,7 +26,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected $second;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -39,7 +39,7 @@ abstract class TestCase extends BaseTestCase
         );
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->cleanTempDirectory();
 

--- a/src/Streams/tests/StreamsTest.php
+++ b/src/Streams/tests/StreamsTest.php
@@ -12,13 +12,13 @@ class StreamsTest extends TestCase
 {
     private const FIXTURE_DIRECTORY = __DIR__ . '/fixtures';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $files = new Files();
         $files->ensureDirectory(self::FIXTURE_DIRECTORY, FilesInterface::RUNTIME);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $files = new Files();
         $files->deleteDirectory(self::FIXTURE_DIRECTORY, true);

--- a/src/Translator/tests/TraitTest.php
+++ b/src/Translator/tests/TraitTest.php
@@ -28,7 +28,7 @@ class TraitTest extends TestCase
 
     private Container $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
 

--- a/src/Views/tests/ManagerTest.php
+++ b/src/Views/tests/ManagerTest.php
@@ -20,7 +20,7 @@ class ManagerTest extends TestCase
 {
     protected $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->container->bindSingleton(LoaderInterface::class, ViewLoader::class);

--- a/tests/Framework/AuthHttp/Middleware/AuthMiddlewareTest.php
+++ b/tests/Framework/AuthHttp/Middleware/AuthMiddlewareTest.php
@@ -15,7 +15,7 @@ use Spiral\Tests\Framework\HttpTestCase;
 
 final class AuthMiddlewareTest extends HttpTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Framework/Command/Translator/ExportCommandTest.php
+++ b/tests/Framework/Command/Translator/ExportCommandTest.php
@@ -8,7 +8,7 @@ use Spiral\Tests\Framework\ConsoleTestCase;
 
 final class ExportCommandTest extends ConsoleTestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Framework/ConsoleTestCase.php
+++ b/tests/Framework/ConsoleTestCase.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Framework;
 
 abstract class ConsoleTestCase extends BaseTestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Framework/Http/CookiesTest.php
+++ b/tests/Framework/Http/CookiesTest.php
@@ -21,7 +21,7 @@ final class CookiesTest extends HttpTestCase
         'ENCRYPTER_KEY' => self::ENCRYPTER_KEY,
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Framework/Http/SessionTest.php
+++ b/tests/Framework/Http/SessionTest.php
@@ -15,7 +15,7 @@ use Spiral\Tests\Framework\HttpTestCase;
 #[TestScope(Spiral::Http)]
 final class SessionTest extends HttpTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Framework/Module/PublishTest.php
+++ b/tests/Framework/Module/PublishTest.php
@@ -13,7 +13,7 @@ final class PublishTest extends ConsoleTestCase
     protected const TEST_FILE   = __DIR__ . '/test.txt';
     protected const TEST_FILE_2 = __DIR__ . '/PublishTest.php';
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (file_exists(self::TEST_FILE)) {
             unlink(self::TEST_FILE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

applied via `MakeInheritedMethodVisibilitySameAsParentRector`