### PR TITLE
[Core] Fix `static` return type in Proxy class generator

### DIFF
--- a/src/Core/src/Exception/Container/TracedContainerException.php
+++ b/src/Core/src/Exception/Container/TracedContainerException.php
@@ -28,6 +28,7 @@ class TracedContainerException extends ContainerException
         array $trace = [],
         ?\Throwable $previous = null,
     ): static {
+        $class = static::class;
         // Merge traces
         if ($previous instanceof self) {
             $merge = $previous->containerTrace;
@@ -39,19 +40,20 @@ class TracedContainerException extends ContainerException
 
             $trace = \array_merge($trace, $merge);
             $message = "$message\n{$previous->originalMessage}";
+            $class = $previous::class;
         }
 
-        return static::createStatic($message, $trace, $previous);
-    }
-
-    protected static function createStatic(string $message, array $trace, ?\Throwable $previous): static
-    {
-        $result = new static(
+        $result = $class::createStatic(
             $message . ($trace === [] ? '' : "\nResolving trace:\n" . Tracer::renderTraceList($trace)),
-            previous: $previous,
+            $previous,
         );
         $result->originalMessage = $message;
         $result->containerTrace = $trace;
         return $result;
+    }
+
+    protected static function createStatic(string $message, ?\Throwable $previous): static
+    {
+        return new static($message, previous: $previous);
     }
 }

--- a/src/Core/src/Exception/Resolver/InvalidArgumentException.php
+++ b/src/Core/src/Exception/Resolver/InvalidArgumentException.php
@@ -4,22 +4,13 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Resolver;
 
