### PR TITLE
[spiral/telemetry] Fix a bug with telemetry info not propagating into log records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- **Bug Fixes**
+  - [spiral/telemetry] Telemetry info was not propagated into log records
+
 ## 3.15.0 - 2025-01-24
 
 - Core

--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.0.7",
+        "rector/rector": "~2.0.9",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.8.3",

--- a/rector.php
+++ b/rector.php
@@ -23,6 +23,7 @@ use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
@@ -125,6 +126,9 @@ return RectorConfig::configure()
         MakeInheritedMethodVisibilitySameAsParentRector::class => [
             __DIR__ . '/src/Models/tests/PublicEntity.php',
         ],
+
+        // Explicit behavior is more preferable
+        AssertCountWithZeroToAssertEmptyRector::class,
     ])
     ->withPhpSets(php81: true)
     ->withPreparedSets(deadCode: true, phpunitCodeQuality: true)

--- a/src/Telemetry/src/Monolog/TelemetryProcessor.php
+++ b/src/Telemetry/src/Monolog/TelemetryProcessor.php
@@ -7,12 +7,13 @@ namespace Spiral\Telemetry\Monolog;
 use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 use Psr\Container\ContainerInterface;
+use Spiral\Core\Attribute\Proxy;
 use Spiral\Telemetry\TracerInterface;
 
 final class TelemetryProcessor implements ProcessorInterface
 {
     public function __construct(
-        private readonly ContainerInterface $container,
+        #[Proxy] private readonly ContainerInterface $container,
     ) {}
 
     /**


### PR DESCRIPTION
This fixes a bug where tracer is not using scoped proxy container, so the trace context is always empty.

Without this fix, telemetry info were never actually added as extra to log records.