### PR TITLE
Bump structarmed to ^0.17 and enable CodeQuality preset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
           composer-options: "--prefer-dist --no-audit"
 
       - name: Install StructArmed
-        run: composer require --dev boundwize/structarmed:^0.16.0 --no-interaction --prefer-dist --no-audit
+        run: composer require --dev boundwize/structarmed:^0.17.0 --no-interaction --prefer-dist --no-audit
 
       # Execution
       - name: Run StructArmed

--- a/src/Files/src/FilesInterface.php
+++ b/src/Files/src/FilesInterface.php
@@ -24,8 +24,8 @@ interface FilesInterface
      */
     public const KB = 1024;
 
-    public const MB = 1048576;
-    public const GB = 1073741824;
+    public const MB = 1_048_576;
+    public const GB = 1_073_741_824;
 
     /**
      * Default location (directory) separator.

--- a/src/Prototype/tests/Commands/DumpCommandTest.php
+++ b/src/Prototype/tests/Commands/DumpCommandTest.php
@@ -27,7 +27,7 @@ final class DumpCommandTest extends AbstractCommandsTestCase
         $files
             ->expects(self::once())
             ->method('write')
-            ->with(static::callback(fn (): bool => true), static::callback($this->validateTrait(...)));
+            ->with(static::callback(static fn (): bool => true), static::callback($this->validateTrait(...)));
 
         $this->app->getContainer()->bindSingleton(FilesInterface::class, $files, true);
 

--- a/src/Storage/tests/FileTest.php
+++ b/src/Storage/tests/FileTest.php
@@ -218,7 +218,7 @@ final class FileTest extends TestCase
         self::assertGreaterThanOrEqual($now, $before);
 
         // Wait 1.1 seconds and then again modify file
-        \usleep(1100000);
+        \usleep(1_100_000);
 
         $file->write('content');
         $after = $file->getLastModified();

--- a/src/Storage/tests/ManagerTest.php
+++ b/src/Storage/tests/ManagerTest.php
@@ -267,7 +267,7 @@ final class ManagerTest extends TestCase
         self::assertGreaterThanOrEqual($now, $before);
 
         // Wait 1.1 seconds and then again modify file
-        \usleep(1100000);
+        \usleep(1_100_000);
 
         $this->manager->write('file.txt', 'content');
         $after = $this->manager->getLastModified('file.txt');

--- a/src/Storage/tests/StorageTest.php
+++ b/src/Storage/tests/StorageTest.php
@@ -172,7 +172,7 @@ final class StorageTest extends TestCase
         self::assertGreaterThanOrEqual($now, $before);
 
         // Wait 1.1 seconds and then again modify file
-        \usleep(1100000);
+        \usleep(1_100_000);
 
         $this->local->write('file.txt', 'content');
         $after = $this->local->getLastModified('file.txt');

--- a/src/Tokenizer/tests/Listener/ClassLocatorByTargetTest.php
+++ b/src/Tokenizer/tests/Listener/ClassLocatorByTargetTest.php
@@ -90,7 +90,7 @@ final class ClassLocatorByTargetTest extends TestCase
         array $expected,
     ): void {
         $classes = \array_map(
-            fn (string $class): \ReflectionClass => new \ReflectionClass($class),
+            static fn (string $class): \ReflectionClass => new \ReflectionClass($class),
             [
                 Targets\ConsoleCommand::class,
                 Targets\Filter::class,

--- a/src/Tokenizer/tests/Listener/EnumLocatorByTargetTest.php
+++ b/src/Tokenizer/tests/Listener/EnumLocatorByTargetTest.php
@@ -66,7 +66,7 @@ final class EnumLocatorByTargetTest extends TestCase
         array $expected,
     ): void {
         $enums = \array_map(
-            fn (string $class): \ReflectionEnum => new \ReflectionEnum($class),
+            static fn (string $class): \ReflectionEnum => new \ReflectionEnum($class),
             [
                 Targets\EnumWithAttributeOnClass::class,
                 Targets\EnumWithAllTargets::class,

--- a/src/Tokenizer/tests/Listener/InterfaceLocatorByTargetTest.php
+++ b/src/Tokenizer/tests/Listener/InterfaceLocatorByTargetTest.php
@@ -88,7 +88,7 @@ final class InterfaceLocatorByTargetTest extends TestCase
         array $expected,
     ): void {
         $interfaces = \array_map(
-            fn (string $class): \ReflectionClass => new \ReflectionClass($class),
+            static fn (string $class): \ReflectionClass => new \ReflectionClass($class),
             [
                 Targets\InterfaceWithAllTargets::class,
                 Targets\InterfaceWithAttributeOnClass::class,

--- a/src/Tokenizer/tests/Listener/ListenerInvokerTest.php
+++ b/src/Tokenizer/tests/Listener/ListenerInvokerTest.php
@@ -29,7 +29,7 @@ final class ListenerInvokerTest extends TestCase
         $invoker = new ListenerInvoker();
 
         $classes = \array_map(
-            fn(string $class): \ReflectionClass => new \ReflectionClass($class),
+            static fn(string $class): \ReflectionClass => new \ReflectionClass($class),
             [
                 Targets\ConsoleCommand::class,
                 Targets\Filter::class,

--- a/structarmed.php
+++ b/structarmed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Preset\Presets\CodeQualityPreset;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 $layerPatterns = [
@@ -149,6 +150,9 @@ $architecture = Architecture::define()
             'tests/app/src/Command/DeadCommand.php',
             'tests/app/src/Controller/TestController.php',
         ],
+        CodeQualityPreset::ANONYMOUS_FUNCTIONS_MUST_BE_STATIC => [
+            __DIR__ . '/src/Core/tests/Exception/ClosureRendererTraitTest.php',
+        ],
     ])
     ->skipPaths([
         // fixtures
@@ -172,4 +176,4 @@ foreach ($layerPatterns as $name => $pattern) {
     $architecture->layerPattern($name, $pattern);
 }
 
-return $architecture->withPreset(Preset::PSR4());
+return $architecture->withPresets(Preset::PSR4(), Preset::CODEQUALITY());


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Bump structarmed to ^0.17 and enable CodeQuality preset

<!-- Describe what has changed in this PR -->

## Why?

The CodeQuality preset applied rules:

- _MustBeStaticAnonymousFunctionRule_: add static to closure/arrow function when possible
- _LargeNumericLiteralMustUseSeparatorRule_: use separator `_` on large numeric.

they are FixableInterface instance rules and applied with:

```bash
vendor/bin/structarmed analyze --fix
```

If you need separate PR, just let me know :)

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
