### PR TITLE
set QueueInterface $payload parameter type to mixed

### DIFF
--- a/src/Queue/src/QueueInterface.php
+++ b/src/Queue/src/QueueInterface.php
@@ -9,5 +9,5 @@ interface QueueInterface
     /**
      * @param string|class-string<HandlerInterface> $name
      */
-    public function push(string $name, array $payload = [], ?OptionsInterface $options = null): string;
+    public function push(string $name, mixed $payload = [], ?OptionsInterface $options = null): string;
 }


### PR DESCRIPTION
## What was changed

Changed `QueueInterface` `$payload` parameter from `array` to `mixed`.

## Why?

All interface implementations uses `mixed` payload where providing serializable objects are possible. Using `QueueInterface` as type, triggers phpstan errors of incompatible types:

Example:
```php
class CallbackService
{
    public function __construct(
        // flow is in-memory roadrunner driver (Spiral\RoadRunnerBridge\Queue\Queue)
        private readonly QueueInterface $flow,
    ) {
    }
    
    public function send(): void
    {
        // CallbackJob is DTO which can be serialized
        $job = new CallbackJob();
    
        // call below will trigger phpstan error:
        // phpstan: Parameter #2 $payload of method Spiral\Queue\QueueInterface::push() expects array, CallbackJob given.
        $this->flow->push(CallbackJob, $job);
    }
}
```