-use Spiral\Core\Exception\Traits\ClosureRendererTrait;
-
 final class InvalidArgumentException extends ValidationException
 {
-    use ClosureRendererTrait;
-
-    public function __construct(
+    protected function getValidationMessage(
         \ReflectionFunctionAbstract $reflection,
-        private readonly string $parameter,
-    ) {
+        string $parameter,
+    ): string {
         $pattern = "Invalid argument value type for the `$parameter` parameter when validating arguments for `%s`.";
-        parent::__construct($this->renderFunctionAndParameter($reflection, $pattern));
-    }
-
-    public function getParameter(): string
-    {
-        return $this->parameter;
+        return $this->renderFunctionAndParameter($reflection, $pattern);
     }
 }

--- a/src/Core/src/Exception/Resolver/MissingRequiredArgumentException.php
+++ b/src/Core/src/Exception/Resolver/MissingRequiredArgumentException.php
@@ -10,16 +10,11 @@ final class MissingRequiredArgumentException extends ValidationException
 {
     use ClosureRendererTrait;
 
-    public function __construct(
+    protected function getValidationMessage(
         \ReflectionFunctionAbstract $reflection,
-        private readonly string $parameter,
-    ) {
+        string $parameter,
+    ): string {
         $pattern = "Missing required argument for the `{$parameter}` parameter for `%s` %s.";
-        parent::__construct($this->renderFunctionAndParameter($reflection, $pattern));
-    }
-
-    public function getParameter(): string
-    {
-        return $this->parameter;
+        return $this->renderFunctionAndParameter($reflection, $pattern);
     }
 }

--- a/src/Core/src/Exception/Resolver/PositionalArgumentException.php
+++ b/src/Core/src/Exception/Resolver/PositionalArgumentException.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Resolver;
 
-use Spiral\Core\Exception\Traits\ClosureRendererTrait;
-
 final class PositionalArgumentException extends ValidationException
 {
-    use ClosureRendererTrait;
-
-    public function __construct(
+    protected function getValidationMessage(
         \ReflectionFunctionAbstract $reflection,
-        private readonly int $position,
-    ) {
+        string $parameter,
+    ): string {
         $pattern = 'Cannot use positional argument after named argument `%s` %s.';
-        parent::__construct($this->renderFunctionAndParameter($reflection, $pattern));
+        return $this->renderFunctionAndParameter($reflection, $pattern);
     }
 
     public function getParameter(): string
     {
-        return '#' . $this->position;
+        return '#' . $this->parameter;
     }
 }

--- a/src/Core/src/Exception/Resolver/ResolvingException.php
+++ b/src/Core/src/Exception/Resolver/ResolvingException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Resolver;
 
-use Spiral\Core\Exception\Container\ContainerException;
+use Spiral\Core\Exception\Container\TracedContainerException;
 
-class ResolvingException extends ContainerException {}
+class ResolvingException extends TracedContainerException {}

--- a/src/Core/src/Exception/Resolver/UnknownParameterException.php
+++ b/src/Core/src/Exception/Resolver/UnknownParameterException.php
@@ -4,22 +4,13 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Resolver;
 
-use Spiral\Core\Exception\Traits\ClosureRendererTrait;
-
 final class UnknownParameterException extends ValidationException
 {
-    use ClosureRendererTrait;
-
-    public function __construct(
+    protected function getValidationMessage(
         \ReflectionFunctionAbstract $reflection,
-        private readonly string $parameter,
-    ) {
+        string $parameter,
+    ): string {
         $pattern = "Unknown named parameter `{$parameter}` `%s` %s.";
-        parent::__construct($this->renderFunctionAndParameter($reflection, $pattern));
-    }
-
-    public function getParameter(): string
-    {
-        return $this->parameter;
+        return $this->renderFunctionAndParameter($reflection, $pattern);
     }
 }

--- a/src/Core/src/Exception/Resolver/ValidationException.php
+++ b/src/Core/src/Exception/Resolver/ValidationException.php
@@ -4,7 +4,41 @@ declare(strict_types=1);
 
 namespace Spiral\Core\Exception\Resolver;
 
+use Spiral\Core\Exception\Traits\ClosureRendererTrait;
+
 abstract class ValidationException extends ResolvingException
 {
-    abstract public function getParameter(): string;
+    use ClosureRendererTrait;
+
+    final private function __construct(
+        protected readonly \ReflectionFunctionAbstract $reflection,
+        protected readonly string $parameter,
+        ?string $message = null,
+    ) {
+        $message ??= $this->getValidationMessage($reflection, $parameter);
+        parent::__construct($this->renderFunctionAndParameter($reflection, $message));
+    }
+
+    public static function createWithParam(\ReflectionFunctionAbstract $reflection, string $parameter): static
+    {
+        return new static($reflection, $parameter);
+    }
+
+    public function getParameter(): string
+    {
+        return $this->parameter;
+    }
+
+    protected static function createStatic(string $message, ?\Throwable $previous): static
+    {
+        $previous instanceof self or throw new \InvalidArgumentException(
+            \sprintf('Previous exception must be an instance of %s.', self::class),
+        );
+        return new static($previous->reflection, $previous->parameter, $message);
+    }
+
+    abstract protected function getValidationMessage(
+        \ReflectionFunctionAbstract $reflection,
+        string $parameter,
+    ): string;
 }

--- a/src/Core/src/Internal/Actor.php
+++ b/src/Core/src/Internal/Actor.php
@@ -251,7 +251,7 @@ final class Actor
 
             return $instance;
         } catch (TracedContainerException $e) {
-            throw isset($injectorInstance) ? $e : $e::extendTracedException(\sprintf(
+            throw isset($injectorInstance) ? $e : $e::createWithTrace(\sprintf(
                 'Can\'t resolve `%s`.',
                 $tracer->getRootAlias(),
             ), $tracer->getTraces(), $e);
@@ -279,7 +279,7 @@ final class Actor
                 //Binding is pointing to something else
                 $instance = $this->factory->make($binding->alias, $arguments, $context);
             } catch (TracedContainerException $e) {
-                throw $e::extendTracedException(
+                throw $e::createWithTrace(
                     $alias === $tracer->getRootAlias()
                         ? "Can't resolve `{$alias}`."
                         : "Can't resolve `$alias` with alias `{$binding->alias}`.",
@@ -378,7 +378,7 @@ final class Actor
                 $e,
             );
         } catch (TracedContainerException $e) {
-            throw $e::extendTracedException(
+            throw $e::createWithTrace(
                 \sprintf("Can't resolve `%s`: factory invocation failed.", $tracer->getRootAlias()),
                 $tracer->getTraces(),
                 $e,
@@ -551,7 +551,7 @@ final class Actor
                     $e->getMessage(),
                 ), $tracer->getTraces());
             } catch (TracedContainerException $e) {
-                throw $e::extendTracedException(\sprintf(
+                throw $e::createWithTrace(\sprintf(
                     'Can\'t resolve `%s`.',
                     $tracer->getRootAlias(),
                 ), $tracer->getTraces(), $e);
@@ -567,7 +567,7 @@ final class Actor
             } catch (\TypeError $e) {
                 throw new WrongTypeException($constructor, $e);
             } catch (TracedContainerException $e) {
-                throw $e::extendTracedException(\sprintf(
+                throw $e::createWithTrace(\sprintf(
                     'Can\'t resolve `%s`: failed constructing `%s`.',
                     $tracer->getRootAlias(),
                     $class,

--- a/src/Core/src/Internal/Actor.php
+++ b/src/Core/src/Internal/Actor.php
@@ -544,17 +544,13 @@ final class Actor
                 $tracer->push($newScope, ...$debug);
                 $tracer->push(true);
                 $args = $actor->resolver->resolveArguments($constructor, $arguments, $actor->options->validateArguments);
-            } catch (ValidationException $e) {
-                throw TracedContainerException::createWithTrace(\sprintf(
-                    'Can\'t resolve `%s`. %s',
-                    $tracer->getRootAlias(),
-                    $e->getMessage(),
-                ), $tracer->getTraces());
-            } catch (TracedContainerException $e) {
-                throw $e::createWithTrace(\sprintf(
-                    'Can\'t resolve `%s`.',
-                    $tracer->getRootAlias(),
-                ), $tracer->getTraces(), $e);
+            } catch (\Throwable $e) {
+                throw TracedContainerException::createWithTrace(
+                    \sprintf(
+                        "Can't resolve `%s`.",
+                        $tracer->getRootAlias(),
+                    ), $tracer->getTraces(), $e
+                );
             } finally {
                 $tracer->pop($newScope);
                 $tracer->pop(false);

--- a/src/Core/src/Internal/Proxy/ProxyClassRenderer.php
+++ b/src/Core/src/Internal/Proxy/ProxyClassRenderer.php
@@ -195,7 +195,11 @@ final class ProxyClassRenderer
 
     public static function normalizeClassType(\ReflectionNamedType $type, \ReflectionClass $class): string
     {
-        return '\\' . ($type->getName() === 'self' ? $class->getName() : $type->getName());
+        return match($type->getName()) {
+            'static' => 'static',
+            'self' => '\\' . $class->getName(),
+            default => '\\' . $type->getName(),
+        };
     }
 
     private static function cutDefaultValue(\ReflectionParameter $param): string

--- a/src/Core/src/Internal/Resolver.php
+++ b/src/Core/src/Internal/Resolver.php
@@ -51,7 +51,7 @@ final class Resolver implements ResolverInterface
         foreach ($reflection->getParameters() as $parameter) {
             $this->resolveParameter($parameter, $state, $validate)
             or
-            throw new ArgumentResolvingException($reflection, $parameter->getName());
+            throw ArgumentResolvingException::createWithParam($reflection, $parameter->getName());
         }
 
         return $state->getResolvedValues();
@@ -74,7 +74,7 @@ final class Resolver implements ResolverInterface
             // For a variadic parameter it's no sense - named or positional argument will be sent
             // But you can't send positional argument after named in any case
             if (\is_int($key) && !$positional) {
-                throw new PositionalArgumentException($reflection, $key);
+                throw PositionalArgumentException::createWithParam($reflection, (string) $key);
             }
 
             $positional = $positional && \is_int($key);
@@ -85,7 +85,7 @@ final class Resolver implements ResolverInterface
             }
 
             if ($parameter === null) {
-                throw new UnknownParameterException($reflection, $key);
+                throw UnknownParameterException::createWithParam($reflection, (string) $key);
             }
             $name = $parameter->getName();
 
@@ -96,14 +96,14 @@ final class Resolver implements ResolverInterface
                 if ($parameter->isOptional()) {
                     continue;
                 }
-                throw new MissingRequiredArgumentException($reflection, $name);
+                throw MissingRequiredArgumentException::createWithParam($reflection, $name);
             } else {
                 $value = &$arguments[$name];
                 unset($arguments[$name]);
             }
 
             if (!$this->validateValueToParameter($parameter, $value)) {
-                throw new InvalidArgumentException($reflection, $name);
+                throw InvalidArgumentException::createWithParam($reflection, $name);
             }
         }
     }
@@ -299,7 +299,7 @@ final class Resolver implements ResolverInterface
 
         // Validation
         if ($validateWith !== null && !$this->validateValueToParameter($validateWith, $value)) {
-            throw new InvalidArgumentException(
+            throw InvalidArgumentException::createWithParam(
                 $validateWith->getDeclaringFunction(),
                 $validateWith->getName(),
             );

--- a/src/Core/tests/ExceptionsTest.php
+++ b/src/Core/tests/ExceptionsTest.php
@@ -108,7 +108,8 @@ class ExceptionsTest extends TestCase
         yield 'withClosure' => [
             $withClosure,
             <<<'MARKDOWN'
-            Can't resolve `Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency`. Invalid argument value type for the `class` parameter when validating arguments for `Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency::__construct`.
+            Can't resolve `Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency`.
+            Invalid argument value type for the `class` parameter when validating arguments for `Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency::__construct`.
             Resolving trace:
             - action: 'autowire'
               alias: 'Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency'

--- a/src/Core/tests/Internal/Proxy/Stub/MockInterface.php
+++ b/src/Core/tests/Internal/Proxy/Stub/MockInterface.php
@@ -30,4 +30,8 @@ interface MockInterface
     public function concatMultiple(string $prefix, string &...$byLink): array;
 
     public function &same(string &$byLink): string;
+
+    public function staticType(): static;
+
+    public function selfType(): self;
 }

--- a/src/Core/tests/Internal/Proxy/Stub/MockInterfaceImpl.php
+++ b/src/Core/tests/Internal/Proxy/Stub/MockInterfaceImpl.php
@@ -55,4 +55,14 @@ final class MockInterfaceImpl implements MockInterface, EmptyInterface
 
         return $byLink;
     }
+
+    public function staticType(): static
+    {
+        return $this;
+    }
+
+    public function selfType(): MockInterface
+    {
+        return $this;
+    }
 }


### PR DESCRIPTION
## What was changed

- Fixed proxy class generator failure when the proxied interface contains `static` return type
- Add resolving trace to resolver exceptions

## Checklist

- Tested
    - [x] Unit tests added
