### PR TITLE
Bind current TracerInterface as singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 # CHANGELOG
 
-## Unreleased
+## 3.15.3 - 2025-02-11
+
+- **Bug Fixes**
+  - [spiral/telemetry] Fixed scoped `TracerInterface` in the `AbstractTracer::runScope` method
+- `\Spiral\Core\Scope` is public now
+
+## 3.15.2 - 2025-02-10
 
 - **Bug Fixes**
   - [spiral/telemetry] Telemetry info was not propagated into log records
+
+## 3.15.1 - 2025-01-31
+
+- Maintenance:
+  - Bumped up dependencies versions
+  - [spiral/prototype] component now uses `nikic/php-parser` v5
 
 ## 3.15.0 - 2025-01-24
 

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -6,6 +6,7 @@ namespace Spiral\Core\Internal;
 
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use ReflectionFunctionAbstract as ContextFunction;
 use Spiral\Core\Attribute;
 use Spiral\Core\BinderInterface;
@@ -334,8 +335,8 @@ final class Factory implements FactoryInterface
                 }
             } catch (ContainerExceptionInterface $e) {
                 $className = match (true) {
-                    $e instanceof NotFoundException => NotFoundException::class,
                     $e instanceof RecursiveProxyException => throw $e,
+                    $e instanceof NotFoundExceptionInterface => NotFoundException::class,
                     default => ContainerException::class,
                 };
                 throw new $className($this->tracer->combineTraceMessage(\sprintf(

--- a/src/Core/src/Scope.php
+++ b/src/Core/src/Scope.php
@@ -8,8 +8,6 @@ namespace Spiral\Core;
  * DTO to define Container Scope.
  *
  * @psalm-import-type TResolver from BinderInterface
- *
- * @internal We are testing this feature, it may be changed in the future.
  */
 final class Scope
 {

--- a/src/Router/tests/Fixtures/TestController.php
+++ b/src/Router/tests/Fixtures/TestController.php
@@ -94,6 +94,6 @@ class TestController
     public function scopes(): string
     {
         $scopes = Introspector::scopeNames();
-        return \implode(', ', $scopes);
+        return \implode(', ', \array_filter($scopes));
     }
 }

--- a/src/Telemetry/composer.json
+++ b/src/Telemetry/composer.json
@@ -38,7 +38,9 @@
         "spiral/core": "^3.16"
     },
     "require-dev": {
+        "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
+        "spiral/testing": "^2.9",
         "vimeo/psalm": "^6.0"
     },
     "autoload": {

--- a/src/Telemetry/src/AbstractTracer.php
+++ b/src/Telemetry/src/AbstractTracer.php
@@ -51,7 +51,7 @@ abstract class AbstractTracer implements TracerInterface
             $prevSpan = null;
         }
 
-        $binder->bindSingleton(SpanInterface::class, $span);
+        $binder->bindSingleton(SpanInterface::class, $span, true);
 
         try {
             return $prevSpan === null

--- a/src/Telemetry/src/AbstractTracer.php
+++ b/src/Telemetry/src/AbstractTracer.php
@@ -54,9 +54,11 @@ abstract class AbstractTracer implements TracerInterface
             $prevSpan = null;
         }
 
+        /** @psalm-suppress TooManyArguments */
         $binder->bindSingleton(SpanInterface::class, $span, true);
 
         try {
+            /** @psalm-suppress InvalidArgument */
             return $prevSpan === null
                 ? $scope->runScope(
                     new Scope(

--- a/src/Telemetry/src/AbstractTracer.php
+++ b/src/Telemetry/src/AbstractTracer.php
@@ -38,7 +38,10 @@ abstract class AbstractTracer implements TracerInterface
         if ($container instanceof Container) {
             $invoker = $container;
             $binder = $container;
+            $scope = $container;
         } else {
+            /** @var ScopeInterface $scope */
+            $scope = $container->get(ScopeInterface::class);
             /** @var InvokerInterface $invoker */
             $invoker = $container->get(InvokerInterface::class);
             /** @var BinderInterface $binder */
@@ -55,13 +58,13 @@ abstract class AbstractTracer implements TracerInterface
 
         try {
             return $prevSpan === null
-                ? $this->scope->runScope(
+                ? $scope->runScope(
                     new Scope(
                         bindings: [
                             TracerInterface::class => $this,
                         ],
                     ),
-                    static fn(): mixed => $invoker->invoke($callback),
+                    static fn(InvokerInterface $invoker): mixed => $invoker->invoke($callback),
                 )
                 : $invoker->invoke($callback);
         } finally {

--- a/src/Telemetry/src/Bootloader/TelemetryBootloader.php
+++ b/src/Telemetry/src/Bootloader/TelemetryBootloader.php
@@ -8,6 +8,8 @@ use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Append;
+use Spiral\Core\BinderInterface;
+use Spiral\Core\Config\Proxy;
 use Spiral\Core\Container\Autowire;
 use Spiral\Telemetry\Clock\SystemClock;
 use Spiral\Telemetry\ClockInterface;
@@ -27,16 +29,14 @@ final class TelemetryBootloader extends Bootloader
         TracerFactoryProviderInterface::class => ConfigTracerFactoryProvider::class,
         ClockInterface::class => SystemClock::class,
     ];
-    protected const BINDINGS = [
-        TracerInterface::class => [self::class, 'getTracer'],
-    ];
 
     public function __construct(
         private readonly ConfiguratorInterface $config,
     ) {}
 
-    public function init(EnvironmentInterface $env): void
+    public function init(BinderInterface $binder, EnvironmentInterface $env): void
     {
+        $binder->bind(TracerInterface::class, new Proxy(TracerInterface::class, false, $this->getTracer(...)));
         $this->initConfig($env);
     }
 

--- a/src/Telemetry/src/Monolog/TelemetryProcessor.php
+++ b/src/Telemetry/src/Monolog/TelemetryProcessor.php
@@ -13,7 +13,7 @@ use Spiral\Telemetry\TracerInterface;
 final class TelemetryProcessor implements ProcessorInterface
 {
     public function __construct(
-        #[Proxy] private readonly ContainerInterface $container,
+        private readonly ContainerInterface $container,
     ) {}
 
     /**

--- a/src/Telemetry/src/TracerInterface.php
+++ b/src/Telemetry/src/TracerInterface.php
@@ -20,16 +20,6 @@ interface TracerInterface
     /**
      * Trace a given callback
      *
-     * The method should always run callback inside container scope.
-     * @see ScopeInterface
-     *
-     * ```php
-     * ScopeInterface::runScope([
-     *      SpanInterface::class => new Span($name),
-     *      TracerInterface::class => $this,
-     * ], static fn (\Spiral\Core\InvokerInterface $invoker): mixed => $invoker->invoke($callback));
-     * ```
-     *
      * @param non-empty-string $name
      * @param array<non-empty-string, mixed> $attributes
      * @param int|null $startTime Start time in nanoseconds.

--- a/src/Telemetry/tests/NullTracerTest.php
+++ b/src/Telemetry/tests/NullTracerTest.php
@@ -66,15 +66,13 @@ final class NullTracerTest extends TestCase
 
         $callable = static fn(): string => 'hello';
 
-        $invoker->shouldReceive('invoke')
-            ->once()
-            ->with($callable)
-            ->andReturn('hello');
+        $invoker->shouldNotReceive('invoke');
         $binder->shouldReceive('bindSingleton')
             ->once();
         $binder->shouldReceive('removeBinding')
             ->with(SpanInterface::class);
-        $scope->shouldNotReceive('runScope');
+        $scope->shouldReceive('runScope')
+            ->andReturn('hello');
 
         ContainerScope::runScope($container, static function () use ($tracer, $callable): void {
             self::assertSame('hello', $tracer->trace('foo', $callable, ['foo' => 'bar']));

--- a/src/Telemetry/tests/NullTracerTest.php
+++ b/src/Telemetry/tests/NullTracerTest.php
@@ -7,9 +7,6 @@ namespace Spiral\Tests\Telemetry;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
-use Spiral\Core\BinderInterface;
-use Spiral\Core\ContainerScope;
 use Spiral\Core\InvokerInterface;
 use Spiral\Core\ScopeInterface;
 use Spiral\Telemetry\NullTracer;
@@ -45,37 +42,5 @@ final class NullTracerTest extends TestCase
             ->andReturnUsing(static fn(array $scope, callable $callable) => $callable($invoker));
 
         self::assertSame('hello', $tracer->trace('foo', $callable, ['foo' => 'bar']));
-    }
-
-    #[RunInSeparateProcess]
-    public function testWithScopedContainer(): void
-    {
-        $tracer = new NullTracer(
-            $scope = m::mock(ScopeInterface::class),
-        );
-
-        $invoker = m::mock(InvokerInterface::class);
-        $binder = m::mock(BinderInterface::class);
-        $container = m::mock(ContainerInterface::class);
-        $container->expects('get')
-            ->with(InvokerInterface::class)
-            ->andReturn($invoker);
-        $container->expects('get')
-            ->with(BinderInterface::class)
-            ->andReturn($binder);
-
-        $callable = static fn(): string => 'hello';
-
-        $invoker->shouldNotReceive('invoke');
-        $binder->shouldReceive('bindSingleton')
-            ->once();
-        $binder->shouldReceive('removeBinding')
-            ->with(SpanInterface::class);
-        $scope->shouldReceive('runScope')
-            ->andReturn('hello');
-
-        ContainerScope::runScope($container, static function () use ($tracer, $callable): void {
-            self::assertSame('hello', $tracer->trace('foo', $callable, ['foo' => 'bar']));
-        });
     }
 }

--- a/src/Telemetry/tests/ScopedTracerTest.php
+++ b/src/Telemetry/tests/ScopedTracerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Telemetry;
 
+use PHPUnit\Framework\Attributes\CoversFunction;
 use Psr\Container\ContainerInterface;
+use Spiral\Core\Internal\Introspector;
 use Spiral\Core\Internal\Proxy;
 use Spiral\Telemetry\Bootloader\TelemetryBootloader;
 use Spiral\Telemetry\NullTracer;
@@ -13,6 +15,7 @@ use Spiral\Telemetry\TracerFactoryInterface;
 use Spiral\Telemetry\TracerInterface;
 use Spiral\Testing\TestCase;
 
+#[CoversFunction('\Spiral\Telemetry\AbstractTracer::runScope')]
 final class ScopedTracerTest extends TestCase
 {
     public function defineBootloaders(): array
@@ -22,7 +25,7 @@ final class ScopedTracerTest extends TestCase
         ];
     }
 
-    public function testTracerIsProxy(): void
+    public function testFirstTracerIsProxy(): void
     {
         $tracer = $this->getContainer()->get(TracerInterface::class);
 
@@ -33,7 +36,7 @@ final class ScopedTracerTest extends TestCase
         );
 
         self::assertTrue(Proxy::isProxy($tracer));
-        self::assertTrue(Proxy::isProxy($result));
+        self::assertFalse(Proxy::isProxy($result));
     }
 
     public function testTracerScopedBinding(): void
@@ -42,7 +45,7 @@ final class ScopedTracerTest extends TestCase
             TracerFactoryInterface::class,
             $factory = $this->createMock(TracerFactoryInterface::class),
         );
-        $factory->expects(self::exactly(2))
+        $factory->expects(self::exactly(1))
             ->method('make')
             ->willReturn(new NullTracer($this->getContainer()));
 

--- a/src/Telemetry/tests/ScopedTracerTest.php
+++ b/src/Telemetry/tests/ScopedTracerTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Telemetry;
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use Psr\Container\ContainerInterface;
-use Spiral\Core\Internal\Introspector;
 use Spiral\Core\Internal\Proxy;
 use Spiral\Telemetry\Bootloader\TelemetryBootloader;
 use Spiral\Telemetry\NullTracer;
@@ -15,7 +13,6 @@ use Spiral\Telemetry\TracerFactoryInterface;
 use Spiral\Telemetry\TracerInterface;
 use Spiral\Testing\TestCase;
 
-#[CoversFunction('\Spiral\Telemetry\AbstractTracer::runScope')]
 final class ScopedTracerTest extends TestCase
 {
     public function defineBootloaders(): array
@@ -53,7 +50,7 @@ final class ScopedTracerTest extends TestCase
 
         $result = $tracer->trace(
             'foo',
-            static function (ContainerInterface $container) {
+            static function (ContainerInterface $container): array {
                 /** @var TracerInterface $tracer */
                 $tracer = $container->get(TracerInterface::class);
 

--- a/src/Telemetry/tests/ScopedTracerTest.php
+++ b/src/Telemetry/tests/ScopedTracerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Telemetry;
+
+use Psr\Container\ContainerInterface;
+use Spiral\Core\Internal\Proxy;
+use Spiral\Telemetry\Bootloader\TelemetryBootloader;
+use Spiral\Telemetry\NullTracer;
+use Spiral\Telemetry\SpanInterface;
+use Spiral\Telemetry\TracerFactoryInterface;
+use Spiral\Telemetry\TracerInterface;
+use Spiral\Testing\TestCase;
+
+final class ScopedTracerTest extends TestCase
+{
+    public function defineBootloaders(): array
+    {
+        return [
+            TelemetryBootloader::class,
+        ];
+    }
+
+    public function testTracerIsProxy(): void
+    {
+        $tracer = $this->getContainer()->get(TracerInterface::class);
+
+        $result = $tracer->trace(
+            'foo',
+            static fn(ContainerInterface $container): TracerInterface => $container
+                ->get(TracerInterface::class)
+        );
+
+        self::assertTrue(Proxy::isProxy($tracer));
+        self::assertTrue(Proxy::isProxy($result));
+    }
+
+    public function testTracerScopedBinding(): void
+    {
+        $this->getContainer()->bindSingleton(
+            TracerFactoryInterface::class,
+            $factory = $this->createMock(TracerFactoryInterface::class),
+        );
+        $factory->expects(self::exactly(2))
+            ->method('make')
+            ->willReturn(new NullTracer($this->getContainer()));
+
+        $tracer = $this->getContainer()->get(TracerInterface::class);
+
+        $result = $tracer->trace(
+            'foo',
+            static function (ContainerInterface $container) {
+                /** @var TracerInterface $tracer */
+                $tracer = $container->get(TracerInterface::class);
+
+                return [
+                    $container->get(SpanInterface::class),
+                    $tracer->trace(
+                        'bar',
+                        static fn(ContainerInterface $container): SpanInterface => $container
+                            ->get(SpanInterface::class),
+                        ['baz' => 42],
+                    ),
+                    $container->get(SpanInterface::class)
+                ];
+            },
+            ['foo' => 'bar'],
+        );
+
+        self::assertSame($result[0], $result[2]);
+
+        self::assertInstanceOf(SpanInterface::class, $result[0]);
+        self::assertInstanceOf(SpanInterface::class, $result[1]);
+
+        self::assertSame('foo', $result[0]->getName());
+        self::assertSame('bar', $result[1]->getName());
+
+        self::assertSame(['foo' => 'bar'], $result[0]->getAttributes());
+        self::assertSame(['baz' => 42], $result[1]->getAttributes());
+    }
+}

--- a/tests/Framework/Bootloader/Telemetry/TelemetryBootloaderTest.php
+++ b/tests/Framework/Bootloader/Telemetry/TelemetryBootloaderTest.php
@@ -13,10 +13,8 @@ use Spiral\Telemetry\ClockInterface;
 use Spiral\Telemetry\Config\TelemetryConfig;
 use Spiral\Telemetry\ConfigTracerFactoryProvider;
 use Spiral\Telemetry\LogTracerFactory;
-use Spiral\Telemetry\NullTracer;
 use Spiral\Telemetry\NullTracerFactory;
 use Spiral\Telemetry\TracerFactoryInterface;
-use Spiral\Telemetry\TracerInterface;
 use Spiral\Telemetry\TracerFactoryProviderInterface;
 use Spiral\Tests\Framework\BaseTestCase;
 
@@ -43,14 +41,6 @@ final class TelemetryBootloaderTest extends BaseTestCase
         $this->assertContainerBoundAsSingleton(
             ClockInterface::class,
             SystemClock::class,
-        );
-    }
-
-    public function testTracerInterfaceBinding(): void
-    {
-        $this->assertContainerBound(
-            TracerInterface::class,
-            NullTracer::class,
         );
     }
 

--- a/tests/Framework/Http/AuthSessionTest.php
+++ b/tests/Framework/Http/AuthSessionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Framework\Http;
 
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Spiral\Auth\AuthContextInterface;
 use Spiral\Bootloader\Http\Exception\ContextualObjectNotFoundException;
 use Spiral\Bootloader\Http\Exception\InvalidRequestScopeException;
@@ -74,11 +76,14 @@ final class AuthSessionTest extends HttpTestCase
         ]));
 
         $this->setHttpHandler(function (): void {
-            $this->expectException(ContextualObjectNotFoundException::class);
             $this->getContainer()->get(AuthContextInterface::class);
         });
 
-        $this->fakeHttp()->get('/');
+        try {
+            $this->fakeHttp()->get('/');
+        } catch (\Psr\Container\NotFoundExceptionInterface $e) {
+            self::assertInstanceOf(ContextualObjectNotFoundException::class, $e->getPrevious());
+        }
     }
 
     public function testCookieQueueBindingWithoutRequest(): void

--- a/tests/Framework/Http/SessionTest.php
+++ b/tests/Framework/Http/SessionTest.php
@@ -106,13 +106,14 @@ final class SessionTest extends HttpTestCase
 
         $this->setHttpHandler(function (): void {
             $session = $this->session();
-
-            $this->expectException(ContextualObjectNotFoundException::class);
-
             $session->getID();
         });
 
-        $this->fakeHttp()->get(uri: '/')->assertOk();
+        try {
+            $this->fakeHttp()->get(uri: '/')->assertOk();
+        } catch (\Psr\Container\NotFoundExceptionInterface $e) {
+            self::assertInstanceOf(ContextualObjectNotFoundException::class, $e->getPrevious());
+        }
     }
 
     public function testSessionBindingWithoutRequest(): void


### PR DESCRIPTION
This will help using TracerInterface during request scope and access its trace context, e.g for monolog telemetry processor.

Without this, traces are being lost most of the time due to TracerInterface overwriting trace context every time it's being accessed.