### PR TITLE
refactor: update phpunit syntax to use attributes and use RunTestsInSeparateProcesses in SessionTest

### DIFF
--- a/src/AnnotatedRoutes/tests/TestCase.php
+++ b/src/AnnotatedRoutes/tests/TestCase.php
@@ -8,9 +8,7 @@ use Spiral\Nyholm\Bootloader\NyholmBootloader;
 use Spiral\Router\Bootloader\AnnotatedRoutesBootloader;
 use Spiral\Testing\TestCase as BaseTestCase;
 
-/**
- * @requires function \Spiral\Framework\Kernel::init
- */
+#[\PHPUnit\Framework\Attributes\RequiresMethod(\Spiral\Framework\Kernel::class, 'init')]
 abstract class TestCase extends BaseTestCase
 {
     public function defineBootloaders(): array

--- a/src/Core/tests/Exception/ClosureRendererTraitTest.php
+++ b/src/Core/tests/Exception/ClosureRendererTraitTest.php
@@ -100,10 +100,9 @@ class ClosureRendererTraitTest extends TestCase
     }
 
     /**
-     * @requires PHP >= 8.2
-     *
      * @link https://wiki.php.net/rfc/null-false-standalone-types
      */
+    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.2')]
     public function testNullAndFalseTypes(): void
     {
         eval('$fn = fn (null $a, false $b) => null;');

--- a/src/Router/tests/RouterTest.php
+++ b/src/Router/tests/RouterTest.php
@@ -92,6 +92,6 @@ class RouterTest extends BaseTestCase
 
         $uri = (string) $router->uri('foo', ['host' => 'some']);
         self::assertSame('some/register', $uri);
-        self::assertFalse(\str_contains('https://host.com', $uri));
+        self::assertStringNotContainsString($uri, 'https://host.com');
     }
 }

--- a/src/Session/tests/SessionTest.php
+++ b/src/Session/tests/SessionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Session;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Spiral\Core\Container;
 use Spiral\Files\Files;
 use Spiral\Files\FilesInterface;
@@ -15,6 +16,7 @@ use Spiral\Session\SessionFactory;
 use Spiral\Session\SessionInterface;
 use Spiral\Session\SessionSection;
 
+#[RunTestsInSeparateProcesses]
 final class SessionTest extends TestCase
 {
     private SessionFactory $factory;

--- a/src/Streams/tests/StreamsTest.php
+++ b/src/Streams/tests/StreamsTest.php
@@ -61,9 +61,7 @@ class StreamsTest extends TestCase
         self::assertSame('sample', \stream_get_contents($resource, 6, 0));
     }
 
-    /**
-     * @requires PHP < 8.0
-     */
+    #[\PHPUnit\Framework\Attributes\RequiresPhp('< 8.0')]
     public function testException(): void
     {
         try {
@@ -79,9 +77,7 @@ class StreamsTest extends TestCase
         }
     }
 
-    /**
-     * @requires PHP >= 8.0
-     */
+    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.0')]
     public function testExceptionPHP8(): void
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA?  | ✔️

<!-- Please, replace this notice by a short description of your feature/bugfix. -->

- update to use phpunit attributes syntax on latest rector release run
- use `RunTestsInSeparateProcesses` to make work on macOS